### PR TITLE
perf: use bottle stats query in collection

### DIFF
--- a/my-app/src/components/bottle-collection.tsx
+++ b/my-app/src/components/bottle-collection.tsx
@@ -21,23 +21,11 @@ export function BottleCollection({
   onAddBottle,
 }: BottleCollectionProps) {
   const bottles = useQuery(api.bottles.listBottles);
-  const wearLogs = useQuery(api.wearLogs.listWearLogs);
+  const bottleStats = useQuery(api.wearLogs.listBottleStats);
   const [search, setSearch] = useState("");
 
-  const bottleStatsMap = useMemo(() => {
-    if (!wearLogs) return undefined;
-    const stats: Record<string, { wears: number; sprays: number }> = {};
-    for (const log of wearLogs) {
-      const current = stats[log.bottleId] ?? { wears: 0, sprays: 0 };
-      current.wears += 1;
-      current.sprays += log.sprays;
-      stats[log.bottleId] = current;
-    }
-    return stats;
-  }, [wearLogs]);
-
   const getStats = (bottleId: string) =>
-    bottleStatsMap ? (bottleStatsMap[bottleId] ?? { wears: 0, sprays: 0 }) : undefined;
+    bottleStats ? (bottleStats[bottleId] ?? { wears: 0, sprays: 0 }) : undefined;
 
   const filteredBottles = useMemo(() => {
     if (!bottles) return [];


### PR DESCRIPTION
This pull request refactors how bottle statistics are fetched and processed in the `BottleCollection` component. Instead of manually computing stats from wear logs on the client, it now retrieves precomputed bottle statistics directly from the API, simplifying the code and potentially improving performance.

**Refactoring data fetching and computation:**

* Replaced the `wearLogs` query with a new `bottleStats` query, which fetches precomputed statistics for each bottle from the API instead of raw wear logs. (`my-app/src/components/bottle-collection.tsx`)
* Removed the `bottleStatsMap` memoized computation that previously aggregated stats from `wearLogs`, and updated the `getStats` function to use the new `bottleStats` data structure. (`my-app/src/components/bottle-collection.tsx`)