### PR TITLE
Fix/card color and wrapping

### DIFF
--- a/my-app/src/components/bottle-card.tsx
+++ b/my-app/src/components/bottle-card.tsx
@@ -6,6 +6,8 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { Droplets } from "lucide-react";
 
+const EMPTY_TAGS: string[] = [];
+
 interface BottleCardProps {
   bottle: Doc<"bottles">;
   isSelected: boolean;
@@ -24,7 +26,7 @@ export function BottleCard({
   index,
 }: BottleCardProps) {
   const staggerClass = `stagger-${Math.min(index + 1, 8)}`;
-  const tags = bottle.tags ?? [];
+  const tags = bottle.tags ?? EMPTY_TAGS;
   const sizerRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [visibleCount, setVisibleCount] = useState(tags.length);
@@ -64,13 +66,13 @@ export function BottleCard({
     const ro = new ResizeObserver(calculate);
     ro.observe(container);
     return () => ro.disconnect();
-  }, [bottle.tags]); // stable reference from Convex doc; `tags` is derived from it
+  }, [tags]);
 
   return (
     <button
       onClick={onClick}
       className={cn(
-        "group w-full text-left rounded-xl border px-6 py-5 transition-all duration-200 cursor-pointer",
+        "group w-full h-full flex flex-col text-left rounded-xl border px-6 py-5 transition-all duration-200 cursor-pointer",
         "hover:shadow-md hover:-translate-y-0.5",
         "animate-fade-up opacity-0",
         staggerClass,
@@ -97,54 +99,56 @@ export function BottleCard({
         )}
       </div>
 
-      {/* Stats row */}
-      <div className="flex items-center gap-4 mt-3.5">
-        {totalWears !== undefined && totalWears > 0 && (
-          <div className="flex items-center gap-1 text-xs text-text-secondary">
-            <Droplets className="h-3 w-3" />
-            <span>
-              {totalWears} wear{totalWears !== 1 ? "s" : ""}
-            </span>
-          </div>
-        )}
-        {totalSprays !== undefined && totalSprays > 0 && (
-          <div className="text-xs text-text-secondary">
-            {totalSprays} sprays
+      <div className="mt-auto">
+        {/* Stats row */}
+        <div className="flex items-center gap-4 mt-3.5">
+          {totalWears !== undefined && totalWears > 0 && (
+            <div className="flex items-center gap-1 text-xs text-text-secondary">
+              <Droplets className="h-3 w-3" />
+              <span>
+                {totalWears} wear{totalWears !== 1 ? "s" : ""}
+              </span>
+            </div>
+          )}
+          {totalSprays !== undefined && totalSprays > 0 && (
+            <div className="text-xs text-text-secondary">
+              {totalSprays} sprays
+            </div>
+          )}
+        </div>
+
+        {/* Tags */}
+        {tags.length > 0 && (
+          <div className="relative mt-3.5">
+            {/* Hidden sizer: renders all tags to measure their widths */}
+            <div
+              ref={sizerRef}
+              className="absolute inset-x-0 flex flex-nowrap gap-1.5 invisible pointer-events-none overflow-hidden"
+              aria-hidden="true"
+              tabIndex={-1}
+            >
+              {tags.map((tag) => (
+                <Badge key={tag} data-tag variant="tag" className="text-[10px] px-2 py-0.5 shrink-0">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+            {/* Visible row: only shows tags that fit on one line */}
+            <div ref={containerRef} className="flex flex-nowrap gap-1.5 overflow-hidden">
+              {tags.slice(0, visibleCount).map((tag) => (
+                <Badge key={tag} variant="tag" className="text-[10px] px-2 py-0.5 shrink-0">
+                  {tag}
+                </Badge>
+              ))}
+              {visibleCount < tags.length && (
+                <Badge variant="outline" className="text-[10px] px-2 py-0.5 shrink-0">
+                  +{tags.length - visibleCount}
+                </Badge>
+              )}
+            </div>
           </div>
         )}
       </div>
-
-      {/* Tags */}
-      {tags.length > 0 && (
-        <div className="relative mt-3.5">
-          {/* Hidden sizer: renders all tags to measure their widths */}
-          <div
-            ref={sizerRef}
-            className="absolute inset-x-0 flex flex-nowrap gap-1.5 invisible pointer-events-none overflow-hidden"
-            aria-hidden="true"
-            tabIndex={-1}
-          >
-            {tags.map((tag) => (
-              <Badge key={tag} data-tag variant="tag" className="text-[10px] px-2 py-0.5 shrink-0">
-                {tag}
-              </Badge>
-            ))}
-          </div>
-          {/* Visible row: only shows tags that fit on one line */}
-          <div ref={containerRef} className="flex flex-nowrap gap-1.5 overflow-hidden">
-            {tags.slice(0, visibleCount).map((tag) => (
-              <Badge key={tag} variant="tag" className="text-[10px] px-2 py-0.5 shrink-0">
-                {tag}
-              </Badge>
-            ))}
-            {visibleCount < tags.length && (
-              <Badge variant="outline" className="text-[10px] px-2 py-0.5 shrink-0">
-                +{tags.length - visibleCount}
-              </Badge>
-            )}
-          </div>
-        </div>
-      )}
     </button>
   );
 }

--- a/my-app/src/components/bottle-card.tsx
+++ b/my-app/src/components/bottle-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef, useState, useLayoutEffect } from "react";
 import { Doc } from "../../convex/_generated/dataModel";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -23,6 +24,47 @@ export function BottleCard({
   index,
 }: BottleCardProps) {
   const staggerClass = `stagger-${Math.min(index + 1, 8)}`;
+  const tags = bottle.tags ?? [];
+  const sizerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = useState(tags.length);
+
+  useLayoutEffect(() => {
+    const sizer = sizerRef.current;
+    const container = containerRef.current;
+    if (!sizer || !container || tags.length === 0) return;
+
+    const calculate = () => {
+      const containerWidth = container.clientWidth;
+      const tagEls = Array.from(sizer.querySelectorAll<HTMLElement>("[data-tag]"));
+      const gap = 6; // gap-1.5 = 6px
+      const plusW = 40; // conservative width for "+N" badge
+
+      let usedWidth = 0;
+      let count = 0;
+
+      for (let i = 0; i < tagEls.length; i++) {
+        const tagWidth = tagEls[i].getBoundingClientRect().width;
+        const addGap = i > 0 ? gap : 0;
+        const wouldShowAll = count + 1 === tags.length;
+        const plusSpace = wouldShowAll ? 0 : gap + plusW;
+
+        if (usedWidth + addGap + tagWidth + plusSpace <= containerWidth) {
+          usedWidth += addGap + tagWidth;
+          count++;
+        } else {
+          break;
+        }
+      }
+
+      setVisibleCount(count);
+    };
+
+    calculate();
+    const ro = new ResizeObserver(calculate);
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, [bottle.tags]); // stable reference from Convex doc; `tags` is derived from it
 
   return (
     <button
@@ -33,7 +75,7 @@ export function BottleCard({
         "animate-fade-up opacity-0",
         staggerClass,
         isSelected
-          ? "border-accent bg-accent-subtle shadow-sm"
+          ? "border-accent bg-accent-subtle/60 shadow-sm"
           : "border-border bg-surface hover:border-border-hover"
       )}
     >
@@ -73,18 +115,34 @@ export function BottleCard({
       </div>
 
       {/* Tags */}
-      {bottle.tags && bottle.tags.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 mt-3.5">
-          {bottle.tags.slice(0, 3).map((tag) => (
-            <Badge key={tag} variant="tag" className="text-[10px] px-2 py-0.5">
-              {tag}
-            </Badge>
-          ))}
-          {bottle.tags.length > 3 && (
-            <Badge variant="outline" className="text-[10px] px-2 py-0.5">
-              +{bottle.tags.length - 3}
-            </Badge>
-          )}
+      {tags.length > 0 && (
+        <div className="relative mt-3.5">
+          {/* Hidden sizer: renders all tags to measure their widths */}
+          <div
+            ref={sizerRef}
+            className="absolute inset-x-0 flex flex-nowrap gap-1.5 invisible pointer-events-none overflow-hidden"
+            aria-hidden="true"
+            tabIndex={-1}
+          >
+            {tags.map((tag) => (
+              <Badge key={tag} data-tag variant="tag" className="text-[10px] px-2 py-0.5 shrink-0">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+          {/* Visible row: only shows tags that fit on one line */}
+          <div ref={containerRef} className="flex flex-nowrap gap-1.5 overflow-hidden">
+            {tags.slice(0, visibleCount).map((tag) => (
+              <Badge key={tag} variant="tag" className="text-[10px] px-2 py-0.5 shrink-0">
+                {tag}
+              </Badge>
+            ))}
+            {visibleCount < tags.length && (
+              <Badge variant="outline" className="text-[10px] px-2 py-0.5 shrink-0">
+                +{tags.length - visibleCount}
+              </Badge>
+            )}
+          </div>
         </div>
       )}
     </button>


### PR DESCRIPTION
This pull request improves the display of tags in the `BottleCard` component by making the tag row responsive to available space. Instead of always showing a fixed number of tags, the component now dynamically calculates how many tags can fit on one line and displays a "+N" badge for any overflow. It also includes some minor style and structure adjustments.

**Responsive tag display:**

* The tag row now uses `useLayoutEffect`, `useRef`, and `useState` to measure available width and determine how many tags can be shown without overflow, updating responsively on resize. A hidden sizer element is used to measure tag widths, and a visible container displays only the tags that fit, followed by a "+N" badge for any additional tags. [[1]](diffhunk://#diff-a0f253f59798fc974c5522a8851b44be9527f40f380e4c7aff61533d600bb817R3-R10) [[2]](diffhunk://#diff-a0f253f59798fc974c5522a8851b44be9527f40f380e4c7aff61533d600bb817R29-R80) [[3]](diffhunk://#diff-a0f253f59798fc974c5522a8851b44be9527f40f380e4c7aff61533d600bb817L76-R151)

**Component structure and styling:**

* The card layout has been updated to use a flex column structure and improved background styling for the selected state. The tags and stats rows are now grouped at the bottom of the card for better alignment.