### PR TITLE
feat: add wear log editing, collection sorting, and average ratings

### DIFF
--- a/my-app/convex/wearLogs.test.ts
+++ b/my-app/convex/wearLogs.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe } from "vitest";
+import { expect, test, describe, vi } from "vitest";
 import { api } from "./_generated/api";
 import { setupTest, createTestUser } from "./test.setup";
 
@@ -430,8 +430,42 @@ describe("listBottleStats", () => {
     });
 
     const stats = await user.as.query(api.wearLogs.listBottleStats);
-    expect(stats[bottleA]).toEqual({ wears: 2, sprays: 8 });
-    expect(stats[bottleB]).toEqual({ wears: 1, sprays: 2 });
+    expect(stats[bottleA]).toEqual({ wears: 2, sprays: 8, avgRating: null });
+    expect(stats[bottleB]).toEqual({ wears: 1, sprays: 2, avgRating: null });
+  });
+
+  test("aggregates average rating from rated logs only", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    const bottleA = await addBottle(user.as, "A");
+    const bottleB = await addBottle(user.as, "B");
+
+    await user.as.mutation(api.wearLogs.addWearLog, {
+      bottleId: bottleA,
+      wornAt: Date.now(),
+      sprays: 3,
+      rating: 8,
+    });
+    await user.as.mutation(api.wearLogs.addWearLog, {
+      bottleId: bottleA,
+      wornAt: Date.now(),
+      sprays: 4,
+      rating: 6,
+    });
+    await user.as.mutation(api.wearLogs.addWearLog, {
+      bottleId: bottleA,
+      wornAt: Date.now(),
+      sprays: 2,
+    });
+    await user.as.mutation(api.wearLogs.addWearLog, {
+      bottleId: bottleB,
+      wornAt: Date.now(),
+      sprays: 1,
+    });
+
+    const stats = await user.as.query(api.wearLogs.listBottleStats);
+    expect(stats[bottleA]).toEqual({ wears: 3, sprays: 9, avgRating: 7 });
+    expect(stats[bottleB]).toEqual({ wears: 1, sprays: 1, avgRating: null });
   });
 
   test("returns empty after all logs deleted", async () => {
@@ -751,6 +785,47 @@ describe("validation", () => {
       }),
     ).rejects.toThrowError("Context must be at most 200 characters.");
   });
+
+  test("wornAt beyond the future tolerance is rejected", async () => {
+    const now = 1_700_000_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      const t = setupTest();
+      const user = await createTestUser(t);
+      const bottleId = await addBottle(user.as);
+      await expect(
+        user.as.mutation(api.wearLogs.addWearLog, {
+          bottleId,
+          wornAt: now + 60_001,
+          sprays: 1,
+        }),
+      ).rejects.toThrowError("wornAt cannot be in the future.");
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  test("wornAt within the future tolerance is accepted", async () => {
+    const now = 1_700_000_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      const t = setupTest();
+      const user = await createTestUser(t);
+      const bottleId = await addBottle(user.as);
+      const logId = await user.as.mutation(api.wearLogs.addWearLog, {
+        bottleId,
+        wornAt: now + 60_000,
+        sprays: 1,
+      });
+
+      const log = await user.as.query(api.wearLogs.getWearLog, {
+        wearLogId: logId,
+      });
+      expect(log!.wornAt).toBe(now + 60_000);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
 });
 
 // ── P2: updateWearLog validation ─────────────────────────────────────────────
@@ -906,5 +981,56 @@ describe("updateWearLog validation", () => {
         wornAt: 0,
       }),
     ).rejects.toThrowError("wornAt must be a positive Unix timestamp (ms).");
+  });
+
+  test("wornAt beyond the future tolerance is rejected", async () => {
+    const now = 1_700_000_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      const t = setupTest();
+      const user = await createTestUser(t);
+      const bottleId = await addBottle(user.as);
+      const logId = await user.as.mutation(api.wearLogs.addWearLog, {
+        bottleId,
+        wornAt: now,
+        sprays: 1,
+      });
+
+      await expect(
+        user.as.mutation(api.wearLogs.updateWearLog, {
+          wearLogId: logId,
+          wornAt: now + 60_001,
+        }),
+      ).rejects.toThrowError("wornAt cannot be in the future.");
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  test("wornAt within the future tolerance is accepted", async () => {
+    const now = 1_700_000_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      const t = setupTest();
+      const user = await createTestUser(t);
+      const bottleId = await addBottle(user.as);
+      const logId = await user.as.mutation(api.wearLogs.addWearLog, {
+        bottleId,
+        wornAt: now,
+        sprays: 1,
+      });
+
+      await user.as.mutation(api.wearLogs.updateWearLog, {
+        wearLogId: logId,
+        wornAt: now + 60_000,
+      });
+
+      const log = await user.as.query(api.wearLogs.getWearLog, {
+        wearLogId: logId,
+      });
+      expect(log!.wornAt).toBe(now + 60_000);
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 });

--- a/my-app/convex/wearLogs.ts
+++ b/my-app/convex/wearLogs.ts
@@ -2,12 +2,13 @@ import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { getOptionalUserId, getUserId } from "./helpers";
 import { rateLimiter } from "./rateLimits";
+import { MAX_SPRAYS } from "../src/lib/constants";
 
 // ── Validation constants ──────────────────────────────────────────────────────
 
 const MAX_COMMENT_LENGTH = 2000;
 const MAX_CONTEXT_LENGTH = 200;
-const MAX_SPRAYS = 100;
+const FUTURE_WORN_AT_TOLERANCE_MS = 60_000;
 
 // ── Queries ──────────────────────────────────────────────────────────────────
 
@@ -23,16 +24,39 @@ export const listBottleStats = query({
       .query("wearLogs")
       .withIndex("by_user", (q) => q.eq("userId", userId))
       .collect();
-    // Aggregate wear count and spray totals per bottle server-side so the
-    // collection view never needs to download the full wear-log history.
-    const stats = new Map<string, { wears: number; sprays: number }>();
+    // Aggregate wear count, spray totals, and average rating per bottle
+    // server-side so the collection view never needs to download the full
+    // wear-log history.
+    const stats = new Map<
+      string,
+      { wears: number; sprays: number; ratingSum: number; ratingCount: number }
+    >();
     for (const log of logs) {
-      const existing = stats.get(log.bottleId) ?? { wears: 0, sprays: 0 };
+      const existing = stats.get(log.bottleId) ?? {
+        wears: 0,
+        sprays: 0,
+        ratingSum: 0,
+        ratingCount: 0,
+      };
       existing.wears += 1;
       existing.sprays += log.sprays;
+      if (typeof log.rating === "number") {
+        existing.ratingSum += log.rating;
+        existing.ratingCount += 1;
+      }
       stats.set(log.bottleId, existing);
     }
-    return Object.fromEntries(stats);
+    return Object.fromEntries(
+      Array.from(stats.entries()).map(([bottleId, s]) => [
+        bottleId,
+        {
+          wears: s.wears,
+          sprays: s.sprays,
+          avgRating:
+            s.ratingCount > 0 ? s.ratingSum / s.ratingCount : null,
+        },
+      ]),
+    );
   },
 });
 
@@ -93,6 +117,9 @@ export const getWearLog = query({
 function assertValidWornAt(wornAt: number): void {
   if (wornAt <= 0) {
     throw new Error("wornAt must be a positive Unix timestamp (ms).");
+  }
+  if (wornAt > Date.now() + FUTURE_WORN_AT_TOLERANCE_MS) {
+    throw new Error("wornAt cannot be in the future.");
   }
 }
 

--- a/my-app/src/components/add-bottle-dialog.tsx
+++ b/my-app/src/components/add-bottle-dialog.tsx
@@ -89,7 +89,7 @@ export function AddBottleDialog({
 
   const handleAddTag = () => {
     const trimmed = tagInput.trim();
-    if (trimmed && !tags.includes(trimmed)) {
+    if (trimmed && !tags.some((t) => t.toLowerCase() === trimmed.toLowerCase())) {
       setTags([...tags, trimmed]);
     }
     setTagInput("");

--- a/my-app/src/components/bottle-card.tsx
+++ b/my-app/src/components/bottle-card.tsx
@@ -4,7 +4,7 @@ import { useRef, useState, useLayoutEffect } from "react";
 import { Doc } from "../../convex/_generated/dataModel";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import { Droplets } from "lucide-react";
+import { Droplets, Star } from "lucide-react";
 
 const EMPTY_TAGS: string[] = [];
 
@@ -14,6 +14,7 @@ interface BottleCardProps {
   onClick: () => void;
   totalSprays?: number;
   totalWears?: number;
+  avgRating?: number | null;
   index: number;
 }
 
@@ -23,6 +24,7 @@ export function BottleCard({
   onClick,
   totalSprays,
   totalWears,
+  avgRating,
   index,
 }: BottleCardProps) {
   const staggerClass = `stagger-${Math.min(index + 1, 8)}`;
@@ -113,6 +115,14 @@ export function BottleCard({
           {totalSprays !== undefined && totalSprays > 0 && (
             <div className="text-xs text-text-secondary">
               {totalSprays} sprays
+            </div>
+          )}
+          {avgRating != null && avgRating > 0 && (
+            <div className="flex items-center gap-1 text-xs text-text-secondary">
+              <Star className="h-3 w-3 fill-current" />
+              <span>
+                {avgRating % 1 === 0 ? avgRating.toFixed(0) : avgRating.toFixed(1)}
+              </span>
             </div>
           )}
         </div>

--- a/my-app/src/components/bottle-collection.tsx
+++ b/my-app/src/components/bottle-collection.tsx
@@ -4,10 +4,30 @@ import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id } from "../../convex/_generated/dataModel";
 import { BottleCard } from "@/components/bottle-card";
+import {
+  filterAndSortBottles,
+  getBottleStats,
+  getNextSortState,
+  type SortDir,
+  type SortOption,
+} from "@/lib/bottle-collection-sort";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Plus, Wine } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { Plus, Wine, ArrowUpDown, ArrowUp, ArrowDown, Check } from "lucide-react";
 import { useState, useMemo } from "react";
+
+const SORT_LABELS: Record<SortOption, string> = {
+  created: "Date Added",
+  name: "Name",
+  wears: "Wears",
+  rating: "Rating",
+};
 
 interface BottleCollectionProps {
   selectedBottleId: Id<"bottles"> | null;
@@ -23,21 +43,25 @@ export function BottleCollection({
   const bottles = useQuery(api.bottles.listBottles);
   const bottleStats = useQuery(api.wearLogs.listBottleStats);
   const [search, setSearch] = useState("");
+  const [sortBy, setSortBy] = useState<SortOption>("created");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
 
-  const getStats = (bottleId: string) =>
-    bottleStats ? (bottleStats[bottleId] ?? { wears: 0, sprays: 0 }) : undefined;
+  const handleSort = (option: SortOption) => {
+    const next = getNextSortState(sortBy, sortDir, option);
+    setSortBy(next.sortBy);
+    setSortDir(next.sortDir);
+  };
 
   const filteredBottles = useMemo(() => {
     if (!bottles) return [];
-    if (!search.trim()) return bottles;
-    const q = search.toLowerCase();
-    return bottles.filter(
-      (b) =>
-        b.name.toLowerCase().includes(q) ||
-        b.brand?.toLowerCase().includes(q) ||
-        b.tags?.some((t) => t.toLowerCase().includes(q))
-    );
-  }, [bottles, search]);
+    return filterAndSortBottles({
+      bottles,
+      bottleStats,
+      search,
+      sortBy,
+      sortDir,
+    });
+  }, [bottles, search, sortBy, sortDir, bottleStats]);
 
   if (bottles === undefined) {
     return (
@@ -116,20 +140,60 @@ export function BottleCollection({
         </Button>
       </div>
 
-      {/* Count */}
-      <div className="pt-2 pb-2 animate-fade-up stagger-2">
+      {/* Count + Sort */}
+      <div className="flex items-center justify-between pt-2 pb-2 animate-fade-up stagger-2">
         <p className="text-xs text-text-secondary">
           {filteredBottles.length} fragrance
           {filteredBottles.length !== 1 ? "s" : ""}
           {search && ` matching "${search}"`}
         </p>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 text-xs text-text-secondary hover:text-text px-2"
+              aria-label="Sort fragrances"
+            >
+              <ArrowUpDown className="h-3 w-3" />
+              {SORT_LABELS[sortBy]}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-[160px]">
+            {(Object.keys(SORT_LABELS) as SortOption[]).map((option) => {
+              const isActive = sortBy === option;
+              return (
+                <DropdownMenuItem
+                  key={option}
+                  onSelect={(e) => {
+                    e.preventDefault();
+                    handleSort(option);
+                  }}
+                  className="flex items-center justify-between gap-3"
+                >
+                  <span className="flex items-center gap-2">
+                    {isActive && <Check className="h-3 w-3 text-accent" />}
+                    {!isActive && <span className="w-3" />}
+                    {SORT_LABELS[option]}
+                  </span>
+                  {isActive && (
+                    sortDir === "asc"
+                      ? <ArrowUp className="h-3 w-3 text-text-secondary" />
+                      : <ArrowDown className="h-3 w-3 text-text-secondary" />
+                  )}
+                </DropdownMenuItem>
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
 
       {/* Grid */}
       <div className="flex-1 overflow-y-auto scrollbar-fade pb-5 pt-4 -mr-6 pr-6 lg:-mr-7 lg:pr-7">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {filteredBottles.map((bottle, i) => {
-            const stats = getStats(bottle._id);
+            const stats = getBottleStats(bottleStats, bottle._id);
             return (
               <BottleCard
                 key={bottle._id}
@@ -138,6 +202,7 @@ export function BottleCollection({
                 onClick={() => onSelectBottle(bottle._id)}
                 totalSprays={stats?.sprays}
                 totalWears={stats?.wears}
+                avgRating={stats?.avgRating ?? null}
                 index={i}
               />
             );

--- a/my-app/src/components/connection-banner.tsx
+++ b/my-app/src/components/connection-banner.tsx
@@ -81,14 +81,19 @@ export function ConnectionBanner() {
 
   // Debounce: only set showBanner=true after sustained disconnection
   useEffect(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+
     if (!isDisconnected) {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        setShowBanner(false);
         debounceRef.current = null;
-      }
-      setShowBanner(false);
+      }, 0);
       return;
     }
+
     debounceRef.current = setTimeout(() => {
       setShowBanner(true);
       debounceRef.current = null;

--- a/my-app/src/components/edit-wear-log-dialog.tsx
+++ b/my-app/src/components/edit-wear-log-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Id } from "../../convex/_generated/dataModel";
+import { Doc } from "../../convex/_generated/dataModel";
 import {
   Dialog,
   DialogContent,
@@ -30,22 +30,20 @@ import { MAX_SPRAYS, CONTEXT_OPTIONS } from "@/lib/constants";
 
 const NO_CONTEXT_VALUE = "__none__";
 
-interface AddWearLogDialogProps {
+interface EditWearLogDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  bottleId: Id<"bottles">;
+  log: Doc<"wearLogs">;
 }
 
-export function AddWearLogDialog({
+export function EditWearLogDialog({
   open,
   onOpenChange,
-  bottleId,
-}: AddWearLogDialogProps) {
-  const addWearLog = useMutation(api.wearLogs.addWearLog);
+  log,
+}: EditWearLogDialogProps) {
+  const updateWearLog = useMutation(api.wearLogs.updateWearLog);
 
-  const [date, setDate] = useState("");
-  const [time, setTime] = useState("");
-  const [sprays, setSprays] = useState("3");
+  const [sprays, setSprays] = useState("");
   const [context, setContext] = useState("");
   const [rating, setRating] = useState("");
   const [comment, setComment] = useState("");
@@ -65,7 +63,6 @@ export function AddWearLogDialog({
 
   const validate = (): boolean => {
     const newErrors: Record<string, string> = {};
-    if (!date) newErrors.date = "Date is required";
     const spraysNum = Number(sprays);
     if (!sprays || isNaN(spraysNum) || spraysNum < 1 || spraysNum > MAX_SPRAYS) {
       newErrors.sprays = `Must be between 1 and ${MAX_SPRAYS}`;
@@ -95,55 +92,41 @@ export function AddWearLogDialog({
     }
 
     // Block plain Enter from submitting the form only on text/number inputs.
-    // Buttons, Select triggers, and other interactive controls are left
-    // unaffected so keyboard users can activate them normally.
     if ((e.target as HTMLElement).tagName === "INPUT") {
       e.preventDefault();
     }
   };
 
+  // Pre-populate form fields from the log when the dialog opens
   useEffect(() => {
     if (open) {
-      const now = new Date();
-      setDate(now.toLocaleDateString("en-CA"));
-      setTime(
-        now.toLocaleTimeString("en-US", {
-          hour12: false,
-          hour: "2-digit",
-          minute: "2-digit",
-        })
-      );
-      setSprays("3");
-      setContext("");
-      setRating("");
-      setComment("");
+      setSprays(String(log.sprays));
+      setContext(log.context ?? "");
+      setRating(log.rating !== undefined ? String(log.rating) : "");
+      setComment(log.comment ?? "");
       setErrors({});
       setFormError(null);
     }
-  }, [open]);
+  }, [open, log]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!validate()) return;
 
-    const wornAt = new Date(`${date}T${time || "12:00"}`).getTime();
-    if (isNaN(wornAt)) return;
-
     setSubmitting(true);
     try {
-      await addWearLog({
-        bottleId,
-        wornAt,
+      await updateWearLog({
+        wearLogId: log._id,
         sprays: Number(sprays),
-        context: context || undefined,
-        rating: rating ? Number(rating) : undefined,
-        comment: comment.trim() || undefined,
+        context: context || null,
+        rating: rating ? Number(rating) : null,
+        comment: comment.trim() || null,
       });
-      toast.success("Wear logged");
+      toast.success("Wear log updated");
       onOpenChange(false);
     } catch (err) {
       if (process.env.NODE_ENV !== "production") {
-        console.error("Failed to log wear:", err);
+        console.error("Failed to update wear log:", err);
       }
       const message = getApiErrorMessage(err);
       toast.error(message);
@@ -153,67 +136,60 @@ export function AddWearLogDialog({
     }
   };
 
+  const formatReadOnlyDate = (timestamp: number) => {
+    const d = new Date(timestamp);
+    return d.toLocaleDateString("en-US", {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      year:
+        d.getFullYear() !== new Date().getFullYear() ? "numeric" : undefined,
+    });
+  };
+
+  const formatReadOnlyTime = (timestamp: number) => {
+    const d = new Date(timestamp);
+    return d.toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Log a Wear</DialogTitle>
+          <DialogTitle>Edit Wear Log</DialogTitle>
           <DialogDescription>
-            Record when you wore this fragrance.
+            Update your notes for this wear.
           </DialogDescription>
         </DialogHeader>
 
         <form ref={formRef} onSubmit={handleSubmit} onKeyDown={handleFormKeyDown} noValidate className="space-y-5">
-          {/* Date + Time side by side */}
+          {/* Read-only date/time */}
           <div className="grid grid-cols-2 gap-4">
-            <div className="relative space-y-2">
-              <Label htmlFor="date" className={errors.date ? "text-danger" : ""}>
-                Date *
-              </Label>
-              <Input
-                id="date"
-                type="date"
-                value={date}
-                onChange={(e) => {
-                  setDate(e.target.value);
-                  clearError("date");
-                }}
-                required
-                className={
-                  errors.date
-                    ? "border-danger focus:border-danger focus:ring-danger"
-                    : ""
-                }
-                aria-invalid={!!errors.date}
-                aria-describedby="date-error"
-              />
-              <p
-                id="date-error"
-                role="alert"
-                className={`absolute -bottom-3 left-0 text-xs text-danger transition-opacity ${errors.date ? "opacity-100" : "opacity-0 pointer-events-none"}`}
-              >
-                {errors.date ?? "\u00A0"}
-              </p>
+            <div className="space-y-2">
+              <Label className="text-text-secondary/60">Date</Label>
+              <div className="flex h-10 w-full items-center rounded-xl border border-border/40 bg-surface-alt/50 px-4 text-sm text-text-secondary/60 select-none cursor-not-allowed">
+                {formatReadOnlyDate(log.wornAt)}
+              </div>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="time">Time</Label>
-              <Input
-                id="time"
-                type="time"
-                value={time}
-                onChange={(e) => setTime(e.target.value)}
-              />
+              <Label className="text-text-secondary/60">Time</Label>
+              <div className="flex h-10 w-full items-center rounded-xl border border-border/40 bg-surface-alt/50 px-4 text-sm text-text-secondary/60 select-none cursor-not-allowed">
+                {formatReadOnlyTime(log.wornAt)}
+              </div>
             </div>
           </div>
 
           {/* Sprays + Rating side by side */}
           <div className="grid grid-cols-2 gap-4">
             <div className="relative space-y-2">
-              <Label htmlFor="sprays" className={errors.sprays ? "text-danger" : ""}>
+              <Label htmlFor="edit-sprays" className={errors.sprays ? "text-danger" : ""}>
                 Sprays *
               </Label>
               <Input
-                id="sprays"
+                id="edit-sprays"
                 type="number"
                 value={sprays}
                 onChange={(e) => {
@@ -229,10 +205,10 @@ export function AddWearLogDialog({
                     : ""
                 }
                 aria-invalid={!!errors.sprays}
-                aria-describedby="sprays-error"
+                aria-describedby="edit-sprays-error"
               />
               <p
-                id="sprays-error"
+                id="edit-sprays-error"
                 role="alert"
                 className={`absolute -bottom-3 left-0 text-xs text-danger transition-opacity ${errors.sprays ? "opacity-100" : "opacity-0 pointer-events-none"}`}
               >
@@ -240,11 +216,11 @@ export function AddWearLogDialog({
               </p>
             </div>
             <div className="relative space-y-2">
-              <Label htmlFor="rating" className={errors.rating ? "text-danger" : ""}>
+              <Label htmlFor="edit-rating" className={errors.rating ? "text-danger" : ""}>
                 Rating (1-10)
               </Label>
               <Input
-                id="rating"
+                id="edit-rating"
                 type="number"
                 value={rating}
                 onChange={(e) => {
@@ -260,10 +236,10 @@ export function AddWearLogDialog({
                     : ""
                 }
                 aria-invalid={!!errors.rating}
-                aria-describedby="rating-error"
+                aria-describedby="edit-rating-error"
               />
               <p
-                id="rating-error"
+                id="edit-rating-error"
                 role="alert"
                 className={`absolute -bottom-3 left-0 text-xs text-danger transition-opacity ${errors.rating ? "opacity-100" : "opacity-0 pointer-events-none"}`}
               >
@@ -297,9 +273,9 @@ export function AddWearLogDialog({
 
           {/* Comment */}
           <div className="space-y-2">
-            <Label htmlFor="comment">Comments</Label>
+            <Label htmlFor="edit-comment">Comments</Label>
             <Textarea
-              id="comment"
+              id="edit-comment"
               value={comment}
               onChange={(e) => setComment(e.target.value)}
               placeholder="Performance comments, compliments received..."
@@ -321,7 +297,7 @@ export function AddWearLogDialog({
               Cancel
             </Button>
             <Button type="submit" disabled={submitting} aria-keyshortcuts="Control+Enter">
-              <span>{submitting ? "Logging..." : "Log Wear"}</span>
+              <span>{submitting ? "Saving..." : "Save Changes"}</span>
               {!submitting && (
                 <KbdGroup aria-hidden="true" className="ml-1">
                   <Kbd className="border-white/20 bg-white/14 text-white shadow-[inset_0_-1px_0_rgba(255,255,255,0.18)]">

--- a/my-app/src/components/wear-log-list.tsx
+++ b/my-app/src/components/wear-log-list.tsx
@@ -6,14 +6,18 @@ import { api } from "../../convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
+import { EditWearLogDialog } from "@/components/edit-wear-log-dialog";
 import {
   Droplets,
   Calendar,
   Star,
   MessageSquare,
+  Pencil,
   Trash2,
 } from "lucide-react";
 import { useState } from "react";
+import { toast } from "sonner";
+import { getApiErrorMessage } from "@/lib/utils";
 
 interface WearLogListProps {
   logs: Doc<"wearLogs">[];
@@ -22,6 +26,7 @@ interface WearLogListProps {
 export function WearLogList({ logs }: WearLogListProps) {
   const deleteLog = useMutation(api.wearLogs.deleteWearLog);
   const [deletingId, setDeletingId] = useState<Id<"wearLogs"> | null>(null);
+  const [editingLog, setEditingLog] = useState<Doc<"wearLogs"> | null>(null);
 
   if (logs.length === 0) {
     return (
@@ -42,8 +47,16 @@ export function WearLogList({ logs }: WearLogListProps) {
       setDeletingId(logId);
       return;
     }
-    await deleteLog({ wearLogId: logId });
-    setDeletingId(null);
+    try {
+      await deleteLog({ wearLogId: logId });
+      setDeletingId(null);
+    } catch (err) {
+      setDeletingId(null);
+      if (process.env.NODE_ENV !== "production") {
+        console.error("Failed to delete wear log:", err);
+      }
+      toast.error(getApiErrorMessage(err));
+    }
   };
 
   const formatDate = (timestamp: number) => {
@@ -130,31 +143,56 @@ export function WearLogList({ logs }: WearLogListProps) {
                   )}
                 </div>
 
-                {/* Delete */}
-                <Button
-                  variant={deletingId === log._id ? "destructive" : "ghost"}
-                  onClick={() => handleDelete(log._id)}
-                  onMouseLeave={() => setDeletingId(null)}
-                  className={cn(
-                    "h-8 transition-all duration-300 ease-out opacity-0 group-hover:opacity-100 shrink-0 overflow-hidden relative gap-0",
-                    deletingId === log._id ? "w-[100px] px-3" : "w-8 px-0 justify-center"
-                  )}
-                >
-                  <Trash2 className="h-3.5 w-3.5 shrink-0 z-10" />
-                  <span
+                {/* Edit + Delete */}
+                <div className="flex items-center gap-1.5 shrink-0">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setEditingLog(log)}
+                    className="h-8 w-8 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 transition-all duration-200 border border-white/15 bg-white/8 hover:bg-white/15"
+                    aria-label="Edit wear log"
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant={deletingId === log._id ? "destructive" : "ghost"}
+                    onClick={() => handleDelete(log._id)}
+                    onMouseLeave={() => setDeletingId(null)}
+                    aria-label={
+                      deletingId === log._id
+                        ? "Confirm delete wear log"
+                        : "Delete wear log"
+                    }
                     className={cn(
-                      "overflow-hidden transition-all duration-300 ease-out whitespace-nowrap text-xs flex items-center z-10",
-                      deletingId === log._id ? "w-[56px] ml-1.5 opacity-100" : "w-0 ml-0 opacity-0"
+                      "h-8 transition-all duration-300 ease-out opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 shrink-0 overflow-hidden relative gap-0",
+                      deletingId === log._id ? "w-[100px] px-3" : "w-8 px-0 justify-center"
                     )}
                   >
-                    Confirm
-                  </span>
-                </Button>
+                    <Trash2 className="h-3.5 w-3.5 shrink-0 z-10" />
+                    <span
+                      aria-hidden={deletingId !== log._id}
+                      className={cn(
+                        "overflow-hidden transition-all duration-300 ease-out whitespace-nowrap text-xs flex items-center z-10",
+                        deletingId === log._id ? "w-[56px] ml-1.5 opacity-100" : "w-0 ml-0 opacity-0"
+                      )}
+                    >
+                      Confirm
+                    </span>
+                  </Button>
+                </div>
               </div>
             ))}
           </div>
         </div>
       ))}
+
+      {editingLog && (
+        <EditWearLogDialog
+          open={!!editingLog}
+          onOpenChange={(open) => { if (!open) setEditingLog(null); }}
+          log={editingLog}
+        />
+      )}
     </div>
   );
 }

--- a/my-app/src/lib/bottle-collection-sort.test.ts
+++ b/my-app/src/lib/bottle-collection-sort.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, test } from "vitest";
+import type { Id } from "../../convex/_generated/dataModel";
+import {
+  filterAndSortBottles,
+  getBottleStats,
+  getNextSortState,
+  type BottleCollectionItem,
+  type BottleStatsMap,
+} from "./bottle-collection-sort";
+
+function bottle(
+  id: string,
+  name: string,
+  creationTime: number,
+  overrides: Partial<BottleCollectionItem> = {},
+): BottleCollectionItem {
+  return {
+    _id: id as Id<"bottles">,
+    _creationTime: creationTime,
+    userId: "test-user" as Id<"users">,
+    createdAt: creationTime,
+    name,
+    brand: undefined,
+    tags: undefined,
+    ...overrides,
+  };
+}
+
+const bottles: BottleCollectionItem[] = [
+  bottle("b1", "Zoologist Bee", 100, {
+    brand: "Zoologist",
+    tags: ["honey", "amber"],
+  }),
+  bottle("b2", "Acqua di Parma", 300, {
+    brand: "Parma",
+    tags: ["citrus"],
+  }),
+  bottle("b3", "Byredo Bal d'Afrique", 200, {
+    brand: "Byredo",
+    tags: ["vetiver"],
+  }),
+  bottle("b4", "Amouage Jubilation", 200, {
+    brand: "Amouage",
+    tags: ["resin"],
+  }),
+];
+
+const stats: BottleStatsMap = {
+  b1: { wears: 4, sprays: 20, avgRating: 7.5 },
+  b2: { wears: 2, sprays: 6, avgRating: null },
+  b3: { wears: 4, sprays: 12, avgRating: 9 },
+  b4: { wears: 1, sprays: 3, avgRating: 7.5 },
+};
+
+function names(items: BottleCollectionItem[]): string[] {
+  return items.map((item) => item.name);
+}
+
+describe("getNextSortState", () => {
+  test("toggles direction when selecting the active option", () => {
+    expect(getNextSortState("created", "desc", "created")).toEqual({
+      sortBy: "created",
+      sortDir: "asc",
+    });
+    expect(getNextSortState("name", "asc", "name")).toEqual({
+      sortBy: "name",
+      sortDir: "desc",
+    });
+  });
+
+  test("uses sensible defaults when selecting a new option", () => {
+    expect(getNextSortState("created", "desc", "name")).toEqual({
+      sortBy: "name",
+      sortDir: "asc",
+    });
+    expect(getNextSortState("name", "asc", "rating")).toEqual({
+      sortBy: "rating",
+      sortDir: "desc",
+    });
+  });
+});
+
+describe("getBottleStats", () => {
+  test("returns zeroed defaults when stats are missing", () => {
+    expect(getBottleStats(undefined, "missing")).toEqual({
+      wears: 0,
+      sprays: 0,
+      avgRating: null,
+    });
+    expect(getBottleStats(stats, "missing")).toEqual({
+      wears: 0,
+      sprays: 0,
+      avgRating: null,
+    });
+  });
+});
+
+describe("filterAndSortBottles", () => {
+  test("sorts by created descending by default and breaks ties by name", () => {
+    const result = filterAndSortBottles({
+      bottles,
+      bottleStats: stats,
+      search: "",
+      sortBy: "created",
+      sortDir: "desc",
+    });
+
+    expect(names(result)).toEqual([
+      "Acqua di Parma",
+      "Amouage Jubilation",
+      "Byredo Bal d'Afrique",
+      "Zoologist Bee",
+    ]);
+  });
+
+  test("sorts by created ascending", () => {
+    const result = filterAndSortBottles({
+      bottles,
+      bottleStats: stats,
+      search: "",
+      sortBy: "created",
+      sortDir: "asc",
+    });
+
+    expect(names(result)).toEqual([
+      "Zoologist Bee",
+      "Amouage Jubilation",
+      "Byredo Bal d'Afrique",
+      "Acqua di Parma",
+    ]);
+  });
+
+  test("sorts by name in both directions", () => {
+    expect(
+      names(
+        filterAndSortBottles({
+          bottles,
+          bottleStats: stats,
+          search: "",
+          sortBy: "name",
+          sortDir: "asc",
+        }),
+      ),
+    ).toEqual([
+      "Acqua di Parma",
+      "Amouage Jubilation",
+      "Byredo Bal d'Afrique",
+      "Zoologist Bee",
+    ]);
+
+    expect(
+      names(
+        filterAndSortBottles({
+          bottles,
+          bottleStats: stats,
+          search: "",
+          sortBy: "name",
+          sortDir: "desc",
+        }),
+      ),
+    ).toEqual([
+      "Zoologist Bee",
+      "Byredo Bal d'Afrique",
+      "Amouage Jubilation",
+      "Acqua di Parma",
+    ]);
+  });
+
+  test("sorts by wears in both directions with deterministic tie-breakers", () => {
+    expect(
+      names(
+        filterAndSortBottles({
+          bottles,
+          bottleStats: stats,
+          search: "",
+          sortBy: "wears",
+          sortDir: "desc",
+        }),
+      ),
+    ).toEqual([
+      "Byredo Bal d'Afrique",
+      "Zoologist Bee",
+      "Acqua di Parma",
+      "Amouage Jubilation",
+    ]);
+
+    expect(
+      names(
+        filterAndSortBottles({
+          bottles,
+          bottleStats: stats,
+          search: "",
+          sortBy: "wears",
+          sortDir: "asc",
+        }),
+      ),
+    ).toEqual([
+      "Amouage Jubilation",
+      "Acqua di Parma",
+      "Byredo Bal d'Afrique",
+      "Zoologist Bee",
+    ]);
+  });
+
+  test("sorts by rating in both directions and always keeps unrated bottles last", () => {
+    expect(
+      names(
+        filterAndSortBottles({
+          bottles,
+          bottleStats: stats,
+          search: "",
+          sortBy: "rating",
+          sortDir: "desc",
+        }),
+      ),
+    ).toEqual([
+      "Byredo Bal d'Afrique",
+      "Amouage Jubilation",
+      "Zoologist Bee",
+      "Acqua di Parma",
+    ]);
+
+    expect(
+      names(
+        filterAndSortBottles({
+          bottles,
+          bottleStats: stats,
+          search: "",
+          sortBy: "rating",
+          sortDir: "asc",
+        }),
+      ),
+    ).toEqual([
+      "Amouage Jubilation",
+      "Zoologist Bee",
+      "Byredo Bal d'Afrique",
+      "Acqua di Parma",
+    ]);
+  });
+
+  test("uses zeroed stats for bottles without wear data", () => {
+    const result = filterAndSortBottles({
+      bottles: [...bottles, bottle("b5", "CdG Avignon", 250)],
+      bottleStats: stats,
+      search: "",
+      sortBy: "wears",
+      sortDir: "asc",
+    });
+
+    expect(names(result).slice(0, 2)).toEqual([
+      "CdG Avignon",
+      "Amouage Jubilation",
+    ]);
+  });
+
+  test("filters by name, brand, and tags before sorting", () => {
+    expect(
+      names(
+        filterAndSortBottles({
+          bottles,
+          bottleStats: stats,
+          search: "parma",
+          sortBy: "name",
+          sortDir: "asc",
+        }),
+      ),
+    ).toEqual(["Acqua di Parma"]);
+
+    expect(
+      names(
+        filterAndSortBottles({
+          bottles,
+          bottleStats: stats,
+          search: "vetiver",
+          sortBy: "name",
+          sortDir: "asc",
+        }),
+      ),
+    ).toEqual(["Byredo Bal d'Afrique"]);
+
+    expect(
+      names(
+        filterAndSortBottles({
+          bottles,
+          bottleStats: stats,
+          search: "  zoo ",
+          sortBy: "name",
+          sortDir: "asc",
+        }),
+      ),
+    ).toEqual(["Zoologist Bee"]);
+  });
+
+  test("combines filtering with non-default sort orders", () => {
+    const result = filterAndSortBottles({
+      bottles,
+      bottleStats: stats,
+      search: "am",
+      sortBy: "rating",
+      sortDir: "desc",
+    });
+
+    expect(names(result)).toEqual([
+      "Amouage Jubilation",
+      "Zoologist Bee",
+    ]);
+  });
+
+  test("does not mutate the original bottle array", () => {
+    const original = [...bottles];
+
+    filterAndSortBottles({
+      bottles: original,
+      bottleStats: stats,
+      search: "",
+      sortBy: "rating",
+      sortDir: "desc",
+    });
+
+    expect(names(original)).toEqual([
+      "Zoologist Bee",
+      "Acqua di Parma",
+      "Byredo Bal d'Afrique",
+      "Amouage Jubilation",
+    ]);
+  });
+});

--- a/my-app/src/lib/bottle-collection-sort.ts
+++ b/my-app/src/lib/bottle-collection-sort.ts
@@ -1,0 +1,108 @@
+import type { Doc } from "../../convex/_generated/dataModel";
+
+export type SortOption = "created" | "name" | "wears" | "rating";
+export type SortDir = "asc" | "desc";
+
+export type BottleCollectionItem = Doc<"bottles">;
+
+export type BottleStatsMap = Record<
+  string,
+  { wears: number; sprays: number; avgRating: number | null }
+>;
+
+const EMPTY_STATS = { wears: 0, sprays: 0, avgRating: null };
+
+function compareNames(a: BottleCollectionItem, b: BottleCollectionItem): number {
+  return a.name.localeCompare(b.name);
+}
+
+function compareCreatedDesc(
+  a: BottleCollectionItem,
+  b: BottleCollectionItem,
+): number {
+  return b._creationTime - a._creationTime;
+}
+
+function compareFallback(
+  a: BottleCollectionItem,
+  b: BottleCollectionItem,
+): number {
+  return compareNames(a, b) || compareCreatedDesc(a, b) || a._id.localeCompare(b._id);
+}
+
+function matchesSearch(bottle: BottleCollectionItem, rawSearch: string): boolean {
+  const search = rawSearch.trim().toLowerCase();
+  if (!search) return true;
+
+  return (
+    bottle.name.toLowerCase().includes(search) ||
+    bottle.brand?.toLowerCase().includes(search) ||
+    bottle.tags?.some((tag) => tag.toLowerCase().includes(search)) ||
+    false
+  );
+}
+
+export function getBottleStats(
+  bottleStats: BottleStatsMap | undefined,
+  bottleId: string,
+) {
+  return bottleStats?.[bottleId] ?? EMPTY_STATS;
+}
+
+export function getNextSortState(
+  currentSortBy: SortOption,
+  currentSortDir: SortDir,
+  option: SortOption,
+): { sortBy: SortOption; sortDir: SortDir } {
+  if (currentSortBy === option) {
+    return {
+      sortBy: option,
+      sortDir: currentSortDir === "asc" ? "desc" : "asc",
+    };
+  }
+
+  return {
+    sortBy: option,
+    sortDir: option === "name" ? "asc" : "desc",
+  };
+}
+
+export function filterAndSortBottles({
+  bottles,
+  bottleStats,
+  search,
+  sortBy,
+  sortDir,
+}: {
+  bottles: BottleCollectionItem[];
+  bottleStats: BottleStatsMap | undefined;
+  search: string;
+  sortBy: SortOption;
+  sortDir: SortDir;
+}): BottleCollectionItem[] {
+  const filtered = bottles.filter((bottle) => matchesSearch(bottle, search));
+  const dir = sortDir === "asc" ? 1 : -1;
+
+  return [...filtered].sort((a, b) => {
+    switch (sortBy) {
+      case "name":
+        return dir * compareNames(a, b) || compareCreatedDesc(a, b) || a._id.localeCompare(b._id);
+      case "wears": {
+        const aWears = getBottleStats(bottleStats, a._id).wears;
+        const bWears = getBottleStats(bottleStats, b._id).wears;
+        return dir * (aWears - bWears) || compareFallback(a, b);
+      }
+      case "rating": {
+        const aRating = getBottleStats(bottleStats, a._id).avgRating;
+        const bRating = getBottleStats(bottleStats, b._id).avgRating;
+        if (aRating === null && bRating === null) return compareFallback(a, b);
+        if (aRating === null) return 1;
+        if (bRating === null) return -1;
+        return dir * (aRating - bRating) || compareFallback(a, b);
+      }
+      case "created":
+      default:
+        return dir * (a._creationTime - b._creationTime) || compareNames(a, b) || a._id.localeCompare(b._id);
+    }
+  });
+}

--- a/my-app/src/lib/constants.ts
+++ b/my-app/src/lib/constants.ts
@@ -1,0 +1,12 @@
+export const MAX_SPRAYS = 100;
+
+export const CONTEXT_OPTIONS = [
+  "Office",
+  "Date Night",
+  "Casual",
+  "Formal",
+  "Gym",
+  "Evening Out",
+  "Travel",
+  "Special Occasion",
+];

--- a/my-app/vitest.config.mts
+++ b/my-app/vitest.config.mts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "edge-runtime",
-    include: ["convex/**/*.test.ts"],
+    include: ["convex/**/*.test.ts", "src/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
### What changed
- **Wear log editing** – Added an `EditWearLogDialog` accessible from each wear-log row. Users can update sprays, context, rating, and comments. Date/time is displayed read-only.
- **Collection sorting & filtering** – Replaced client-side search with a dedicated `filterAndSortBottles` engine that supports sorting by **Date Added**, **Name**, **Wears**, and **Rating** (asc/desc toggle). Unrated bottles are always pushed to the bottom when sorting by rating.
- **Average rating aggregation** – `listBottleStats` now computes `avgRating` server-side. Bottle cards display the average when available.
- **Shared constants** – Extracted `MAX_SPRAYS` (100) and `CONTEXT_OPTIONS` into `src/lib/constants.ts` so both frontend and backend use the same values.
- **Validation** – Added a 60-second future-date tolerance for `wornAt` on create and update.
- **Polish / fixes**
  - Case-insensitive tag deduplication in the add-bottle dialog.
  - Fixed connection-banner debounce cleanup.
  - Added error handling + toast on wear-log deletion.
  - Updated `vitest.config.mts` to run `src/**/*.test.ts` in addition to Convex tests.

### How to test
1. Open a bottle and add a wear log.
2. Click the **pencil** icon on the wear log to edit it. Change sprays/context/rating/comment and save.
3. In the collection sidebar, use the sort dropdown to reorder by wears, rating, etc.
4. Verify that bottles with ratings show an average star value on their card.
5. Run `npm test` (or `vitest`) — new unit tests cover the sort engine, and backend tests cover avg-rating aggregation + future-date tolerance.

closes #29 #12 