### PR TITLE
feat: guided onboarding tour and comma-separated tag input

### DIFF
--- a/my-app/src/app/globals.css
+++ b/my-app/src/app/globals.css
@@ -205,15 +205,15 @@ body {
 }
 
 .animate-fade-up {
-  animation: fadeUp 0.5s var(--ease-smooth) both;
+  animation: fadeUp 0.5s var(--ease-smooth) backwards;
 }
 
 .animate-fade-in {
-  animation: fadeIn 0.4s var(--ease-smooth) both;
+  animation: fadeIn 0.4s var(--ease-smooth) backwards;
 }
 
 .animate-scale-in {
-  animation: scaleIn 0.35s var(--ease-smooth) both;
+  animation: scaleIn 0.35s var(--ease-smooth) backwards;
 }
 
 .animate-shimmer {
@@ -273,6 +273,37 @@ body {
   to {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
+  }
+}
+
+/* ── Onboarding coach-mark pulse ─────────────────────────────────────────── */
+@keyframes coachPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 var(--accent);
+  }
+
+  50% {
+    box-shadow: 0 0 0 6px transparent;
+  }
+}
+
+.coach-pulse {
+  animation: coachPulse 2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .coach-pulse {
+    animation: none;
+  }
+
+  .animate-fade-up,
+  .animate-fade-in,
+  .animate-scale-in,
+  .animate-shimmer {
+    animation: none;
+    opacity: 1;
+    transform: none;
   }
 }
 

--- a/my-app/src/components/add-bottle-dialog.tsx
+++ b/my-app/src/components/add-bottle-dialog.tsx
@@ -88,9 +88,16 @@ export function AddBottleDialog({
   };
 
   const handleAddTag = () => {
-    const trimmed = tagInput.trim();
-    if (trimmed && !tags.some((t) => t.toLowerCase() === trimmed.toLowerCase())) {
-      setTags([...tags, trimmed]);
+    const newTags = tagInput
+      .split(",")
+      .map((t) => t.trim())
+      .filter(
+        (t) =>
+          t.length > 0 &&
+          !tags.some((existing) => existing.toLowerCase() === t.toLowerCase()),
+      );
+    if (newTags.length > 0) {
+      setTags([...tags, ...newTags]);
     }
     setTagInput("");
   };
@@ -268,7 +275,7 @@ export function AddBottleDialog({
                 value={tagInput}
                 onChange={(e) => setTagInput(e.target.value)}
                 onKeyDown={handleTagKeyDown}
-                placeholder="Type and press Enter"
+                placeholder="fresh, citrus, woody..."
                 className="flex-1"
               />
               <Button

--- a/my-app/src/components/add-wear-log-dialog.tsx
+++ b/my-app/src/components/add-wear-log-dialog.tsx
@@ -34,12 +34,15 @@ interface AddWearLogDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   bottleId: Id<"bottles">;
+  /** Called after a wear log is successfully created. */
+  onSuccess?: () => void;
 }
 
 export function AddWearLogDialog({
   open,
   onOpenChange,
   bottleId,
+  onSuccess,
 }: AddWearLogDialogProps) {
   const addWearLog = useMutation(api.wearLogs.addWearLog);
 
@@ -140,6 +143,7 @@ export function AddWearLogDialog({
         comment: comment.trim() || undefined,
       });
       toast.success("Wear logged");
+      onSuccess?.();
       onOpenChange(false);
     } catch (err) {
       if (process.env.NODE_ENV !== "production") {

--- a/my-app/src/components/bottle-card.tsx
+++ b/my-app/src/components/bottle-card.tsx
@@ -16,6 +16,7 @@ interface BottleCardProps {
   totalWears?: number;
   avgRating?: number | null;
   index: number;
+  className?: string;
 }
 
 export function BottleCard({
@@ -26,6 +27,7 @@ export function BottleCard({
   totalWears,
   avgRating,
   index,
+  className: extraClassName,
 }: BottleCardProps) {
   const staggerClass = `stagger-${Math.min(index + 1, 8)}`;
   const tags = bottle.tags ?? EMPTY_TAGS;
@@ -76,11 +78,12 @@ export function BottleCard({
       className={cn(
         "group w-full h-full flex flex-col text-left rounded-xl border px-6 py-5 transition-all duration-200 cursor-pointer",
         "hover:shadow-md hover:-translate-y-0.5",
-        "animate-fade-up opacity-0",
+        "animate-fade-up",
         staggerClass,
         isSelected
           ? "border-accent bg-accent-subtle/60 shadow-sm"
-          : "border-border bg-surface hover:border-border-hover"
+          : "border-border bg-surface hover:border-border-hover",
+        extraClassName,
       )}
     >
       <div className="flex items-start justify-between gap-3">

--- a/my-app/src/components/bottle-collection.tsx
+++ b/my-app/src/components/bottle-collection.tsx
@@ -4,6 +4,8 @@ import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id } from "../../convex/_generated/dataModel";
 import { BottleCard } from "@/components/bottle-card";
+import { CoachMark } from "@/components/coach-mark";
+import { cn } from "@/lib/utils";
 import {
   filterAndSortBottles,
   getBottleStats,
@@ -19,8 +21,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
-import { Plus, Wine, ArrowUpDown, ArrowUp, ArrowDown, Check } from "lucide-react";
-import { useState, useMemo } from "react";
+import { type OnboardingStep } from "@/lib/use-onboarding";
+import { Plus, Wine, ArrowUp, ArrowDown, Check } from "lucide-react";
+import { useState, useMemo, useEffect, useRef } from "react";
 
 const SORT_LABELS: Record<SortOption, string> = {
   created: "Date Added",
@@ -33,18 +36,50 @@ interface BottleCollectionProps {
   selectedBottleId: Id<"bottles"> | null;
   onSelectBottle: (id: Id<"bottles">) => void;
   onAddBottle: () => void;
+  onboardingStep?: OnboardingStep;
+  onAdvanceOnboarding?: () => void;
+  onDismissOnboarding?: () => void;
 }
 
 export function BottleCollection({
   selectedBottleId,
   onSelectBottle,
   onAddBottle,
+  onboardingStep,
+  onAdvanceOnboarding,
+  onDismissOnboarding,
 }: BottleCollectionProps) {
   const bottles = useQuery(api.bottles.listBottles);
   const bottleStats = useQuery(api.wearLogs.listBottleStats);
   const [search, setSearch] = useState("");
   const [sortBy, setSortBy] = useState<SortOption>("created");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  // Track whether we've already auto-advanced from welcome → select-bottle.
+  // This prevents the advance from firing on every re-render.
+  const hasAdvancedWelcome = useRef(false);
+
+  // Auto-advance: when bottles appear during the 'welcome' step,
+  // transition to 'select-bottle'.
+  useEffect(() => {
+    if (
+      onboardingStep === "welcome" &&
+      bottles &&
+      bottles.length > 0 &&
+      !hasAdvancedWelcome.current
+    ) {
+      hasAdvancedWelcome.current = true;
+      onAdvanceOnboarding?.();
+    }
+  }, [onboardingStep, bottles, onAdvanceOnboarding]);
+
+  // Reset when the tour leaves the welcome step so the ref is fresh
+  // if onboarding is re-triggered (e.g. via NEXT_PUBLIC_FORCE_ONBOARDING).
+  useEffect(() => {
+    if (onboardingStep !== "welcome") {
+      hasAdvancedWelcome.current = false;
+    }
+  }, [onboardingStep]);
 
   const handleSort = (option: SortOption) => {
     const next = getNextSortState(sortBy, sortDir, option);
@@ -80,7 +115,7 @@ export function BottleCollection({
         </div>
 
         {/* Grid Skeleton */}
-        <div className="flex-1 overflow-y-auto scrollbar-fade pb-5 pt-4 -mr-6 pr-6 lg:-mr-7 lg:pr-7">
+        <div className="flex-1 overflow-y-auto scrollbar-fade pb-5 pt-4 -ml-2 pl-2 -mr-6 pr-6 lg:-mr-7 lg:pr-7">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {Array.from({ length: 6 }).map((_, i) => (
               <div
@@ -96,22 +131,39 @@ export function BottleCollection({
   }
 
   if (bottles.length === 0) {
+    const isWelcome = onboardingStep === "welcome";
     return (
       <div className="flex h-full flex-col items-center justify-center py-16 animate-fade-up">
         <div className="w-16 h-16 rounded-2xl bg-surface-alt flex items-center justify-center mb-4">
           <Wine className="h-8 w-8 text-text-secondary/50" />
         </div>
         <h3 className="font-display text-xl font-semibold text-text mb-1">
-          Your collection awaits
+          {isWelcome ? "Welcome! Let\u2019s get started" : "Your collection awaits"}
         </h3>
         <p className="text-sm text-text-secondary text-center max-w-[240px] mb-6">
-          Add your first fragrance to start tracking your collection and wear
-          history.
+          {isWelcome
+            ? "Add your first fragrance to begin your tracking journey."
+            : "Add your first fragrance to start tracking your collection and wear history."}
         </p>
-        <Button onClick={onAddBottle} className="gap-2">
-          <Plus className="h-4 w-4" />
-          Add Fragrance
-        </Button>
+        <div className={cn("relative", isWelcome && "z-50")}>
+          <Button
+            onClick={onAddBottle}
+            className={cn("gap-2", isWelcome && "coach-pulse")}
+          >
+            <Plus className="h-4 w-4" />
+            Add Fragrance
+          </Button>
+          {isWelcome && onDismissOnboarding && (
+            <CoachMark
+              step={1}
+              totalSteps={3}
+              title="Add your first fragrance"
+              description="Start by adding a fragrance from your collection."
+              onDismiss={onDismissOnboarding}
+              position="bottom"
+            />
+          )}
+        </div>
       </div>
     );
   }
@@ -156,11 +208,11 @@ export function BottleCollection({
               className="h-7 gap-1.5 text-xs text-text-secondary hover:text-text px-2"
               aria-label="Sort fragrances"
             >
-              <ArrowUpDown className="h-3 w-3" />
+              {sortDir === "asc" ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />}
               {SORT_LABELS[sortBy]}
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="min-w-[160px]">
+          <DropdownMenuContent align="start" className="min-w-[160px]">
             {(Object.keys(SORT_LABELS) as SortOption[]).map((option) => {
               const isActive = sortBy === option;
               return (
@@ -190,21 +242,34 @@ export function BottleCollection({
       </div>
 
       {/* Grid */}
-      <div className="flex-1 overflow-y-auto scrollbar-fade pb-5 pt-4 -mr-6 pr-6 lg:-mr-7 lg:pr-7">
+      <div className="flex-1 overflow-y-auto scrollbar-fade pb-5 pt-4 -ml-2 pl-2 -mr-6 pr-6 lg:-mr-7 lg:pr-7">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {filteredBottles.map((bottle, i) => {
             const stats = getBottleStats(bottleStats, bottle._id);
+            const showCoachMark = i === 0 && onboardingStep === "select-bottle";
             return (
-              <BottleCard
-                key={bottle._id}
-                bottle={bottle}
-                isSelected={selectedBottleId === bottle._id}
-                onClick={() => onSelectBottle(bottle._id)}
-                totalSprays={stats?.sprays}
-                totalWears={stats?.wears}
-                avgRating={stats?.avgRating ?? null}
-                index={i}
-              />
+              <div key={bottle._id} className={cn("relative", showCoachMark && "z-50")}>
+                <BottleCard
+                  bottle={bottle}
+                  isSelected={selectedBottleId === bottle._id}
+                  onClick={() => onSelectBottle(bottle._id)}
+                  totalSprays={stats?.sprays}
+                  totalWears={stats?.wears}
+                  avgRating={stats?.avgRating ?? null}
+                  index={i}
+                  className={showCoachMark ? "coach-pulse" : undefined}
+                />
+                {showCoachMark && onDismissOnboarding && (
+                  <CoachMark
+                    step={2}
+                    totalSteps={3}
+                    title="Open your fragrance"
+                    description="Tap to see details and start tracking wears."
+                    onDismiss={onDismissOnboarding}
+                    position="bottom"
+                  />
+                )}
+              </div>
             );
           })}
         </div>

--- a/my-app/src/components/bottle-detail.tsx
+++ b/my-app/src/components/bottle-detail.tsx
@@ -6,6 +6,7 @@ import { Id } from "../../convex/_generated/dataModel";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { CoachMark } from "@/components/coach-mark";
 import { cn } from "@/lib/utils";
 import { WearLogList } from "@/components/wear-log-list";
 import {
@@ -20,12 +21,15 @@ import {
 import { useState } from "react";
 import { toast } from "sonner";
 import { getApiErrorMessage } from "@/lib/utils";
+import { type OnboardingStep } from "@/lib/use-onboarding";
 
 interface BottleDetailProps {
   bottleId: Id<"bottles">;
   onEdit: () => void;
   onAddWearLog: () => void;
   onClose: () => void;
+  onboardingStep?: OnboardingStep;
+  onDismissOnboarding?: () => void;
 }
 
 export function BottleDetail({
@@ -33,6 +37,8 @@ export function BottleDetail({
   onEdit,
   onAddWearLog,
   onClose,
+  onboardingStep,
+  onDismissOnboarding,
 }: BottleDetailProps) {
   const bottle = useQuery(api.bottles.getBottle, { bottleId });
   const logs = useQuery(api.wearLogs.listWearLogsByBottle, { bottleId });
@@ -199,10 +205,31 @@ export function BottleDetail({
         <h3 className="font-display text-lg font-semibold text-text">
           Wear History
         </h3>
-        <Button onClick={onAddWearLog} size="sm" variant="outline" className="gap-1.5 bg-white/10 hover:bg-white/20 transition-colors">
-          <Plus className="h-3.5 w-3.5" />
-          Log Wear
-        </Button>
+        <div className={cn("relative", onboardingStep === "log-wear" && "z-50")}>
+          <Button
+            onClick={onAddWearLog}
+            size="sm"
+            variant="outline"
+            className={cn(
+              "gap-1.5 bg-white/10 hover:bg-white/20 transition-colors",
+              onboardingStep === "log-wear" && "coach-pulse",
+            )}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Log Wear
+          </Button>
+          {onboardingStep === "log-wear" && onDismissOnboarding && (
+            <CoachMark
+              step={3}
+              totalSteps={3}
+              title="Log your first wear!"
+              description="Record when you wore this fragrance — sprays, context, and a rating."
+              onDismiss={onDismissOnboarding}
+              position="bottom"
+              align="end"
+            />
+          )}
+        </div>
       </div>
 
       <div className="flex-1 overflow-y-auto scrollbar-fade px-7 pb-7">

--- a/my-app/src/components/coach-mark.tsx
+++ b/my-app/src/components/coach-mark.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { ONBOARDING_SETTLE_MS } from "@/lib/use-onboarding";
+import { X } from "lucide-react";
+import { useRef, useState, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
+
+interface CoachMarkProps {
+  step: number;
+  totalSteps: number;
+  title: string;
+  description: string;
+  onDismiss: () => void;
+  /** Where the tooltip appears relative to the target. Arrow points opposite. */
+  position?: "top" | "bottom";
+  /**
+   * Horizontal alignment hint.
+   *   center — try to centre on the parent (default)
+   *   start  — left-align to parent
+   *   end    — right-align to parent
+   * The tooltip is always clamped to the viewport so it never bleeds.
+   */
+  align?: "center" | "start" | "end";
+  className?: string;
+}
+
+const TOOLTIP_W = 256; // w-64 = 16rem
+const GAP = 12; // 0.75rem
+const VIEWPORT_PAD = 12;
+
+export function CoachMark({
+  step,
+  totalSteps,
+  title,
+  description,
+  onDismiss,
+  position = "bottom",
+  align = "center",
+  className,
+}: CoachMarkProps) {
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const [settled, setSettled] = useState(false);
+
+  const sync = useCallback(() => {
+    const parent = anchorRef.current?.parentElement;
+    if (!parent) return;
+    setRect(parent.getBoundingClientRect());
+  }, []);
+
+  // Delay initial render so card animations can finish and we measure
+  // the final laid-out position.
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setSettled(true);
+      sync();
+    }, ONBOARDING_SETTLE_MS);
+    return () => clearTimeout(id);
+  }, [sync]);
+
+  // Re-measure on scroll / resize after settled.
+  useEffect(() => {
+    if (!settled) return;
+    window.addEventListener("resize", sync);
+    window.addEventListener("scroll", sync, true);
+    return () => {
+      window.removeEventListener("resize", sync);
+      window.removeEventListener("scroll", sync, true);
+    };
+  }, [settled, sync]);
+
+  // Invisible inline anchor to locate the parent wrapper.
+  const anchor = (
+    <span
+      ref={anchorRef}
+      className="absolute w-0 h-0 overflow-hidden pointer-events-none"
+      aria-hidden="true"
+    />
+  );
+
+  if (!settled || !rect) return anchor;
+
+  // ── Compute fixed position ────────────────────────────────────────────
+
+  const top =
+    position === "bottom"
+      ? rect.bottom + GAP
+      : rect.top - GAP;
+
+  let left: number;
+  if (align === "start") {
+    left = rect.left;
+  } else if (align === "end") {
+    left = rect.right - TOOLTIP_W;
+  } else {
+    left = rect.left + rect.width / 2 - TOOLTIP_W / 2;
+  }
+  left = Math.max(
+    VIEWPORT_PAD,
+    Math.min(left, window.innerWidth - TOOLTIP_W - VIEWPORT_PAD),
+  );
+
+  // Arrow always points at the horizontal centre of the parent.
+  const parentCenterX = rect.left + rect.width / 2;
+  const arrowOffset = Math.max(
+    20,
+    Math.min(parentCenterX - left, TOOLTIP_W - 20),
+  );
+
+  const style: React.CSSProperties = {
+    position: "fixed",
+    zIndex: 60,
+    width: TOOLTIP_W,
+    top: position === "bottom" ? top : undefined,
+    bottom: position === "top" ? window.innerHeight - top : undefined,
+    left,
+  };
+
+  const tooltip = (
+    <div
+      role="status"
+      aria-live="polite"
+      style={style}
+      className={cn("animate-scale-in", className)}
+    >
+      {/* Arrow (points up toward target) */}
+      {position === "bottom" && (
+        <div className="flex -mb-1.5" style={{ paddingLeft: arrowOffset - 6 }}>
+          <div className="h-3 w-3 rotate-45 rounded-sm bg-[rgba(30,32,46,0.65)] backdrop-blur-3xl border-l border-t border-white/[0.15]" />
+        </div>
+      )}
+
+      {/* Card — frosted dark glass */}
+      <div
+        className={cn(
+          "rounded-xl p-4 shadow-xl",
+          // Frosted glass: dark translucent base + strong blur + luminous border
+          "border border-white/[0.15] bg-[rgba(30,32,46,0.65)] backdrop-blur-3xl",
+          "shadow-black/40",
+        )}
+      >
+        {/* Step dots + dismiss */}
+        <div className="mb-3 flex items-center justify-between">
+          <div className="flex gap-1.5">
+            {Array.from({ length: totalSteps }).map((_, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "h-1.5 w-1.5 rounded-full transition-colors",
+                  i < step ? "bg-white" : "bg-white/30",
+                )}
+              />
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="-mr-1 -mt-1 rounded-md p-0.5 text-white/40 hover:text-white transition-colors"
+            aria-label="Dismiss onboarding tour"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+
+        <p className="text-sm font-semibold text-white">
+          {title}
+        </p>
+        <p className="mt-1 text-xs leading-relaxed text-white/75">
+          {description}
+        </p>
+      </div>
+
+      {/* Arrow (points down toward target) */}
+      {position === "top" && (
+        <div className="flex -mt-1.5" style={{ paddingLeft: arrowOffset - 6 }}>
+          <div className="h-3 w-3 rotate-45 rounded-sm bg-[rgba(30,32,46,0.65)] backdrop-blur-3xl border-r border-b border-white/[0.15]" />
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <>
+      {anchor}
+      {createPortal(tooltip, document.body)}
+    </>
+  );
+}

--- a/my-app/src/components/home-page.tsx
+++ b/my-app/src/components/home-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useAuthActions } from "@convex-dev/auth/react";
-import { useState } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useQuery } from "convex/react";
 import { useRouter } from "next/navigation";
 import { api } from "../../convex/_generated/api";
@@ -12,6 +12,7 @@ import { BottleDetail } from "@/components/bottle-detail";
 import { AddBottleDialog } from "@/components/add-bottle-dialog";
 import { AddWearLogDialog } from "@/components/add-wear-log-dialog";
 import { Button } from "@/components/ui/button";
+import { useOnboarding, ONBOARDING_SETTLE_MS } from "@/lib/use-onboarding";
 import { LoaderCircle, LogOut, Wine } from "lucide-react";
 
 export function HomePage() {
@@ -25,6 +26,7 @@ export function HomePage() {
   const [mobileDetailOpen, setMobileDetailOpen] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
   const currentUser = useQuery(api.users.currentUser);
+  const { step: onboardingStep, advance: advanceOnboarding, dismiss: dismissOnboarding } = useOnboarding();
 
   const selectedBottle = useQuery(
     api.bottles.getBottle,
@@ -34,7 +36,35 @@ export function HomePage() {
   const handleSelectBottle = (id: Id<"bottles">) => {
     setSelectedBottleId(id);
     setMobileDetailOpen(true);
+    // Advance onboarding from select-bottle → log-wear
+    if (onboardingStep === "select-bottle" && selectedBottleId !== id) {
+      advanceOnboarding();
+    }
   };
+
+  const handleWearLogSuccess = useCallback(() => {
+    if (onboardingStep === "log-wear") {
+      advanceOnboarding();
+    }
+  }, [onboardingStep, advanceOnboarding]);
+
+  // Used to gate onboarding backdrop until data has loaded.
+  const bottles = useQuery(api.bottles.listBottles);
+
+  const isTourActive = onboardingStep !== null && bottles !== undefined && !addBottleOpen && !addWearLogOpen;
+  const [isBackdropSettled, setIsBackdropSettled] = useState(false);
+
+  // Only reset the backdrop when onboarding truly ends (step → null).
+  // This avoids a flash/re-animation when a dialog opens and closes
+  // during an active tour.
+  useEffect(() => {
+    if (onboardingStep !== null && bottles !== undefined) {
+      const id = setTimeout(() => setIsBackdropSettled(true), ONBOARDING_SETTLE_MS);
+      return () => clearTimeout(id);
+    } else if (onboardingStep === null) {
+      setIsBackdropSettled(false);
+    }
+  }, [onboardingStep, bottles]);
 
   const handleCloseDetail = () => {
     setSelectedBottleId(null);
@@ -111,6 +141,9 @@ export function HomePage() {
             selectedBottleId={selectedBottleId}
             onSelectBottle={handleSelectBottle}
             onAddBottle={() => setAddBottleOpen(true)}
+            onboardingStep={isTourActive ? onboardingStep : undefined}
+            onAdvanceOnboarding={advanceOnboarding}
+            onDismissOnboarding={dismissOnboarding}
           />
         </div>
 
@@ -126,6 +159,8 @@ export function HomePage() {
               onEdit={handleEditBottle}
               onAddWearLog={() => setAddWearLogOpen(true)}
               onClose={handleCloseDetail}
+              onboardingStep={isTourActive ? onboardingStep : undefined}
+              onDismissOnboarding={dismissOnboarding}
             />
           ) : (
             <div className="flex flex-col items-center justify-center h-full animate-fade-in p-8">
@@ -154,7 +189,25 @@ export function HomePage() {
           open={addWearLogOpen}
           onOpenChange={setAddWearLogOpen}
           bottleId={selectedBottleId}
+          onSuccess={handleWearLogSuccess}
         />
+      )}
+
+      {/* Global Onboarding Backdrop & Exit Button */}
+      {isBackdropSettled && isTourActive && (
+        <div className="fixed inset-0 z-40">
+          <div
+            className="absolute inset-0 bg-black/40 backdrop-blur-[2px] animate-fade-in"
+            aria-hidden="true"
+          />
+          <button
+            onClick={dismissOnboarding}
+            aria-label="Exit onboarding tour"
+            className="absolute bottom-8 left-1/2 -translate-x-1/2 z-[60] cursor-pointer rounded-full bg-[rgba(30,32,46,0.65)] px-6 py-2.5 text-sm font-semibold text-white/90 backdrop-blur-3xl border border-white/[0.15] hover:bg-[rgba(30,32,46,0.85)] hover:text-white transition-all shadow-xl animate-fade-up"
+          >
+            Exit tour
+          </button>
+        </div>
       )}
     </div>
   );

--- a/my-app/src/lib/use-onboarding.ts
+++ b/my-app/src/lib/use-onboarding.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+
+/**
+ * Guided onboarding steps for first-time users.
+ *
+ * welcome        → empty collection, prompt to add first fragrance
+ * select-bottle  → first bottle exists, prompt to tap it
+ * log-wear       → detail panel open, prompt to log a wear
+ * null           → onboarding complete or dismissed
+ */
+export type OnboardingStep = "welcome" | "select-bottle" | "log-wear" | null;
+
+const STORAGE_KEY = "ft-onboarding-done";
+
+/**
+ * Delay (ms) to wait for entrance animations to settle before showing
+ * onboarding overlays and measuring element positions.
+ */
+export const ONBOARDING_SETTLE_MS = 450;
+
+export function useOnboarding() {
+  // Start as `undefined` to avoid SSR/hydration mismatch, then resolve
+  // from localStorage in a client-only effect.
+  const [step, setStep] = useState<OnboardingStep | undefined>(undefined);
+  const prevStepRef = useRef<OnboardingStep | undefined>(undefined);
+
+  // Reading localStorage in an effect is necessary to avoid hydration mismatch
+  // (localStorage is unavailable on the server). The cascading render is
+  // intentional — we want the tour to appear after the client hydrates.
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_FORCE_ONBOARDING === "1") {
+      setStep("welcome"); // eslint-disable-line react-hooks/set-state-in-effect
+      return;
+    }
+    const done = localStorage.getItem(STORAGE_KEY) === "1";
+    setStep(done ? null : "welcome");
+  }, []);
+
+  // Persist to localStorage when the tour completes or is dismissed.
+  // step === null with a previous non-null value means the user just
+  // finished or dismissed the tour.
+  useEffect(() => {
+    if (step === null && prevStepRef.current !== null && prevStepRef.current !== undefined) {
+      localStorage.setItem(STORAGE_KEY, "1");
+    }
+    prevStepRef.current = step;
+  }, [step]);
+
+  const advance = useCallback(() => {
+    setStep((prev) => {
+      switch (prev) {
+        case "welcome":
+          return "select-bottle";
+        case "select-bottle":
+          return "log-wear";
+        case "log-wear":
+          return null;
+        default:
+          return null;
+      }
+    });
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setStep(null);
+  }, []);
+
+  return {
+    /** Current step, or null when onboarding is inactive/complete. */
+    step: step === undefined ? null : step,
+    advance,
+    dismiss,
+  };
+}


### PR DESCRIPTION
## Summary

- **Guided onboarding tour** — three-step walkthrough (welcome → select a bottle → log a wear) for first-time users, with frosted-glass coach-mark tooltips, a pulsing highlight on targets, and a dismissible backdrop overlay
- **Comma-separated tag input** — the add-bottle dialog now accepts comma-separated values (e.g. `fresh, citrus, woody`) with case-insensitive deduplication and the same validation limits (50 chars per tag, 20 tags max)
- **`prefers-reduced-motion` support** — global CSS rule suppresses coach-pulse and entrance animations for users who opt out of motion (#46 tracks expanding this to dialogs/modals)

## Key changes

| File | What |
|---|---|
| `coach-mark.tsx` | New portal-rendered tooltip with viewport clamping, step dots, and dismiss |
| `use-onboarding.ts` | New hook: step state machine (`welcome` → `selectBottle` → `logWear`) with localStorage persistence, SSR-safe hydration, and advance/dismiss callbacks |
| `bottle-collection.tsx` | Integrates coach marks + pulse highlights; resets `hasAdvancedWelcome` when step leaves `welcome` |
| `home-page.tsx` | Wires onboarding state machine; guards advance on already-selected bottle |
| `add-bottle-dialog.tsx` | Comma-split tag input with dedup |
| `add-wear-log-dialog.tsx` | `onSuccess` callback for onboarding wiring |
| `bottle-card.tsx` | Accepts `className` prop for pulse highlight; removed `opacity-0` (animation fill-mode fix) |
| `bottle-detail.tsx` | Coach mark on log-wear button |
| `globals.css` | `prefers-reduced-motion` block; animation fill-mode `both` → `backwards` |

## Correctness fixes

- Extracted `localStorage.setItem` from `setState` updater into a `useEffect` with `prevStepRef` (React state updater must be pure)
- Reset `hasAdvancedWelcome` ref when step leaves `welcome` so `FORCE_ONBOARDING` re-runs work
- Guard `advanceOnboarding()` on `selectedBottleId !== id` to prevent spurious advance on re-select

## Screenshots

_(add screenshots here)_

Closes #46 (partially — reduced-motion is scoped to coach/entrance animations; broader modal/dialog coverage tracked in that issue)