### PR TITLE
feat: improve reduced-motion accessibility and simplify theme toggle

### DIFF
--- a/my-app/src/app/globals.css
+++ b/my-app/src/app/globals.css
@@ -293,17 +293,32 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .coach-pulse {
-    animation: none;
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 
-  .animate-fade-up,
-  .animate-fade-in,
-  .animate-scale-in,
-  .animate-shimmer {
-    animation: none;
-    opacity: 1;
-    transform: none;
+  /* Zero out stagger delays so the whole group fades in together */
+  .stagger-1, .stagger-2, .stagger-3, .stagger-4,
+  .stagger-5, .stagger-6, .stagger-7, .stagger-8 {
+    animation-delay: 0s !important;
+  }
+
+  /* Gentle single fade-in for card grids (no movement, just opacity) */
+  .reduced-motion-fade-in {
+    animation: fadeIn 0.2s var(--ease-smooth) backwards !important;
+  }
+
+  /* Gentle opacity-only fade for dialogs (no scale/translate) — open only */
+  [data-state="open"].reduced-motion-overlay {
+    animation: overlayShow 0.2s var(--ease-smooth) !important;
+  }
+  [data-state="open"].reduced-motion-content {
+    animation: fadeIn 0.2s var(--ease-smooth) !important;
   }
 }
 

--- a/my-app/src/components/bottle-collection.tsx
+++ b/my-app/src/components/bottle-collection.tsx
@@ -243,7 +243,7 @@ export function BottleCollection({
 
       {/* Grid */}
       <div className="flex-1 overflow-y-auto scrollbar-fade pb-5 pt-4 -ml-2 pl-2 -mr-6 pr-6 lg:-mr-7 lg:pr-7">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 reduced-motion-fade-in">
           {filteredBottles.map((bottle, i) => {
             const stats = getBottleStats(bottleStats, bottle._id);
             const showCoachMark = i === 0 && onboardingStep === "select-bottle";

--- a/my-app/src/components/theme-toggle.tsx
+++ b/my-app/src/components/theme-toggle.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import { useSyncExternalStore } from "react";
 import { Sun, Moon, Monitor } from "lucide-react";
 import {
   DropdownMenu,
@@ -11,51 +10,28 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 
-const subscribe = () => () => {};
-
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
-  const mounted = useSyncExternalStore(subscribe, () => true, () => false);
-
-  if (!mounted) {
-    return (
-      <div className="h-9 w-9 rounded-lg bg-surface-alt animate-shimmer" />
-    );
-  }
+  const { setTheme } = useTheme();
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="rounded-lg">
-          {theme === "dark" ? (
-            <Moon className="h-4 w-4" />
-          ) : theme === "light" ? (
-            <Sun className="h-4 w-4" />
-          ) : (
-            <Monitor className="h-4 w-4" />
-          )}
+        <Button variant="ghost" size="icon" className="relative rounded-lg">
+          <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           <span className="sr-only">Toggle theme</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          onClick={() => setTheme("light")}
-          className="gap-2"
-        >
+        <DropdownMenuItem onClick={() => setTheme("light")} className="gap-2">
           <Sun className="h-4 w-4" />
           Light
         </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => setTheme("dark")}
-          className="gap-2"
-        >
+        <DropdownMenuItem onClick={() => setTheme("dark")} className="gap-2">
           <Moon className="h-4 w-4" />
           Dark
         </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => setTheme("system")}
-          className="gap-2"
-        >
+        <DropdownMenuItem onClick={() => setTheme("system")} className="gap-2">
           <Monitor className="h-4 w-4" />
           System
         </DropdownMenuItem>

--- a/my-app/src/components/ui/dialog.tsx
+++ b/my-app/src/components/ui/dialog.tsx
@@ -20,6 +20,7 @@ const DialogOverlay = React.forwardRef<
       "fixed inset-0 z-50 bg-overlay backdrop-blur-sm",
       "data-[state=open]:animate-in data-[state=closed]:animate-out",
       "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "reduced-motion-overlay",
       className
     )}
     style={{
@@ -40,6 +41,7 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed z-50 grid w-full max-w-lg gap-4 border border-border bg-surface p-6 shadow-xl rounded-2xl",
+        "reduced-motion-content",
         className
       )}
       style={{


### PR DESCRIPTION
## Summary

- **Reduced-motion overhaul**: Replace narrow per-class `animation: none` overrides with a comprehensive global rule (`*, *::before, *::after`) that zeroes `animation-duration`, `iteration-count`, and `transition-duration` for users who prefer reduced motion
- **Accessible fade alternatives**: Add `reduced-motion-fade-in` for card grids and `reduced-motion-overlay` / `reduced-motion-content` for dialogs — gentle opacity-only transitions instead of scale/translate animations
- **Stagger reset**: Zero out stagger delays in reduced-motion mode so card groups fade in together without cascading
- **ThemeToggle simplification**: Remove `useSyncExternalStore` shimmer placeholder hack; use CSS `dark:` rotate/scale classes for the sun/moon icon swap (standard next-themes pattern, fewer re-renders, no hydration mismatch risk)
- **Dialog accessibility**: Wire `reduced-motion-overlay` and `reduced-motion-content` classes on `DialogOverlay` and `DialogContent`

## Test plan

- [ ] Toggle system reduced-motion preference on/off — verify animations are suppressed when enabled, normal when disabled
- [ ] Open a dialog with reduced-motion on — should see a gentle fade, no scale/translate
- [ ] Verify theme toggle icon transitions smoothly between sun/moon with no shimmer flash
- [ ] Check bottle collection grid stagger animation works normally without reduced-motion
- [ ] Verify stagger group fades in together (no cascade) with reduced-motion enabled