### PR TITLE
fix: validate future wear-log dates client-side with inline field errors

### DIFF
--- a/my-app/src/components/add-wear-log-dialog.tsx
+++ b/my-app/src/components/add-wear-log-dialog.tsx
@@ -30,6 +30,16 @@ import { MAX_SPRAYS, CONTEXT_OPTIONS } from "@/lib/constants";
 
 const NO_CONTEXT_VALUE = "__none__";
 
+function getWornAtTimestamp(date: string, time: string): number {
+  if (!date) return NaN;
+  if (time) return new Date(`${date}T${time}`).getTime();
+
+  const today = new Date().toLocaleDateString("en-CA");
+  if (date === today) return Date.now();
+
+  return new Date(`${date}T12:00`).getTime();
+}
+
 interface AddWearLogDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -70,7 +80,7 @@ export function AddWearLogDialog({
     const newErrors: Record<string, string> = {};
     if (!date) newErrors.date = "Date is required";
     if (date) {
-      const wornAt = new Date(`${date}T${time || "12:00"}`).getTime();
+      const wornAt = getWornAtTimestamp(date, time);
       if (!isNaN(wornAt) && wornAt > Date.now()) {
         newErrors.wornAt = "Time cannot be in the future";
       }
@@ -136,7 +146,7 @@ export function AddWearLogDialog({
     setFormError(null);
     if (!validate()) return;
 
-    const wornAt = new Date(`${date}T${time || "12:00"}`).getTime();
+    const wornAt = getWornAtTimestamp(date, time);
     if (isNaN(wornAt)) return;
 
     setSubmitting(true);

--- a/my-app/src/components/add-wear-log-dialog.tsx
+++ b/my-app/src/components/add-wear-log-dialog.tsx
@@ -25,7 +25,7 @@ import {
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { useState, useEffect, useRef } from "react";
 import { toast } from "sonner";
-import { getApiErrorMessage } from "@/lib/utils";
+import { getApiErrorMessage, isFutureWornAtError } from "@/lib/utils";
 import { MAX_SPRAYS, CONTEXT_OPTIONS } from "@/lib/constants";
 
 const NO_CONTEXT_VALUE = "__none__";
@@ -69,6 +69,12 @@ export function AddWearLogDialog({
   const validate = (): boolean => {
     const newErrors: Record<string, string> = {};
     if (!date) newErrors.date = "Date is required";
+    if (date) {
+      const wornAt = new Date(`${date}T${time || "12:00"}`).getTime();
+      if (!isNaN(wornAt) && wornAt > Date.now()) {
+        newErrors.wornAt = "Time cannot be in the future";
+      }
+    }
     const spraysNum = Number(sprays);
     if (!sprays || isNaN(spraysNum) || spraysNum < 1 || spraysNum > MAX_SPRAYS) {
       newErrors.sprays = `Must be between 1 and ${MAX_SPRAYS}`;
@@ -127,6 +133,7 @@ export function AddWearLogDialog({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setFormError(null);
     if (!validate()) return;
 
     const wornAt = new Date(`${date}T${time || "12:00"}`).getTime();
@@ -150,13 +157,10 @@ export function AddWearLogDialog({
         console.error("Failed to log wear:", err);
       }
       const message = getApiErrorMessage(err);
-      toast.error(message);
-      if (
-        err instanceof Error &&
-        err.message.includes("wornAt cannot be in the future")
-      ) {
-        setErrors({ date: message });
+      if (isFutureWornAtError(err)) {
+        setErrors({ wornAt: message });
       } else {
+        toast.error(message);
         setFormError(message);
       }
     } finally {
@@ -178,7 +182,7 @@ export function AddWearLogDialog({
           {/* Date + Time side by side */}
           <div className="grid grid-cols-2 gap-4">
             <div className="relative space-y-2">
-              <Label htmlFor="date" className={errors.date ? "text-danger" : ""}>
+              <Label htmlFor="date" className={errors.date || errors.wornAt ? "text-danger" : ""}>
                 Date *
               </Label>
               <Input
@@ -188,31 +192,51 @@ export function AddWearLogDialog({
                 onChange={(e) => {
                   setDate(e.target.value);
                   clearError("date");
+                  clearError("wornAt");
                 }}
                 required
                 className={
-                  errors.date
+                  errors.date || errors.wornAt
                     ? "border-danger focus:border-danger focus:ring-danger"
                     : ""
                 }
-                aria-invalid={!!errors.date}
-                aria-describedby="date-error"
+                aria-invalid={!!(errors.date || errors.wornAt)}
+                aria-describedby={errors.wornAt ? "worn-at-error" : "date-error"}
               />
               <p
                 id="date-error"
                 role="alert"
-                className={`absolute -bottom-3 left-0 text-xs text-danger transition-opacity ${errors.date ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+                className={`absolute -bottom-3 left-0 text-xs text-danger transition-opacity ${errors.date && !errors.wornAt ? "opacity-100" : "opacity-0 pointer-events-none"}`}
               >
                 {errors.date ?? "\u00A0"}
               </p>
+              <p
+                id="worn-at-error"
+                role="alert"
+                className={`absolute -bottom-3 left-0 whitespace-nowrap text-xs text-danger transition-opacity ${errors.wornAt ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+              >
+                {errors.wornAt ?? "\u00A0"}
+              </p>
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="time">Time</Label>
+            <div className="relative space-y-2">
+              <Label htmlFor="time" className={errors.wornAt ? "text-danger" : ""}>
+                Time
+              </Label>
               <Input
                 id="time"
                 type="time"
                 value={time}
-                onChange={(e) => setTime(e.target.value)}
+                onChange={(e) => {
+                  setTime(e.target.value);
+                  clearError("wornAt");
+                }}
+                className={
+                  errors.wornAt
+                    ? "border-danger focus:border-danger focus:ring-danger"
+                    : ""
+                }
+                aria-invalid={!!errors.wornAt}
+                aria-describedby="worn-at-error"
               />
             </div>
           </div>

--- a/my-app/src/components/add-wear-log-dialog.tsx
+++ b/my-app/src/components/add-wear-log-dialog.tsx
@@ -151,7 +151,14 @@ export function AddWearLogDialog({
       }
       const message = getApiErrorMessage(err);
       toast.error(message);
-      setFormError(message);
+      if (
+        err instanceof Error &&
+        err.message.includes("wornAt cannot be in the future")
+      ) {
+        setErrors({ date: message });
+      } else {
+        setFormError(message);
+      }
     } finally {
       setSubmitting(false);
     }

--- a/my-app/src/lib/utils.test.ts
+++ b/my-app/src/lib/utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "vitest";
+import { getApiErrorMessage } from "./utils";
+
+describe("getApiErrorMessage", () => {
+  test("returns a user-friendly message for future-date server errors", () => {
+    // Convex wraps the message — "Uncaught Error: ..." is the realistic shape.
+    const err = new Error("Uncaught Error: wornAt cannot be in the future.");
+    expect(getApiErrorMessage(err)).toBe(
+      "The date and time can't be in the future."
+    );
+  });
+
+  test("exact server message also matches", () => {
+    const err = new Error("wornAt cannot be in the future.");
+    expect(getApiErrorMessage(err)).toBe(
+      "The date and time can't be in the future."
+    );
+  });
+
+  test("returns rate-limit message for rate-limited errors", () => {
+    const err = Object.assign(new Error("rate limited"), {
+      data: { kind: "RateLimited" },
+    });
+    expect(getApiErrorMessage(err)).toBe(
+      "You've made too many requests. Please wait a moment and try again."
+    );
+  });
+
+  test("returns network message for fetch failures", () => {
+    const err = new Error("Failed to fetch");
+    expect(getApiErrorMessage(err)).toBe(
+      "Network error. Please check your connection and try again."
+    );
+  });
+
+  test("returns generic fallback for unknown errors", () => {
+    const err = new Error("some unexpected internal error");
+    expect(getApiErrorMessage(err)).toBe(
+      "Something went wrong. Please try again."
+    );
+  });
+});

--- a/my-app/src/lib/utils.test.ts
+++ b/my-app/src/lib/utils.test.ts
@@ -1,20 +1,25 @@
 import { describe, test, expect } from "vitest";
-import { getApiErrorMessage } from "./utils";
+import { getApiErrorMessage, isFutureWornAtError } from "./utils";
 
 describe("getApiErrorMessage", () => {
   test("returns a user-friendly message for future-date server errors", () => {
     // Convex wraps the message — "Uncaught Error: ..." is the realistic shape.
     const err = new Error("Uncaught Error: wornAt cannot be in the future.");
     expect(getApiErrorMessage(err)).toBe(
-      "The date and time can't be in the future."
+      "Time cannot be in the future"
     );
   });
 
   test("exact server message also matches", () => {
     const err = new Error("wornAt cannot be in the future.");
     expect(getApiErrorMessage(err)).toBe(
-      "The date and time can't be in the future."
+      "Time cannot be in the future"
     );
+  });
+
+  test("identifies future-date server errors", () => {
+    const err = new Error("Uncaught Error: wornAt cannot be in the future.");
+    expect(isFutureWornAtError(err)).toBe(true);
   });
 
   test("returns rate-limit message for rate-limited errors", () => {

--- a/my-app/src/lib/utils.ts
+++ b/my-app/src/lib/utils.ts
@@ -31,5 +31,13 @@ export function getApiErrorMessage(err: unknown): string {
     return "Network error. Please check your connection and try again.";
   }
 
+  // Future-date rejection from assertValidWornAt on the server
+  if (
+    err instanceof Error &&
+    err.message.includes("wornAt cannot be in the future")
+  ) {
+    return "The date and time can't be in the future.";
+  }
+
   return "Something went wrong. Please try again.";
 }

--- a/my-app/src/lib/utils.ts
+++ b/my-app/src/lib/utils.ts
@@ -11,6 +11,13 @@ export function cn(...inputs: ClassValue[]) {
  * and network/offline errors; falls back to a generic message for everything
  * else.  Raw error details are only logged in non-production environments.
  */
+export function isFutureWornAtError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    err.message.includes("wornAt cannot be in the future")
+  );
+}
+
 export function getApiErrorMessage(err: unknown): string {
   // Rate-limit errors thrown by @convex-dev/rate-limiter with throws:true
   // arrive as a ConvexError whose .data has { kind: "RateLimited", retryAfter }
@@ -32,11 +39,8 @@ export function getApiErrorMessage(err: unknown): string {
   }
 
   // Future-date rejection from assertValidWornAt on the server
-  if (
-    err instanceof Error &&
-    err.message.includes("wornAt cannot be in the future")
-  ) {
-    return "The date and time can't be in the future.";
+  if (isFutureWornAtError(err)) {
+    return "Time cannot be in the future";
   }
 
   return "Something went wrong. Please try again.";


### PR DESCRIPTION
Closes #52

When logging a wear with a future date/time, feedback only came from the server as a toast on the wrong field and a super jank general error that's really ugly. Now caught client-side with inline errors consistent with how an invalid spray value does.

## Changes
- **`utils.ts`** — extracted `isFutureWornAtError()` as a reusable exported helper
- **`add-wear-log-dialog.tsx`** — future date caught on submit before the request; inline error on Date/Time fields instead of toast; stale form errors cleared on each submit
- **`utils.test.ts`** — test for the new helper