### PR TITLE
Fix: Prevent entrance animation replay on card reordering

### DIFF
--- a/my-app/src/components/bottle-card.tsx
+++ b/my-app/src/components/bottle-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useLayoutEffect } from "react";
+import { useRef, useState, useLayoutEffect, useCallback } from "react";
 import { Doc } from "../../convex/_generated/dataModel";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -31,6 +31,18 @@ export function BottleCard({
 }: BottleCardProps) {
   const staggerClass = `stagger-${Math.min(index + 1, 8)}`;
   const tags = bottle.tags ?? EMPTY_TAGS;
+
+  // Track whether the entrance animation has played so DOM reorders
+  // (from favoriting / pin-favorites) never replay it.
+  const hasAnimated = useRef(false);
+  const [, rerender] = useState(0);
+
+  const handleAnimationEnd = useCallback(() => {
+    if (!hasAnimated.current) {
+      hasAnimated.current = true;
+      rerender((n) => n + 1);
+    }
+  }, []);
   const sizerRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [visibleCount, setVisibleCount] = useState(tags.length);
@@ -75,11 +87,12 @@ export function BottleCard({
   return (
     <button
       onClick={onClick}
+      onAnimationEnd={handleAnimationEnd}
       className={cn(
         "group w-full h-full flex flex-col text-left rounded-xl border px-6 py-5 transition-all duration-200 ease-smooth cursor-pointer",
         "group-hover:shadow-md",
-        "animate-fade-up",
-        staggerClass,
+        !hasAnimated.current && "animate-fade-up",
+        !hasAnimated.current && staggerClass,
         isSelected
           ? "border-accent bg-accent-subtle/60 shadow-sm"
           : "border-border bg-surface group-hover:border-border-hover",

--- a/my-app/src/components/bottle-card.tsx
+++ b/my-app/src/components/bottle-card.tsx
@@ -35,14 +35,17 @@ export function BottleCard({
   // Track whether the entrance animation has played so DOM reorders
   // (from favoriting / pin-favorites) never replay it.
   const hasAnimated = useRef(false);
+  // Dummy state toggle – the sole purpose is to force a re-render after
+  // flipping `hasAnimated` so the ref read in the JSX below picks it up.
   const [, rerender] = useState(0);
 
-  const handleAnimationEnd = useCallback(() => {
-    if (!hasAnimated.current) {
+  const handleAnimationEnd = useCallback((e: React.AnimationEvent) => {
+    if (e.animationName === "fadeUp" && !hasAnimated.current) {
       hasAnimated.current = true;
       rerender((n) => n + 1);
     }
   }, []);
+
   const sizerRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [visibleCount, setVisibleCount] = useState(tags.length);

--- a/my-app/src/components/bottle-collection.tsx
+++ b/my-app/src/components/bottle-collection.tsx
@@ -59,6 +59,11 @@ export function BottleCollection({
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [pinFavorites, setPinFavorites] = useState(true);
 
+  // Incremented on sort changes to force-remount the card grid,
+  // replaying the entrance animation. Favorite / pin-favorites
+  // changes leave this untouched so cards reorder instantly.
+  const [animationKey, setAnimationKey] = useState(0);
+
   // Track whether we've already auto-advanced from welcome → select-bottle.
   // This prevents the advance from firing on every re-render.
   const hasAdvancedWelcome = useRef(false);
@@ -89,6 +94,7 @@ export function BottleCollection({
     const next = getNextSortState(sortBy, sortDir, option);
     setSortBy(next.sortBy);
     setSortDir(next.sortDir);
+    setAnimationKey((k) => k + 1);
   };
 
   const filteredBottles = useMemo(() => {
@@ -266,7 +272,7 @@ export function BottleCollection({
 
       {/* Grid */}
       <div className="flex-1 overflow-y-auto scrollbar-fade pb-5 pt-4 -ml-2 pl-2 -mr-6 pr-6 lg:-mr-7 lg:pr-7">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 reduced-motion-fade-in">
+        <div key={animationKey} className="grid grid-cols-1 sm:grid-cols-2 gap-4 reduced-motion-fade-in">
           {filteredBottles.map((bottle, i) => {
             const stats = getBottleStats(bottleStats, bottle._id);
             const showCoachMark = i === 0 && onboardingStep === "select-bottle";


### PR DESCRIPTION
## Overview

Resolves #56 — fragrance cards were replaying their fade-in entrance animations (`animate-fade-up` + stagger delay classes) whenever they were reordered by favoriting a card or toggling "Pin Favorites." This caused a subset cards to fade in unintentionally which looks horrendous and not unified like intended.

**After this fix:**
- Toggling favorite status or pin-favorites smoothly repositions cards without retriggering animations
- Explicitly changing sort options still correctly replays the entrance fade animation

---

## Key Changes

### 1. Track animation completion per card (`bottle-card.tsx`)
- Added a `hasAnimated` ref to track whether the fade-up entrance animation has already played
- Added an `onAnimationEnd` handler that flips `hasAnimated` to `true` and triggers a re-render
- Conditionally applies `animate-fade-up` and `staggerClass` only when `!hasAnimated.current`, preventing DOM reordering from restarting the animation

### 2. Remount card grid only on sort changes (`bottle-collection.tsx`)
- Added an `animationKey` state that increments only when the user explicitly changes sort criteria
- Applied `animationKey` as the `key` on the grid wrapper `<div>`, forcing a full remount (and animation replay) on sort changes
- Favorite toggles and Pin Favorites changes leave `animationKey` untouched, so cards reorder instantly without replaying entrance animations
