### PR TITLE
Fix: show more/less button disappearing on expand + improved tap target

### DIFF
--- a/my-app/src/components/bottle-detail.tsx
+++ b/my-app/src/components/bottle-detail.tsx
@@ -107,7 +107,7 @@ export function BottleDetail({
               bottleId={bottle._id}
               isFavorite={bottle.isFavorite ?? false}
               size="detail"
-              className="border border-white/15 bg-white/8 hover:bg-white/15 transition-colors"
+              className="border border-white/15 bg-white/8 hover:bg-white/15"
             />
             <Button
               variant="ghost"

--- a/my-app/src/components/bottle-detail.tsx
+++ b/my-app/src/components/bottle-detail.tsx
@@ -176,7 +176,7 @@ export function BottleDetail({
 
         {/* Comments */}
         {bottle.comments && (
-          <div className="flex items-start gap-2.5 mt-5 p-4 rounded-lg bg-surface-alt">
+          <div className="flex items-start gap-2.5 mt-5 p-4 rounded-lg bg-surface-alt overflow-hidden">
             <MessageSquare className="h-4 w-4 text-text-secondary mt-0.5 shrink-0" />
             <MarkdownContent
               content={bottle.comments}

--- a/my-app/src/components/markdown-content.tsx
+++ b/my-app/src/components/markdown-content.tsx
@@ -103,7 +103,7 @@ export function MarkdownContent({ content, collapsible = false, className }: Mar
         <button
           type="button"
           onClick={() => setCollapsed((prev) => !prev)}
-          className="mt-1.5 w-full text-left text-xs text-accent/60 hover:text-accent transition-colors cursor-pointer relative before:absolute before:-inset-y-3 before:-left-8 before:-right-[9999px]"
+          className="mt-1.5 w-full text-left text-xs text-accent/60 hover:text-accent transition-colors cursor-pointer relative before:absolute before:-top-3 before:-bottom-[100vh] before:-left-[100vw] before:-right-[100vw]"
         >
           {collapsed ? "Show more" : "Show less"}
         </button>

--- a/my-app/src/components/markdown-content.tsx
+++ b/my-app/src/components/markdown-content.tsx
@@ -47,7 +47,9 @@ export function MarkdownContent({ content, collapsible = false, className }: Mar
   useEffect(() => {
     // When not collapsible, `isClickable` is already false so overflow state
     // is irrelevant — skip measurement entirely.
-    if (!collapsible) return;
+    // When not collapsed (i.e. expanded), skip measurement so that `overflows`
+    // keeps its previous `true` value and the "Show less" button stays visible.
+    if (!collapsible || !collapsed) return;
     const el = contentRef.current;
     if (!el) return;
 
@@ -66,7 +68,7 @@ export function MarkdownContent({ content, collapsible = false, className }: Mar
       cancelAnimationFrame(frame);
       observer.disconnect();
     };
-  }, [content, collapsible]);
+  }, [content, collapsible, collapsed]);
 
   const isClickable = collapsible && overflows;
 
@@ -101,7 +103,7 @@ export function MarkdownContent({ content, collapsible = false, className }: Mar
         <button
           type="button"
           onClick={() => setCollapsed((prev) => !prev)}
-          className="mt-1.5 w-full text-left text-xs text-accent/60 hover:text-accent transition-colors cursor-pointer relative before:absolute before:-inset-y-3 before:-left-8 before:-right-2"
+          className="mt-1.5 w-full text-left text-xs text-accent/60 hover:text-accent transition-colors cursor-pointer relative before:absolute before:-inset-y-3 before:-left-8 before:-right-[9999px]"
         >
           {collapsed ? "Show more" : "Show less"}
         </button>

--- a/my-app/src/components/wear-log-list.tsx
+++ b/my-app/src/components/wear-log-list.tsx
@@ -91,7 +91,7 @@ export function WearLogList({ logs }: WearLogListProps) {
             {dateLogs.map((log, i) => (
               <div
                 key={log._id}
-                className="group flex items-start gap-3 p-4 rounded-lg border border-border/50 bg-surface hover:border-border transition-all duration-200 animate-fade-up"
+                className="group flex items-start gap-3 p-4 rounded-lg border border-border/50 bg-surface hover:border-border transition-all duration-200 animate-fade-up overflow-hidden"
                 style={{ animationDelay: `${(groupIdx * dateLogs.length + i) * 0.05}s` }}
               >
                 {/* Timeline dot */}
@@ -123,7 +123,7 @@ export function WearLogList({ logs }: WearLogListProps) {
                   </div>
 
                   {log.comment && (
-                    <div className="flex items-start gap-1.5 mt-2">
+                    <div className="flex items-start gap-1.5 mt-2 min-w-0">
                       <MessageSquare className="h-3 w-3 text-text-secondary/50 mt-0.5 shrink-0" />
                       <MarkdownContent
                         content={log.comment}


### PR DESCRIPTION
Currently the show more/less button would disappear when expanding a comment. That was fixed. Also, the hit-area of this button was expanded to cover the full bottom section of the comment card, making it more intentional and easier to tap especially on mobile.

**What changed:**

- **`markdown-content.tsx`** — The root cause of the disappearing button: the overflow measurement effect was running even when the comment was in the expanded state. Since the content is unclamped when expanded, it no longer "overflows," causing `overflows` to flip back to `false` and hide the button entirely. The fix skips re-measurement when the comment is already expanded, preserving the `true` overflow state so "Show less" stays visible. `collapsed` was also added to the effect's dependency array to match this new behaviour.

- The "Show more / Show less" button's pseudo-element hit area was also reworked — previously it only extended a small fixed amount (`-inset-y-3`, `-left-8`, `-right-2`). It now stretches to the full width and down to the bottom of the container (`-left-[100vw]`, `-right-[100vw]`, `-bottom-[100vh]`), so the entire lower portion of the comment card is tappable, not just the text label itself. Also instead of doing 9999px it was made a lot more intentional and reusable using vw and vh.

- **`bottle-detail.tsx`** and **`wear-log-list.tsx`** — Added `overflow-hidden` to the comment card containers so the enlarged pseudo-element hit area is clipped to the card bounds and doesn't bleed visually outside it. `wear-log-list.tsx` also adds `min-w-0` to the comment wrapper to prevent flex children from overflowing their lane.