### PR TITLE
[codex] Add multi-term bottle search

### DIFF
--- a/my-app/src/lib/bottle-collection-sort.test.ts
+++ b/my-app/src/lib/bottle-collection-sort.test.ts
@@ -260,6 +260,68 @@ describe("filterAndSortBottles", () => {
     ).toEqual(["Zoologist Bee"]);
   });
 
+  test("filters by multiple terms across searchable fields", () => {
+    expect(
+      names(
+        filterAndSortBottles({
+          bottles,
+          bottleStats: stats,
+          search: "  AMBER   hon ",
+          sortBy: "name",
+          sortDir: "asc",
+        }),
+      ),
+    ).toEqual(["Zoologist Bee"]);
+
+    expect(
+      names(
+        filterAndSortBottles({
+          bottles,
+          bottleStats: stats,
+          search: "zoologist amber",
+          sortBy: "name",
+          sortDir: "asc",
+        }),
+      ),
+    ).toEqual(["Zoologist Bee"]);
+
+    expect(
+      names(
+        filterAndSortBottles({
+          bottles,
+          bottleStats: stats,
+          search: "parma citrus",
+          sortBy: "name",
+          sortDir: "asc",
+        }),
+      ),
+    ).toEqual(["Acqua di Parma"]);
+
+    expect(
+      names(
+        filterAndSortBottles({
+          bottles,
+          bottleStats: stats,
+          search: "parma acqua",
+          sortBy: "name",
+          sortDir: "asc",
+        }),
+      ),
+    ).toEqual(["Acqua di Parma"]);
+
+    expect(
+      names(
+        filterAndSortBottles({
+          bottles,
+          bottleStats: stats,
+          search: "amber citrus",
+          sortBy: "name",
+          sortDir: "asc",
+        }),
+      ),
+    ).toEqual([]);
+  });
+
   test("combines filtering with non-default sort orders", () => {
     const result = filterAndSortBottles({
       bottles,

--- a/my-app/src/lib/bottle-collection-sort.ts
+++ b/my-app/src/lib/bottle-collection-sort.ts
@@ -24,16 +24,36 @@ function compareFallback(a: BottleCollectionItem, b: BottleCollectionItem): numb
   return compareNames(a, b) || compareCreatedDesc(a, b) || a._id.localeCompare(b._id);
 }
 
-function matchesSearch(bottle: BottleCollectionItem, rawSearch: string): boolean {
-  const search = rawSearch.trim().toLowerCase();
-  if (!search) return true;
+type SearchQuery = {
+  terms: string[];
+};
 
-  return (
-    bottle.name.toLowerCase().includes(search) ||
-    bottle.brand?.toLowerCase().includes(search) ||
-    bottle.tags?.some((tag) => tag.toLowerCase().includes(search)) ||
-    false
-  );
+function getSearchQuery(rawSearch: string): SearchQuery {
+  return {
+    terms: rawSearch.trim().toLowerCase().match(/\S+/g) ?? [],
+  };
+}
+
+function matchesSearch(bottle: BottleCollectionItem, searchQuery: SearchQuery): boolean {
+  const { terms } = searchQuery;
+  if (terms.length === 0) return true;
+
+  const name = bottle.name.toLowerCase();
+  const brand = bottle.brand?.toLowerCase();
+
+  return terms.every((term) => {
+    if (name.includes(term) || (brand?.includes(term) ?? false)) return true;
+
+    if (!bottle.tags || bottle.tags.length === 0) return false;
+
+    for (const tag of bottle.tags) {
+      if (tag.toLowerCase().includes(term)) {
+        return true;
+      }
+    }
+
+    return false;
+  });
 }
 
 export function getBottleStats(bottleStats: BottleStatsMap | undefined, bottleId: string) {
@@ -73,7 +93,11 @@ export function filterAndSortBottles({
   sortDir: SortDir;
   pinFavorites?: boolean;
 }): BottleCollectionItem[] {
-  const filtered = bottles.filter((bottle) => matchesSearch(bottle, search));
+  const searchQuery = getSearchQuery(search);
+  const filtered =
+    searchQuery.terms.length === 0
+      ? bottles
+      : bottles.filter((bottle) => matchesSearch(bottle, searchQuery));
   const dir = sortDir === "asc" ? 1 : -1;
 
   const baseComparator = (a: BottleCollectionItem, b: BottleCollectionItem): number => {


### PR DESCRIPTION
tldr more flexible search

Updates bottle collection search so the raw search input is normalized into individual terms instead of being treated as one continuous string. Each term now has to match somewhere on the bottle's name, brand, or tags, which lets searches like `spicy ysl` or `spicy woody` work across different searchable fields. If a term shows up generally anywhere on a fragrance, it's in.

The filtering path now builds the parsed search query once before filtering. Empty or whitespace-only searches still return the original bottle list for the later sort step, while non-empty searches use the shared term matcher.

Previously it was kinda scuffed it just tolower eveything then had to precisely match up to the end of the search term, very rigid and not flexible!

## Tests

Added coverage for multi-term searches across name, brand, and tags, including extra whitespace, case-insensitive input, terms split across fields, and a no-match case when not all terms are present.

Validated with:

```sh
bun test src/lib/bottle-collection-sort.test.ts
```
