### PR TITLE
[codex] Simplify card usage summary

### DIFF
--- a/my-app/src/components/bottle-card.test.tsx
+++ b/my-app/src/components/bottle-card.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { BottleCard } from "./bottle-card";
+import type { Doc, Id } from "../../convex/_generated/dataModel";
+
+const bottle = {
+  _id: "bottle_1" as Id<"bottles">,
+  _creationTime: 0,
+  userId: "user_1" as Id<"users">,
+  name: "Yeah! Man Passion",
+  brand: "Maison Alhambra",
+  sizeMl: 100,
+  createdAt: 0,
+} satisfies Doc<"bottles">;
+
+describe("BottleCard", () => {
+  test("uses wears as the card-level usage summary", () => {
+    render(
+      <BottleCard
+        bottle={bottle}
+        isSelected={false}
+        onClick={vi.fn()}
+        totalWears={10}
+        index={0}
+      />,
+    );
+
+    expect(screen.getByText("10 wears")).toBeInTheDocument();
+    expect(screen.queryByText(/sprays/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/avg/i)).not.toBeInTheDocument();
+  });
+});

--- a/my-app/src/components/bottle-card.test.tsx
+++ b/my-app/src/components/bottle-card.test.tsx
@@ -16,13 +16,7 @@ const bottle = {
 describe("BottleCard", () => {
   test("uses wears as the card-level usage summary", () => {
     render(
-      <BottleCard
-        bottle={bottle}
-        isSelected={false}
-        onClick={vi.fn()}
-        totalWears={10}
-        index={0}
-      />,
+      <BottleCard bottle={bottle} isSelected={false} onClick={vi.fn()} totalWears={10} index={0} />,
     );
 
     expect(screen.getByText("10 wears")).toBeInTheDocument();

--- a/my-app/src/components/bottle-card.tsx
+++ b/my-app/src/components/bottle-card.tsx
@@ -4,7 +4,7 @@ import { useRef, useState, useLayoutEffect, useCallback } from "react";
 import { Doc } from "../../convex/_generated/dataModel";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import { Droplets, Star } from "lucide-react";
+import { Droplets } from "lucide-react";
 
 const EMPTY_TAGS: string[] = [];
 
@@ -12,9 +12,7 @@ interface BottleCardProps {
   bottle: Doc<"bottles">;
   isSelected: boolean;
   onClick: () => void;
-  totalSprays?: number;
   totalWears?: number;
-  avgRating?: number | null;
   index: number;
   className?: string;
 }
@@ -23,9 +21,7 @@ export function BottleCard({
   bottle,
   isSelected,
   onClick,
-  totalSprays,
   totalWears,
-  avgRating,
   index,
   className: extraClassName,
 }: BottleCardProps) {
@@ -118,26 +114,14 @@ export function BottleCard({
       </div>
 
       <div className="mt-auto">
-        {/* Stats row */}
-        <div className="flex items-center gap-4 mt-3.5">
-          {totalWears !== undefined && totalWears > 0 && (
-            <div className="flex items-center gap-1 text-xs text-text-secondary">
-              <Droplets className="h-3 w-3" />
-              <span>
-                {totalWears} wear{totalWears !== 1 ? "s" : ""}
-              </span>
-            </div>
-          )}
-          {totalSprays !== undefined && totalSprays > 0 && (
-            <div className="text-xs text-text-secondary">{totalSprays} sprays</div>
-          )}
-          {avgRating != null && avgRating > 0 && (
-            <div className="flex items-center gap-1 text-xs text-text-secondary">
-              <Star className="h-3 w-3 fill-current" />
-              <span>{avgRating % 1 === 0 ? avgRating.toFixed(0) : avgRating.toFixed(1)}</span>
-            </div>
-          )}
-        </div>
+        {totalWears !== undefined && (
+          <div className="mt-3.5 flex items-center gap-1 whitespace-nowrap text-xs text-text-secondary">
+            <Droplets className="h-3 w-3 shrink-0" />
+            <span>
+              {totalWears} wear{totalWears !== 1 ? "s" : ""}
+            </span>
+          </div>
+        )}
 
         {/* Tags */}
         {tags.length > 0 && (

--- a/my-app/src/components/bottle-collection.tsx
+++ b/my-app/src/components/bottle-collection.tsx
@@ -295,9 +295,7 @@ export function BottleCollection({
                   bottle={bottle}
                   isSelected={selectedBottleId === bottle._id}
                   onClick={() => onSelectBottle(bottle._id)}
-                  totalSprays={stats?.sprays}
-                  totalWears={stats?.wears}
-                  avgRating={stats?.avgRating ?? null}
+                  totalWears={bottleStats ? stats.wears : undefined}
                   index={i}
                   className={showCoachMark ? "coach-pulse" : undefined}
                 />

--- a/my-app/src/components/bottle-detail.tsx
+++ b/my-app/src/components/bottle-detail.tsx
@@ -11,7 +11,16 @@ import { FavoriteToggle } from "@/components/favorite-toggle";
 import { cn } from "@/lib/utils";
 import { WearLogList } from "@/components/wear-log-list";
 import { MarkdownContent } from "@/components/markdown-content";
-import { Pencil, Trash2, Plus, Droplets, Calendar, MessageSquare, ArrowLeft, Star } from "lucide-react";
+import {
+  Pencil,
+  Trash2,
+  Plus,
+  Droplets,
+  Calendar,
+  MessageSquare,
+  ArrowLeft,
+  Star,
+} from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { getApiErrorMessage } from "@/lib/utils";

--- a/my-app/src/components/bottle-detail.tsx
+++ b/my-app/src/components/bottle-detail.tsx
@@ -11,7 +11,7 @@ import { FavoriteToggle } from "@/components/favorite-toggle";
 import { cn } from "@/lib/utils";
 import { WearLogList } from "@/components/wear-log-list";
 import { MarkdownContent } from "@/components/markdown-content";
-import { Pencil, Trash2, Plus, Droplets, Calendar, MessageSquare, ArrowLeft } from "lucide-react";
+import { Pencil, Trash2, Plus, Droplets, Calendar, MessageSquare, ArrowLeft, Star } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { getApiErrorMessage } from "@/lib/utils";
@@ -171,7 +171,12 @@ export function BottleDetail({
           {totalSprays > 0 && (
             <div className="text-sm text-text-secondary">{totalSprays} total sprays</div>
           )}
-          {avgRating && <div className="text-sm text-accent font-medium">{avgRating}/10 avg</div>}
+          {avgRating && (
+            <div className="flex items-center gap-1 text-sm text-accent font-medium">
+              <Star className="h-3.5 w-3.5 fill-current" />
+              {avgRating}/10
+            </div>
+          )}
         </div>
 
         {/* Comments */}


### PR DESCRIPTION
## Summary

Simplifies fragrance cards to show wears as the only card-level usage summary.

## Why

Spray totals are not a reliable comparison across fragrances because strength and dose vary. Keeping the collection card focused on wears also avoids cramped stat wrapping on narrow card widths.

## Changes

- Removed card-level spray total and average rating display.
- Kept the wear count as a single non-wrapping summary metric.
- Added a focused component test for the card summary behavior.

## Validation

- `npm test -- bottle-card.test.tsx`
- `npm run typecheck`
- `npm run lint`
- Browser boot smoke on `/signin` with no client errors; authenticated card view needs manual session verification.