### PR TITLE
refactor: extract shared form components and Convex helpers

### DIFF
--- a/my-app/convex/bottles.ts
+++ b/my-app/convex/bottles.ts
@@ -2,6 +2,7 @@ import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
 import { rateLimiter } from "./rateLimits";
+import { buildPatch } from "./patch";
 
 // ── Validation helpers ────────────────────────────────────────────────────────
 // HTML min/max attributes are client-side only and trivially bypassed, so we
@@ -127,26 +128,16 @@ export const updateBottle = mutation({
     }
     assertValidBottleInput(args);
 
-    // Build the patch explicitly so that:
-    //   undefined  → field is omitted (no change)
-    //   null       → field is set to undefined in the patch (clears it from the document)
-    //   <value>    → field is updated to that value
-    const patch: {
-      name?: string;
-      brand?: string;
-      sizeMl?: number;
-      tags?: string[];
-      comments?: string;
-      updatedAt: number;
-    } = { updatedAt: Date.now() };
-
-    if (args.name !== undefined) patch.name = args.name;
-    if (args.brand !== undefined) patch.brand = args.brand ?? undefined;
-    if (args.sizeMl !== undefined) patch.sizeMl = args.sizeMl ?? undefined;
-    if (args.tags !== undefined) patch.tags = args.tags ?? undefined;
-    if (args.comments !== undefined) patch.comments = args.comments ?? undefined;
-
-    await ctx.db.patch(args.bottleId, patch);
+    await ctx.db.patch(args.bottleId, {
+      ...buildPatch({
+        name: args.name,
+        brand: args.brand,
+        sizeMl: args.sizeMl,
+        tags: args.tags,
+        comments: args.comments,
+      }),
+      updatedAt: Date.now(),
+    });
   },
 });
 

--- a/my-app/convex/bottles.ts
+++ b/my-app/convex/bottles.ts
@@ -1,6 +1,6 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import { getOptionalUserId, getUserId } from "./helpers";
+import { getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
 import { rateLimiter } from "./rateLimits";
 
 // ── Validation helpers ────────────────────────────────────────────────────────
@@ -119,10 +119,7 @@ export const updateBottle = mutation({
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "updateBottle", { key: userId, throws: true });
-    const bottle = await ctx.db.get(args.bottleId);
-    if (!bottle || bottle.userId !== userId) {
-      throw new Error("Bottle not found or access denied.");
-    }
+    await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
 
     // Validate sizeMl when a real value (not a clear) is being set.
     if (args.sizeMl !== undefined && args.sizeMl !== null && args.sizeMl <= 0) {
@@ -158,10 +155,7 @@ export const deleteBottle = mutation({
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "deleteBottle", { key: userId, throws: true });
-    const bottle = await ctx.db.get(args.bottleId);
-    if (!bottle || bottle.userId !== userId) {
-      throw new Error("Bottle not found or access denied.");
-    }
+    await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
 
     // Cascade-delete all wear logs that reference this bottle so no orphaned
     // records are left behind after the bottle document is removed.
@@ -185,10 +179,7 @@ export const toggleFavorite = mutation({
       throws: true,
     });
 
-    const bottle = await ctx.db.get(args.bottleId);
-    if (!bottle || bottle.userId !== userId) {
-      throw new Error("Bottle not found or access denied.");
-    }
+    const bottle = await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
 
     // Intentionally do NOT touch updatedAt — favoriting is metadata, not a
     // content edit. Keeps any future "last modified" view honest.

--- a/my-app/convex/helpers.ts
+++ b/my-app/convex/helpers.ts
@@ -1,5 +1,5 @@
 import { getAuthUserId } from "@convex-dev/auth/server";
-import { Id } from "./_generated/dataModel";
+import { Doc, Id } from "./_generated/dataModel";
 import { MutationCtx, QueryCtx } from "./_generated/server";
 
 export async function getOptionalUserId(ctx: QueryCtx | MutationCtx): Promise<Id<"users"> | null> {
@@ -12,4 +12,32 @@ export async function getUserId(ctx: QueryCtx | MutationCtx): Promise<Id<"users"
     throw new Error("Unauthenticated.");
   }
   return userId;
+}
+
+const OWNED_DOC_LABELS = {
+  bottles: "Bottle",
+  wearLogs: "Wear log",
+} as const;
+
+type OwnedTable = keyof typeof OWNED_DOC_LABELS;
+
+/**
+ * Fetches a document and verifies it belongs to the given user. Throws the
+ * same "not found or access denied" error for both the missing and the
+ * foreign-owner case so responses never leak whether another user's
+ * document exists.
+ */
+export async function getOwnedDoc<T extends OwnedTable>(
+  ctx: QueryCtx | MutationCtx,
+  table: T,
+  id: Id<T>,
+  userId: Id<"users">,
+): Promise<Doc<T>> {
+  // Cast: TS can't prove `userId` exists on Doc<T> for a generic T, but both
+  // owned tables carry it in the schema.
+  const doc = (await ctx.db.get(id)) as Doc<OwnedTable> | null;
+  if (!doc || doc.userId !== userId) {
+    throw new Error(`${OWNED_DOC_LABELS[table]} not found or access denied.`);
+  }
+  return doc as unknown as Doc<T>;
 }

--- a/my-app/convex/patch.test.ts
+++ b/my-app/convex/patch.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+import { buildPatch } from "./patch";
+
+describe("buildPatch", () => {
+  test("omits undefined args entirely", () => {
+    const patch = buildPatch({ name: undefined, sprays: 4 });
+    expect("name" in patch).toBe(false);
+    expect(patch.sprays).toBe(4);
+  });
+
+  test("maps null to a present key with value undefined (field clear)", () => {
+    const patch = buildPatch({ comment: null });
+    expect("comment" in patch).toBe(true);
+    expect(patch.comment).toBeUndefined();
+  });
+
+  test("passes real values through, including falsy ones", () => {
+    const patch = buildPatch({ name: "Aventus", comment: "", rating: 0 });
+    expect(patch).toEqual({ name: "Aventus", comment: "", rating: 0 });
+  });
+});

--- a/my-app/convex/patch.ts
+++ b/my-app/convex/patch.ts
@@ -1,0 +1,17 @@
+/**
+ * Builds a Convex patch from update-mutation args that use the
+ * "null clears, undefined leaves unchanged" convention:
+ *   undefined → key omitted (no change)
+ *   null      → key present with value undefined (clears the field)
+ *   value     → key set to that value
+ */
+export function buildPatch<T extends Record<string, unknown>>(
+  args: T,
+): { [K in keyof T]?: Exclude<T[K], null> | undefined } {
+  const patch: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (value === undefined) continue;
+    patch[key] = value === null ? undefined : value;
+  }
+  return patch as { [K in keyof T]?: Exclude<T[K], null> | undefined };
+}

--- a/my-app/convex/wearLogs.ts
+++ b/my-app/convex/wearLogs.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
 import { rateLimiter } from "./rateLimits";
 import { MAX_SPRAYS } from "../src/lib/constants";
+import { buildPatch } from "./patch";
 
 // ── Validation constants ──────────────────────────────────────────────────────
 
@@ -135,6 +136,18 @@ function assertValidRating(rating: number): void {
   }
 }
 
+function assertValidWearLogStrings(args: {
+  comment?: string | null;
+  context?: string | null;
+}): void {
+  if (args.comment != null && args.comment.length > MAX_COMMENT_LENGTH) {
+    throw new Error(`Comment must be at most ${MAX_COMMENT_LENGTH} characters.`);
+  }
+  if (args.context != null && args.context.length > MAX_CONTEXT_LENGTH) {
+    throw new Error(`Context must be at most ${MAX_CONTEXT_LENGTH} characters.`);
+  }
+}
+
 // ── Mutations ─────────────────────────────────────────────────────────────────
 
 export const addWearLog = mutation({
@@ -158,12 +171,7 @@ export const addWearLog = mutation({
     await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
 
     // Validate string lengths server-side (HTML max is client-only).
-    if (args.comment && args.comment.length > MAX_COMMENT_LENGTH) {
-      throw new Error(`Comment must be at most ${MAX_COMMENT_LENGTH} characters.`);
-    }
-    if (args.context && args.context.length > MAX_CONTEXT_LENGTH) {
-      throw new Error(`Context must be at most ${MAX_CONTEXT_LENGTH} characters.`);
-    }
+    assertValidWearLogStrings(args);
 
     return await ctx.db.insert("wearLogs", {
       userId,
@@ -200,40 +208,18 @@ export const updateWearLog = mutation({
     await getOwnedDoc(ctx, "wearLogs", args.wearLogId, userId);
 
     // Validate string lengths server-side.
-    if (
-      args.comment !== undefined &&
-      args.comment !== null &&
-      args.comment.length > MAX_COMMENT_LENGTH
-    ) {
-      throw new Error(`Comment must be at most ${MAX_COMMENT_LENGTH} characters.`);
-    }
-    if (
-      args.context !== undefined &&
-      args.context !== null &&
-      args.context.length > MAX_CONTEXT_LENGTH
-    ) {
-      throw new Error(`Context must be at most ${MAX_CONTEXT_LENGTH} characters.`);
-    }
+    assertValidWearLogStrings(args);
 
-    // Build the patch explicitly so that:
-    //   undefined  → field is omitted (no change)
-    //   null       → field is set to undefined in the patch (clears it from the document)
-    //   <value>    → field is updated to that value
-    const patch: {
-      wornAt?: number;
-      sprays?: number;
-      context?: string;
-      rating?: number;
-      comment?: string;
-    } = {};
-
-    if (args.wornAt !== undefined) patch.wornAt = args.wornAt;
-    if (args.sprays !== undefined) patch.sprays = args.sprays;
-    if (args.context !== undefined) patch.context = args.context ?? undefined;
-    if (args.rating !== undefined) patch.rating = args.rating ?? undefined;
-    if (args.comment !== undefined) patch.comment = args.comment ?? undefined;
-
-    await ctx.db.patch(args.wearLogId, patch);
+    await ctx.db.patch(
+      args.wearLogId,
+      buildPatch({
+        wornAt: args.wornAt,
+        sprays: args.sprays,
+        context: args.context,
+        rating: args.rating,
+        comment: args.comment,
+      }),
+    );
   },
 });
 

--- a/my-app/convex/wearLogs.ts
+++ b/my-app/convex/wearLogs.ts
@@ -1,6 +1,6 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import { getOptionalUserId, getUserId } from "./helpers";
+import { getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
 import { rateLimiter } from "./rateLimits";
 import { MAX_SPRAYS } from "../src/lib/constants";
 
@@ -155,10 +155,7 @@ export const addWearLog = mutation({
     await rateLimiter.limit(ctx, "addWearLog", { key: userId, throws: true });
 
     // Verify the bottle belongs to this user.
-    const bottle = await ctx.db.get(args.bottleId);
-    if (!bottle || bottle.userId !== userId) {
-      throw new Error("Bottle not found or access denied.");
-    }
+    await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
 
     // Validate string lengths server-side (HTML max is client-only).
     if (args.comment && args.comment.length > MAX_COMMENT_LENGTH) {
@@ -200,10 +197,7 @@ export const updateWearLog = mutation({
 
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "updateWearLog", { key: userId, throws: true });
-    const log = await ctx.db.get(args.wearLogId);
-    if (!log || log.userId !== userId) {
-      throw new Error("Wear log not found or access denied.");
-    }
+    await getOwnedDoc(ctx, "wearLogs", args.wearLogId, userId);
 
     // Validate string lengths server-side.
     if (
@@ -248,10 +242,7 @@ export const deleteWearLog = mutation({
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "deleteWearLog", { key: userId, throws: true });
-    const log = await ctx.db.get(args.wearLogId);
-    if (!log || log.userId !== userId) {
-      throw new Error("Wear log not found or access denied.");
-    }
+    await getOwnedDoc(ctx, "wearLogs", args.wearLogId, userId);
     await ctx.db.delete(args.wearLogId);
   },
 });

--- a/my-app/src/components/add-bottle-dialog.tsx
+++ b/my-app/src/components/add-bottle-dialog.tsx
@@ -15,11 +15,16 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { FormErrorBanner } from "@/components/form-error-banner";
+import { FormField } from "@/components/form-field";
+import { MarkdownHint } from "@/components/markdown-hint";
+import { SubmitButton } from "@/components/submit-button";
 import { useState, useEffect, useRef } from "react";
 import { X } from "lucide-react";
 import { toast } from "sonner";
-import { getApiErrorMessage } from "@/lib/utils";
+import { reportApiError } from "@/lib/utils";
+import { useCtrlEnterSubmit } from "@/lib/use-ctrl-enter-submit";
+import { useFormErrors } from "@/lib/use-form-errors";
 
 interface AddBottleDialogProps {
   open: boolean;
@@ -38,9 +43,9 @@ export function AddBottleDialog({ open, onOpenChange, editBottle }: AddBottleDia
   const [tags, setTags] = useState<string[]>([]);
   const [comments, setComments] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [formError, setFormError] = useState<string | null>(null);
+  const { errors, setErrors, clearError, formError, setFormError, resetErrors } = useFormErrors();
   const formRef = useRef<HTMLFormElement>(null);
+  const handleFormKeyDown = useCtrlEnterSubmit(formRef, submitting);
 
   const isEditing = !!editBottle;
 
@@ -52,8 +57,7 @@ export function AddBottleDialog({ open, onOpenChange, editBottle }: AddBottleDia
       setTags(editBottle.tags ?? []);
       setTagInput("");
       setComments(editBottle.comments ?? "");
-      setErrors({});
-      setFormError(null);
+      resetErrors();
     } else if (open) {
       setName("");
       setBrand("");
@@ -61,19 +65,9 @@ export function AddBottleDialog({ open, onOpenChange, editBottle }: AddBottleDia
       setTags([]);
       setTagInput("");
       setComments("");
-      setErrors({});
-      setFormError(null);
+      resetErrors();
     }
-  }, [open, editBottle]);
-
-  const clearError = (field: string) => {
-    setErrors((prev) => {
-      if (!prev[field]) return prev;
-      const next = { ...prev };
-      delete next[field];
-      return next;
-    });
-  };
+  }, [open, editBottle, resetErrors]);
 
   const validate = (): boolean => {
     const newErrors: Record<string, string> = {};
@@ -100,28 +94,6 @@ export function AddBottleDialog({ open, onOpenChange, editBottle }: AddBottleDia
     if (e.key === "Enter" && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
       e.preventDefault();
       handleAddTag();
-    }
-  };
-
-  const handleFormKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
-    if (e.key !== "Enter") return;
-
-    // Allow plain Enter in textareas (for newlines)
-    if ((e.target as HTMLElement).tagName === "TEXTAREA" && !e.ctrlKey) return;
-
-    // Ctrl+Enter: submit the form
-    if (e.ctrlKey && !e.shiftKey && !e.metaKey) {
-      if (submitting) return;
-      e.preventDefault();
-      formRef.current?.requestSubmit();
-      return;
-    }
-
-    // Block plain Enter from submitting the form only on text/number inputs.
-    // Buttons, Select triggers, and other interactive controls are left
-    // unaffected so keyboard users can activate them normally.
-    if ((e.target as HTMLElement).tagName === "INPUT") {
-      e.preventDefault();
     }
   };
 
@@ -157,10 +129,7 @@ export function AddBottleDialog({ open, onOpenChange, editBottle }: AddBottleDia
       }
       onOpenChange(false);
     } catch (err) {
-      if (process.env.NODE_ENV !== "production") {
-        console.error("Failed to save bottle:", err);
-      }
-      const message = getApiErrorMessage(err);
+      const message = reportApiError(err, "Failed to save bottle:");
       toast.error(message);
       setFormError(message);
     } finally {
@@ -187,69 +156,41 @@ export function AddBottleDialog({ open, onOpenChange, editBottle }: AddBottleDia
         >
           {/* Name + Brand side by side */}
           <div className="grid grid-cols-2 gap-4">
-            <div className="relative space-y-2">
-              <Label htmlFor="name" className={errors.name ? "text-danger" : ""}>
-                Name *
-              </Label>
-              <Input
-                id="name"
-                value={name}
-                onChange={(e) => {
-                  setName(e.target.value);
-                  clearError("name");
-                }}
-                placeholder="Aventus"
-                className={errors.name ? "border-danger focus:border-danger focus:ring-danger" : ""}
-                aria-invalid={!!errors.name}
-                aria-describedby="name-error"
-              />
-              <p
-                id="name-error"
-                role="alert"
-                className={`absolute -bottom-3 left-0 text-xs text-danger transition-opacity ${errors.name ? "opacity-100" : "opacity-0 pointer-events-none"}`}
-              >
-                {errors.name ?? "\u00A0"}
-              </p>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="brand">Brand</Label>
-              <Input
-                id="brand"
-                value={brand}
-                onChange={(e) => setBrand(e.target.value)}
-                placeholder="Creed"
-              />
-            </div>
+            <FormField
+              id="name"
+              label="Name *"
+              error={errors.name}
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                clearError("name");
+              }}
+              placeholder="Aventus"
+            />
+            <FormField
+              id="brand"
+              label="Brand"
+              value={brand}
+              onChange={(e) => setBrand(e.target.value)}
+              placeholder="Creed"
+            />
           </div>
 
           {/* Size */}
-          <div className="relative space-y-2">
-            <Label htmlFor="size" className={errors.sizeMl ? "text-danger" : ""}>
-              Size (ml)
-            </Label>
-            <Input
-              id="size"
-              type="number"
-              value={sizeMl}
-              onChange={(e) => {
-                setSizeMl(e.target.value);
-                clearError("sizeMl");
-              }}
-              placeholder="100"
-              min="1"
-              step="1"
-              className={errors.sizeMl ? "border-danger focus:border-danger focus:ring-danger" : ""}
-              aria-invalid={!!errors.sizeMl}
-              aria-describedby="size-error"
-            />
-            <p
-              id="size-error"
-              role="alert"
-              className={`absolute top-full left-0 mt-1 text-xs text-danger transition-opacity ${errors.sizeMl ? "opacity-100" : "opacity-0 pointer-events-none"}`}
-            >
-              {errors.sizeMl ?? "\u00A0"}
-            </p>
-          </div>
+          <FormField
+            id="size"
+            label="Size (ml)"
+            error={errors.sizeMl}
+            type="number"
+            value={sizeMl}
+            onChange={(e) => {
+              setSizeMl(e.target.value);
+              clearError("sizeMl");
+            }}
+            placeholder="100"
+            min="1"
+            step="1"
+          />
 
           {/* Tags */}
           <div className="space-y-2">
@@ -304,45 +245,19 @@ export function AddBottleDialog({ open, onOpenChange, editBottle }: AddBottleDia
               placeholder="Personal thoughts, batch code, where purchased..."
               rows={3}
             />
-            <p className="text-xs text-text-secondary/50">
-              Markdown supported: **bold**, *italic*, [link text](url), - lists
-            </p>
+            <MarkdownHint />
           </div>
 
           <DialogFooter>
-            {formError && (
-              <p
-                role="alert"
-                className="w-full rounded-lg border border-danger/30 bg-danger/5 px-3 py-2.5 text-sm text-danger"
-              >
-                {formError}
-              </p>
-            )}
+            <FormErrorBanner message={formError} />
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={submitting} aria-keyshortcuts="Control+Enter">
-              <span>
-                {submitting
-                  ? isEditing
-                    ? "Saving..."
-                    : "Adding..."
-                  : isEditing
-                    ? "Save Changes"
-                    : "Add Fragrance"}
-              </span>
-              {!submitting && (
-                <KbdGroup aria-hidden="true" className="ml-1">
-                  <Kbd className="border-white/20 bg-white/14 text-white shadow-[inset_0_-1px_0_rgba(255,255,255,0.18)]">
-                    Ctrl
-                  </Kbd>
-                  <span className="text-white/65">+</span>
-                  <Kbd className="border-white/20 bg-white/14 text-white shadow-[inset_0_-1px_0_rgba(255,255,255,0.18)]">
-                    ⏎
-                  </Kbd>
-                </KbdGroup>
-              )}
-            </Button>
+            <SubmitButton
+              submitting={submitting}
+              label={isEditing ? "Save Changes" : "Add Fragrance"}
+              busyLabel={isEditing ? "Saving..." : "Adding..."}
+            />
           </DialogFooter>
         </form>
       </DialogContent>

--- a/my-app/src/components/add-wear-log-dialog.tsx
+++ b/my-app/src/components/add-wear-log-dialog.tsx
@@ -15,20 +15,17 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { ContextSelect } from "@/components/context-select";
+import { FormErrorBanner } from "@/components/form-error-banner";
+import { FormField } from "@/components/form-field";
+import { MarkdownHint } from "@/components/markdown-hint";
+import { SubmitButton } from "@/components/submit-button";
 import { useState, useEffect, useRef } from "react";
 import { toast } from "sonner";
-import { getApiErrorMessage, isFutureWornAtError } from "@/lib/utils";
-import { MAX_SPRAYS, CONTEXT_OPTIONS } from "@/lib/constants";
-
-const NO_CONTEXT_VALUE = "__none__";
+import { isFutureWornAtError, reportApiError } from "@/lib/utils";
+import { useCtrlEnterSubmit } from "@/lib/use-ctrl-enter-submit";
+import { useFormErrors } from "@/lib/use-form-errors";
+import { MAX_SPRAYS } from "@/lib/constants";
 
 function getWornAtTimestamp(date: string, time: string): number {
   if (!date) return NaN;
@@ -63,18 +60,9 @@ export function AddWearLogDialog({
   const [rating, setRating] = useState("");
   const [comment, setComment] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [formError, setFormError] = useState<string | null>(null);
+  const { errors, setErrors, clearError, formError, setFormError, resetErrors } = useFormErrors();
   const formRef = useRef<HTMLFormElement>(null);
-
-  const clearError = (field: string) => {
-    setErrors((prev) => {
-      if (!prev[field]) return prev;
-      const next = { ...prev };
-      delete next[field];
-      return next;
-    });
-  };
+  const handleFormKeyDown = useCtrlEnterSubmit(formRef, submitting);
 
   const validate = (): boolean => {
     const newErrors: Record<string, string> = {};
@@ -99,28 +87,6 @@ export function AddWearLogDialog({
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleFormKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
-    if (e.key !== "Enter") return;
-
-    // Allow plain Enter in textareas (for newlines)
-    if ((e.target as HTMLElement).tagName === "TEXTAREA" && !e.ctrlKey) return;
-
-    // Ctrl+Enter: submit the form
-    if (e.ctrlKey && !e.shiftKey && !e.metaKey) {
-      if (submitting) return;
-      e.preventDefault();
-      formRef.current?.requestSubmit();
-      return;
-    }
-
-    // Block plain Enter from submitting the form only on text/number inputs.
-    // Buttons, Select triggers, and other interactive controls are left
-    // unaffected so keyboard users can activate them normally.
-    if ((e.target as HTMLElement).tagName === "INPUT") {
-      e.preventDefault();
-    }
-  };
-
   useEffect(() => {
     if (open) {
       const now = new Date();
@@ -136,10 +102,9 @@ export function AddWearLogDialog({
       setContext("");
       setRating("");
       setComment("");
-      setErrors({});
-      setFormError(null);
+      resetErrors();
     }
-  }, [open]);
+  }, [open, resetErrors]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -163,10 +128,7 @@ export function AddWearLogDialog({
       onSuccess?.();
       onOpenChange(false);
     } catch (err) {
-      if (process.env.NODE_ENV !== "production") {
-        console.error("Failed to log wear:", err);
-      }
-      const message = getApiErrorMessage(err);
+      const message = reportApiError(err, "Failed to log wear:");
       if (isFutureWornAtError(err)) {
         setErrors({ wornAt: message });
       } else {
@@ -193,7 +155,9 @@ export function AddWearLogDialog({
           noValidate
           className="space-y-5"
         >
-          {/* Date + Time side by side */}
+          {/* Date + Time side by side. Kept bespoke (not FormField): the wornAt
+              error spans both fields, with two stacked error paragraphs and a
+              switching aria-describedby. */}
           <div className="grid grid-cols-2 gap-4">
             <div className="relative space-y-2">
               <Label htmlFor="date" className={errors.date || errors.wornAt ? "text-danger" : ""}>
@@ -222,14 +186,14 @@ export function AddWearLogDialog({
                 role="alert"
                 className={`absolute -bottom-3 left-0 text-xs text-danger transition-opacity ${errors.date && !errors.wornAt ? "opacity-100" : "opacity-0 pointer-events-none"}`}
               >
-                {errors.date ?? "\u00A0"}
+                {errors.date ?? " "}
               </p>
               <p
                 id="worn-at-error"
                 role="alert"
                 className={`absolute -bottom-3 left-0 whitespace-nowrap text-xs text-danger transition-opacity ${errors.wornAt ? "opacity-100" : "opacity-0 pointer-events-none"}`}
               >
-                {errors.wornAt ?? "\u00A0"}
+                {errors.wornAt ?? " "}
               </p>
             </div>
             <div className="relative space-y-2">
@@ -255,86 +219,37 @@ export function AddWearLogDialog({
 
           {/* Sprays + Rating side by side */}
           <div className="grid grid-cols-2 gap-4">
-            <div className="relative space-y-2">
-              <Label htmlFor="sprays" className={errors.sprays ? "text-danger" : ""}>
-                Sprays *
-              </Label>
-              <Input
-                id="sprays"
-                type="number"
-                value={sprays}
-                onChange={(e) => {
-                  setSprays(e.target.value);
-                  clearError("sprays");
-                }}
-                min="1"
-                max={MAX_SPRAYS}
-                required
-                className={
-                  errors.sprays ? "border-danger focus:border-danger focus:ring-danger" : ""
-                }
-                aria-invalid={!!errors.sprays}
-                aria-describedby="sprays-error"
-              />
-              <p
-                id="sprays-error"
-                role="alert"
-                className={`absolute -bottom-3 left-0 text-xs text-danger transition-opacity ${errors.sprays ? "opacity-100" : "opacity-0 pointer-events-none"}`}
-              >
-                {errors.sprays ?? "\u00A0"}
-              </p>
-            </div>
-            <div className="relative space-y-2">
-              <Label htmlFor="rating" className={errors.rating ? "text-danger" : ""}>
-                Rating (1-10)
-              </Label>
-              <Input
-                id="rating"
-                type="number"
-                value={rating}
-                onChange={(e) => {
-                  setRating(e.target.value);
-                  clearError("rating");
-                }}
-                min="1"
-                max="10"
-                placeholder="Optional"
-                className={
-                  errors.rating ? "border-danger focus:border-danger focus:ring-danger" : ""
-                }
-                aria-invalid={!!errors.rating}
-                aria-describedby="rating-error"
-              />
-              <p
-                id="rating-error"
-                role="alert"
-                className={`absolute -bottom-3 left-0 text-xs text-danger transition-opacity ${errors.rating ? "opacity-100" : "opacity-0 pointer-events-none"}`}
-              >
-                {errors.rating ?? "\u00A0"}
-              </p>
-            </div>
+            <FormField
+              id="sprays"
+              label="Sprays *"
+              error={errors.sprays}
+              type="number"
+              value={sprays}
+              onChange={(e) => {
+                setSprays(e.target.value);
+                clearError("sprays");
+              }}
+              min="1"
+              max={MAX_SPRAYS}
+              required
+            />
+            <FormField
+              id="rating"
+              label="Rating (1-10)"
+              error={errors.rating}
+              type="number"
+              value={rating}
+              onChange={(e) => {
+                setRating(e.target.value);
+                clearError("rating");
+              }}
+              min="1"
+              max="10"
+              placeholder="Optional"
+            />
           </div>
 
-          {/* Context */}
-          <div className="space-y-2">
-            <Label>Context</Label>
-            <Select
-              value={context || NO_CONTEXT_VALUE}
-              onValueChange={(value) => setContext(value === NO_CONTEXT_VALUE ? "" : value)}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select occasion..." />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={NO_CONTEXT_VALUE}>No context</SelectItem>
-                {CONTEXT_OPTIONS.map((opt) => (
-                  <SelectItem key={opt} value={opt}>
-                    {opt}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+          <ContextSelect value={context} onChange={setContext} />
 
           {/* Comment */}
           <div className="space-y-2">
@@ -346,37 +261,15 @@ export function AddWearLogDialog({
               placeholder="Performance comments, compliments received..."
               rows={2}
             />
-            <p className="text-xs text-text-secondary/50">
-              Markdown supported: **bold**, *italic*, [link text](url), - lists
-            </p>
+            <MarkdownHint />
           </div>
 
           <DialogFooter>
-            {formError && (
-              <p
-                role="alert"
-                className="w-full rounded-lg border border-danger/30 bg-danger/5 px-3 py-2.5 text-sm text-danger"
-              >
-                {formError}
-              </p>
-            )}
+            <FormErrorBanner message={formError} />
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={submitting} aria-keyshortcuts="Control+Enter">
-              <span>{submitting ? "Logging..." : "Log Wear"}</span>
-              {!submitting && (
-                <KbdGroup aria-hidden="true" className="ml-1">
-                  <Kbd className="border-white/20 bg-white/14 text-white shadow-[inset_0_-1px_0_rgba(255,255,255,0.18)]">
-                    Ctrl
-                  </Kbd>
-                  <span className="text-white/65">+</span>
-                  <Kbd className="border-white/20 bg-white/14 text-white shadow-[inset_0_-1px_0_rgba(255,255,255,0.18)]">
-                    ⏎
-                  </Kbd>
-                </KbdGroup>
-              )}
-            </Button>
+            <SubmitButton submitting={submitting} label="Log Wear" busyLabel="Logging..." />
           </DialogFooter>
         </form>
       </DialogContent>

--- a/my-app/src/components/bottle-detail.tsx
+++ b/my-app/src/components/bottle-detail.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-import { getApiErrorMessage } from "@/lib/utils";
+import { reportApiError } from "@/lib/utils";
 import { type OnboardingStep } from "@/lib/use-onboarding";
 
 interface BottleDetailProps {
@@ -84,10 +84,7 @@ export function BottleDetail({
       toast.success("Fragrance deleted");
       onClose();
     } catch (err) {
-      if (process.env.NODE_ENV !== "production") {
-        console.error("Failed to delete bottle:", err);
-      }
-      toast.error(getApiErrorMessage(err));
+      toast.error(reportApiError(err, "Failed to delete bottle:"));
       // Keep confirmDelete true so the user can retry without an extra click
     }
   };

--- a/my-app/src/components/bottle-detail.tsx
+++ b/my-app/src/components/bottle-detail.tsx
@@ -12,15 +12,7 @@ import { FavoriteToggle } from "@/components/favorite-toggle";
 import { cn } from "@/lib/utils";
 import { WearLogList } from "@/components/wear-log-list";
 import { MarkdownContent } from "@/components/markdown-content";
-import {
-  Pencil,
-  Plus,
-  Droplets,
-  Calendar,
-  MessageSquare,
-  ArrowLeft,
-  Star,
-} from "lucide-react";
+import { Pencil, Plus, Droplets, Calendar, MessageSquare, ArrowLeft, Star } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { reportApiError } from "@/lib/utils";

--- a/my-app/src/components/bottle-detail.tsx
+++ b/my-app/src/components/bottle-detail.tsx
@@ -7,13 +7,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { CoachMark } from "@/components/coach-mark";
+import { ConfirmDeleteButton } from "@/components/confirm-delete-button";
 import { FavoriteToggle } from "@/components/favorite-toggle";
 import { cn } from "@/lib/utils";
 import { WearLogList } from "@/components/wear-log-list";
 import { MarkdownContent } from "@/components/markdown-content";
 import {
   Pencil,
-  Trash2,
   Plus,
   Droplets,
   Calendar,
@@ -125,29 +125,16 @@ export function BottleDetail({
             >
               <Pencil className="h-4 w-4" />
             </Button>
-            <Button
-              variant={confirmDelete ? "destructive" : "ghost"}
+            <ConfirmDeleteButton
+              confirming={confirmDelete}
               onClick={handleDelete}
               onMouseLeave={() => setConfirmDelete(false)}
-              aria-label={confirmDelete ? "Confirm delete" : `Delete ${bottle.name}`}
-              className={cn(
-                "h-10 transition-all duration-300 ease-out shrink-0 overflow-hidden relative gap-0 border",
-                confirmDelete
-                  ? "w-[116px] px-4 border-transparent"
-                  : "w-10 px-0 justify-center border-red-500/25 bg-red-500/10 text-red-400 hover:bg-red-500/20",
-              )}
-            >
-              <Trash2 className="h-4 w-4 shrink-0 z-10" />
-              <span
-                aria-hidden="true"
-                className={cn(
-                  "overflow-hidden transition-all duration-300 ease-out whitespace-nowrap text-sm flex items-center z-10",
-                  confirmDelete ? "w-[60px] ml-1.5 opacity-100" : "w-0 ml-0 opacity-0",
-                )}
-              >
-                Confirm
-              </span>
-            </Button>
+              idleLabel={`Delete ${bottle.name}`}
+              confirmLabel="Confirm delete"
+              className="border"
+              idleClassName="border-red-500/25 bg-red-500/10 text-red-400 hover:bg-red-500/20"
+              confirmingClassName="border-transparent"
+            />
           </div>
         </div>
 

--- a/my-app/src/components/confirm-delete-button.test.tsx
+++ b/my-app/src/components/confirm-delete-button.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+import { ConfirmDeleteButton } from "./confirm-delete-button";
+
+describe("ConfirmDeleteButton", () => {
+  test("idle: shows the idle label and hides the confirm text", () => {
+    render(
+      <ConfirmDeleteButton
+        confirming={false}
+        onClick={vi.fn()}
+        onMouseLeave={vi.fn()}
+        idleLabel="Delete wear log"
+        confirmLabel="Confirm delete wear log"
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Delete wear log" })).toBeInTheDocument();
+    expect(screen.getByText("Confirm")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  test("confirming: shows the confirm label and fires onClick", async () => {
+    const onClick = vi.fn();
+    render(
+      <ConfirmDeleteButton
+        confirming
+        onClick={onClick}
+        onMouseLeave={vi.fn()}
+        idleLabel="Delete wear log"
+        confirmLabel="Confirm delete wear log"
+      />,
+    );
+    const button = screen.getByRole("button", { name: "Confirm delete wear log" });
+    await userEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/my-app/src/components/confirm-delete-button.tsx
+++ b/my-app/src/components/confirm-delete-button.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const SIZES = {
+  /** Bottle-detail header action (h-10 icon button). */
+  default: {
+    button: "h-10",
+    expanded: "w-[116px] px-4",
+    collapsed: "w-10 px-0 justify-center",
+    icon: "h-4 w-4",
+    text: "text-sm",
+    confirmText: "w-[60px]",
+  },
+  /** Wear-log row action (h-8 icon button). */
+  compact: {
+    button: "h-8",
+    expanded: "w-[100px] px-3",
+    collapsed: "w-8 px-0 justify-center",
+    icon: "h-3.5 w-3.5",
+    text: "text-xs",
+    confirmText: "w-[56px]",
+  },
+} as const;
+
+interface ConfirmDeleteButtonProps {
+  /** Armed by the parent on first click; second click confirms. */
+  confirming: boolean;
+  onClick: () => void;
+  /** Parent resets its armed state here. */
+  onMouseLeave: () => void;
+  idleLabel: string;
+  confirmLabel: string;
+  size?: keyof typeof SIZES;
+  /** Extra classes applied in both states (e.g. hover-reveal opacity). */
+  className?: string;
+  /** Extra classes applied only at rest (e.g. red outline styling). */
+  idleClassName?: string;
+  /** Extra classes applied only while armed. */
+  confirmingClassName?: string;
+}
+
+/**
+ * Two-step delete button: an icon at rest that expands to reveal a "Confirm"
+ * label once armed. Mousing away should disarm it via onMouseLeave.
+ */
+export function ConfirmDeleteButton({
+  confirming,
+  onClick,
+  onMouseLeave,
+  idleLabel,
+  confirmLabel,
+  size = "default",
+  className,
+  idleClassName,
+  confirmingClassName,
+}: ConfirmDeleteButtonProps) {
+  const s = SIZES[size];
+  return (
+    <Button
+      variant={confirming ? "destructive" : "ghost"}
+      onClick={onClick}
+      onMouseLeave={onMouseLeave}
+      aria-label={confirming ? confirmLabel : idleLabel}
+      className={cn(
+        "transition-all duration-300 ease-out shrink-0 overflow-hidden relative gap-0",
+        s.button,
+        confirming ? cn(s.expanded, confirmingClassName) : cn(s.collapsed, idleClassName),
+        className,
+      )}
+    >
+      <Trash2 className={cn(s.icon, "shrink-0 z-10")} />
+      <span
+        aria-hidden={!confirming}
+        className={cn(
+          "overflow-hidden transition-all duration-300 ease-out whitespace-nowrap flex items-center z-10",
+          s.text,
+          confirming ? cn(s.confirmText, "ml-1.5 opacity-100") : "w-0 ml-0 opacity-0",
+        )}
+      >
+        Confirm
+      </span>
+    </Button>
+  );
+}

--- a/my-app/src/components/context-select.test.tsx
+++ b/my-app/src/components/context-select.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { ContextSelect } from "./context-select";
+
+describe("ContextSelect", () => {
+  test("shows 'No context' when value is empty", () => {
+    render(<ContextSelect value="" onChange={vi.fn()} />);
+    expect(screen.getByRole("combobox")).toHaveTextContent("No context");
+  });
+
+  test("shows the selected context", () => {
+    render(<ContextSelect value="Office" onChange={vi.fn()} />);
+    expect(screen.getByRole("combobox")).toHaveTextContent("Office");
+  });
+});

--- a/my-app/src/components/context-select.tsx
+++ b/my-app/src/components/context-select.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { CONTEXT_OPTIONS, NO_CONTEXT_VALUE } from "@/lib/constants";
+
+interface ContextSelectProps {
+  /** Current context; "" means none selected. */
+  value: string;
+  /** Receives "" when "No context" is chosen. */
+  onChange: (value: string) => void;
+}
+
+/** Labeled occasion picker shared by the add/edit wear-log dialogs. */
+export function ContextSelect({ value, onChange }: ContextSelectProps) {
+  return (
+    <div className="space-y-2">
+      <Label>Context</Label>
+      <Select
+        value={value || NO_CONTEXT_VALUE}
+        onValueChange={(v) => onChange(v === NO_CONTEXT_VALUE ? "" : v)}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder="Select occasion..." />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={NO_CONTEXT_VALUE}>No context</SelectItem>
+          {CONTEXT_OPTIONS.map((opt) => (
+            <SelectItem key={opt} value={opt}>
+              {opt}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/my-app/src/components/edit-wear-log-dialog.tsx
+++ b/my-app/src/components/edit-wear-log-dialog.tsx
@@ -12,23 +12,20 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { ContextSelect } from "@/components/context-select";
+import { FormErrorBanner } from "@/components/form-error-banner";
+import { FormField } from "@/components/form-field";
+import { MarkdownHint } from "@/components/markdown-hint";
+import { SubmitButton } from "@/components/submit-button";
 import { useState, useEffect, useRef } from "react";
 import { toast } from "sonner";
-import { getApiErrorMessage } from "@/lib/utils";
-import { MAX_SPRAYS, CONTEXT_OPTIONS } from "@/lib/constants";
-
-const NO_CONTEXT_VALUE = "__none__";
+import { reportApiError } from "@/lib/utils";
+import { useCtrlEnterSubmit } from "@/lib/use-ctrl-enter-submit";
+import { useFormErrors } from "@/lib/use-form-errors";
+import { formatWearDate, formatWearTime } from "@/lib/format";
+import { MAX_SPRAYS } from "@/lib/constants";
 
 interface EditWearLogDialogProps {
   open: boolean;
@@ -44,18 +41,9 @@ export function EditWearLogDialog({ open, onOpenChange, log }: EditWearLogDialog
   const [rating, setRating] = useState("");
   const [comment, setComment] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [formError, setFormError] = useState<string | null>(null);
+  const { errors, setErrors, clearError, formError, setFormError, resetErrors } = useFormErrors();
   const formRef = useRef<HTMLFormElement>(null);
-
-  const clearError = (field: string) => {
-    setErrors((prev) => {
-      if (!prev[field]) return prev;
-      const next = { ...prev };
-      delete next[field];
-      return next;
-    });
-  };
+  const handleFormKeyDown = useCtrlEnterSubmit(formRef, submitting);
 
   const validate = (): boolean => {
     const newErrors: Record<string, string> = {};
@@ -73,26 +61,6 @@ export function EditWearLogDialog({ open, onOpenChange, log }: EditWearLogDialog
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleFormKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
-    if (e.key !== "Enter") return;
-
-    // Allow plain Enter in textareas (for newlines)
-    if ((e.target as HTMLElement).tagName === "TEXTAREA" && !e.ctrlKey) return;
-
-    // Ctrl+Enter: submit the form
-    if (e.ctrlKey && !e.shiftKey && !e.metaKey) {
-      if (submitting) return;
-      e.preventDefault();
-      formRef.current?.requestSubmit();
-      return;
-    }
-
-    // Block plain Enter from submitting the form only on text/number inputs.
-    if ((e.target as HTMLElement).tagName === "INPUT") {
-      e.preventDefault();
-    }
-  };
-
   // Pre-populate form fields from the log when the dialog opens
   useEffect(() => {
     if (open) {
@@ -100,10 +68,9 @@ export function EditWearLogDialog({ open, onOpenChange, log }: EditWearLogDialog
       setContext(log.context ?? "");
       setRating(log.rating !== undefined ? String(log.rating) : "");
       setComment(log.comment ?? "");
-      setErrors({});
-      setFormError(null);
+      resetErrors();
     }
-  }, [open, log]);
+  }, [open, log, resetErrors]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -121,33 +88,12 @@ export function EditWearLogDialog({ open, onOpenChange, log }: EditWearLogDialog
       toast.success("Wear log updated");
       onOpenChange(false);
     } catch (err) {
-      if (process.env.NODE_ENV !== "production") {
-        console.error("Failed to update wear log:", err);
-      }
-      const message = getApiErrorMessage(err);
+      const message = reportApiError(err, "Failed to update wear log:");
       toast.error(message);
       setFormError(message);
     } finally {
       setSubmitting(false);
     }
-  };
-
-  const formatReadOnlyDate = (timestamp: number) => {
-    const d = new Date(timestamp);
-    return d.toLocaleDateString("en-US", {
-      weekday: "short",
-      month: "short",
-      day: "numeric",
-      year: d.getFullYear() !== new Date().getFullYear() ? "numeric" : undefined,
-    });
-  };
-
-  const formatReadOnlyTime = (timestamp: number) => {
-    const d = new Date(timestamp);
-    return d.toLocaleTimeString("en-US", {
-      hour: "numeric",
-      minute: "2-digit",
-    });
   };
 
   return (
@@ -170,99 +116,50 @@ export function EditWearLogDialog({ open, onOpenChange, log }: EditWearLogDialog
             <div className="space-y-2">
               <Label className="text-text-secondary/60">Date</Label>
               <div className="flex h-10 w-full items-center rounded-xl border border-border/40 bg-surface-alt/50 px-4 text-sm text-text-secondary/60 select-none cursor-not-allowed">
-                {formatReadOnlyDate(log.wornAt)}
+                {formatWearDate(log.wornAt, { weekday: true })}
               </div>
             </div>
             <div className="space-y-2">
               <Label className="text-text-secondary/60">Time</Label>
               <div className="flex h-10 w-full items-center rounded-xl border border-border/40 bg-surface-alt/50 px-4 text-sm text-text-secondary/60 select-none cursor-not-allowed">
-                {formatReadOnlyTime(log.wornAt)}
+                {formatWearTime(log.wornAt)}
               </div>
             </div>
           </div>
 
           {/* Sprays + Rating side by side */}
           <div className="grid grid-cols-2 gap-4">
-            <div className="relative space-y-2">
-              <Label htmlFor="edit-sprays" className={errors.sprays ? "text-danger" : ""}>
-                Sprays *
-              </Label>
-              <Input
-                id="edit-sprays"
-                type="number"
-                value={sprays}
-                onChange={(e) => {
-                  setSprays(e.target.value);
-                  clearError("sprays");
-                }}
-                min="1"
-                max={MAX_SPRAYS}
-                required
-                className={
-                  errors.sprays ? "border-danger focus:border-danger focus:ring-danger" : ""
-                }
-                aria-invalid={!!errors.sprays}
-                aria-describedby="edit-sprays-error"
-              />
-              <p
-                id="edit-sprays-error"
-                role="alert"
-                className={`absolute -bottom-3 left-0 text-xs text-danger transition-opacity ${errors.sprays ? "opacity-100" : "opacity-0 pointer-events-none"}`}
-              >
-                {errors.sprays ?? "\u00A0"}
-              </p>
-            </div>
-            <div className="relative space-y-2">
-              <Label htmlFor="edit-rating" className={errors.rating ? "text-danger" : ""}>
-                Rating (1-10)
-              </Label>
-              <Input
-                id="edit-rating"
-                type="number"
-                value={rating}
-                onChange={(e) => {
-                  setRating(e.target.value);
-                  clearError("rating");
-                }}
-                min="1"
-                max="10"
-                placeholder="Optional"
-                className={
-                  errors.rating ? "border-danger focus:border-danger focus:ring-danger" : ""
-                }
-                aria-invalid={!!errors.rating}
-                aria-describedby="edit-rating-error"
-              />
-              <p
-                id="edit-rating-error"
-                role="alert"
-                className={`absolute -bottom-3 left-0 text-xs text-danger transition-opacity ${errors.rating ? "opacity-100" : "opacity-0 pointer-events-none"}`}
-              >
-                {errors.rating ?? "\u00A0"}
-              </p>
-            </div>
+            <FormField
+              id="edit-sprays"
+              label="Sprays *"
+              error={errors.sprays}
+              type="number"
+              value={sprays}
+              onChange={(e) => {
+                setSprays(e.target.value);
+                clearError("sprays");
+              }}
+              min="1"
+              max={MAX_SPRAYS}
+              required
+            />
+            <FormField
+              id="edit-rating"
+              label="Rating (1-10)"
+              error={errors.rating}
+              type="number"
+              value={rating}
+              onChange={(e) => {
+                setRating(e.target.value);
+                clearError("rating");
+              }}
+              min="1"
+              max="10"
+              placeholder="Optional"
+            />
           </div>
 
-          {/* Context */}
-          <div className="space-y-2">
-            <Label>Context</Label>
-            <Select
-              value={context || NO_CONTEXT_VALUE}
-              onValueChange={(value) => setContext(value === NO_CONTEXT_VALUE ? "" : value)}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select occasion..." />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={NO_CONTEXT_VALUE}>No context</SelectItem>
-                {CONTEXT_OPTIONS.map((opt) => (
-                  <SelectItem key={opt} value={opt}>
-                    {opt}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+          <ContextSelect value={context} onChange={setContext} />
 
           {/* Comment */}
           <div className="space-y-2">
@@ -274,37 +171,15 @@ export function EditWearLogDialog({ open, onOpenChange, log }: EditWearLogDialog
               placeholder="Performance comments, compliments received..."
               rows={2}
             />
-            <p className="text-xs text-text-secondary/50">
-              Markdown supported: **bold**, *italic*, [link text](url), - lists
-            </p>
+            <MarkdownHint />
           </div>
 
           <DialogFooter>
-            {formError && (
-              <p
-                role="alert"
-                className="w-full rounded-lg border border-danger/30 bg-danger/5 px-3 py-2.5 text-sm text-danger"
-              >
-                {formError}
-              </p>
-            )}
+            <FormErrorBanner message={formError} />
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={submitting} aria-keyshortcuts="Control+Enter">
-              <span>{submitting ? "Saving..." : "Save Changes"}</span>
-              {!submitting && (
-                <KbdGroup aria-hidden="true" className="ml-1">
-                  <Kbd className="border-white/20 bg-white/14 text-white shadow-[inset_0_-1px_0_rgba(255,255,255,0.18)]">
-                    Ctrl
-                  </Kbd>
-                  <span className="text-white/65">+</span>
-                  <Kbd className="border-white/20 bg-white/14 text-white shadow-[inset_0_-1px_0_rgba(255,255,255,0.18)]">
-                    ⏎
-                  </Kbd>
-                </KbdGroup>
-              )}
-            </Button>
+            <SubmitButton submitting={submitting} label="Save Changes" busyLabel="Saving..." />
           </DialogFooter>
         </form>
       </DialogContent>

--- a/my-app/src/components/favorite-toggle.tsx
+++ b/my-app/src/components/favorite-toggle.tsx
@@ -6,7 +6,7 @@ import { useMutation } from "convex/react";
 import type { OptimisticLocalStore } from "convex/browser";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
-import { cn, getApiErrorMessage } from "@/lib/utils";
+import { cn, reportApiError } from "@/lib/utils";
 import { toast } from "sonner";
 
 interface FavoriteToggleProps {
@@ -63,10 +63,7 @@ export function FavoriteToggle({
     try {
       await toggleFavorite({ bottleId });
     } catch (err) {
-      if (process.env.NODE_ENV !== "production") {
-        console.error("Failed to toggle favorite:", err);
-      }
-      toast.error(getApiErrorMessage(err));
+      toast.error(reportApiError(err, "Failed to toggle favorite:"));
       // Convex auto-rolls back the optimistic patch on rejection.
     }
   };

--- a/my-app/src/components/form-error-banner.tsx
+++ b/my-app/src/components/form-error-banner.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+/** Form-level error line shown above the dialog footer buttons. */
+export function FormErrorBanner({ message }: { message: string | null }) {
+  if (!message) return null;
+  return (
+    <p
+      role="alert"
+      className="w-full rounded-lg border border-danger/30 bg-danger/5 px-3 py-2.5 text-sm text-danger"
+    >
+      {message}
+    </p>
+  );
+}

--- a/my-app/src/components/form-field.test.tsx
+++ b/my-app/src/components/form-field.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+import { FormField } from "./form-field";
+
+describe("FormField", () => {
+  test("wires label, input, and passthrough props", async () => {
+    const onChange = vi.fn();
+    render(
+      <FormField id="sprays" label="Sprays *" type="number" value="3" onChange={onChange} min="1" />,
+    );
+    const input = screen.getByLabelText("Sprays *");
+    expect(input).toHaveValue(3);
+    expect(input).toHaveAttribute("aria-invalid", "false");
+    await userEvent.type(input, "1");
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  test("shows the error state", () => {
+    render(
+      <FormField id="sprays" label="Sprays *" error="Must be between 1 and 100" value="" onChange={() => {}} />,
+    );
+    const input = screen.getByLabelText("Sprays *");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("aria-describedby", "sprays-error");
+    expect(screen.getByRole("alert")).toHaveTextContent("Must be between 1 and 100");
+  });
+});

--- a/my-app/src/components/form-field.test.tsx
+++ b/my-app/src/components/form-field.test.tsx
@@ -7,7 +7,14 @@ describe("FormField", () => {
   test("wires label, input, and passthrough props", async () => {
     const onChange = vi.fn();
     render(
-      <FormField id="sprays" label="Sprays *" type="number" value="3" onChange={onChange} min="1" />,
+      <FormField
+        id="sprays"
+        label="Sprays *"
+        type="number"
+        value="3"
+        onChange={onChange}
+        min="1"
+      />,
     );
     const input = screen.getByLabelText("Sprays *");
     expect(input).toHaveValue(3);
@@ -18,7 +25,13 @@ describe("FormField", () => {
 
   test("shows the error state", () => {
     render(
-      <FormField id="sprays" label="Sprays *" error="Must be between 1 and 100" value="" onChange={() => {}} />,
+      <FormField
+        id="sprays"
+        label="Sprays *"
+        error="Must be between 1 and 100"
+        value=""
+        onChange={() => {}}
+      />,
     );
     const input = screen.getByLabelText("Sprays *");
     expect(input).toHaveAttribute("aria-invalid", "true");

--- a/my-app/src/components/form-field.tsx
+++ b/my-app/src/components/form-field.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+interface FormFieldProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "id"> {
+  id: string;
+  label: string;
+  /** Validation error; when set, label/input/message render in the danger state. */
+  error?: string;
+}
+
+/**
+ * Labeled input with a reserved, absolutely-positioned error line beneath it
+ * (`role="alert"`, id `` `${id}-error` ``), matching the dialog form styling.
+ */
+export function FormField({ id, label, error, className, ...inputProps }: FormFieldProps) {
+  const errorId = `${id}-error`;
+  return (
+    <div className="relative space-y-2">
+      <Label htmlFor={id} className={error ? "text-danger" : ""}>
+        {label}
+      </Label>
+      <Input
+        id={id}
+        className={cn(error && "border-danger focus:border-danger focus:ring-danger", className)}
+        aria-invalid={!!error}
+        aria-describedby={errorId}
+        {...inputProps}
+      />
+      <p
+        id={errorId}
+        role="alert"
+        className={cn(
+          "absolute -bottom-3 left-0 text-xs text-danger transition-opacity",
+          error ? "opacity-100" : "opacity-0 pointer-events-none",
+        )}
+      >
+        {error ?? " "}
+      </p>
+    </div>
+  );
+}

--- a/my-app/src/components/markdown-hint.tsx
+++ b/my-app/src/components/markdown-hint.tsx
@@ -1,0 +1,8 @@
+/** Markdown syntax hint shown under dialog comment textareas. */
+export function MarkdownHint() {
+  return (
+    <p className="text-xs text-text-secondary/50">
+      Markdown supported: **bold**, *italic*, [link text](url), - lists
+    </p>
+  );
+}

--- a/my-app/src/components/submit-button.test.tsx
+++ b/my-app/src/components/submit-button.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { SubmitButton } from "./submit-button";
+import { FormErrorBanner } from "./form-error-banner";
+
+describe("SubmitButton", () => {
+  test("idle: shows label and Ctrl+Enter hint, enabled", () => {
+    render(<SubmitButton submitting={false} label="Log Wear" busyLabel="Logging..." />);
+    const button = screen.getByRole("button", { name: /Log Wear/ });
+    expect(button).toBeEnabled();
+    expect(button).toHaveAttribute("aria-keyshortcuts", "Control+Enter");
+    expect(button).toHaveTextContent("Ctrl");
+  });
+
+  test("submitting: shows busy label, disabled, no hint", () => {
+    render(<SubmitButton submitting label="Log Wear" busyLabel="Logging..." />);
+    const button = screen.getByRole("button", { name: "Logging..." });
+    expect(button).toBeDisabled();
+    expect(button).not.toHaveTextContent("Ctrl");
+  });
+});
+
+describe("FormErrorBanner", () => {
+  test("renders nothing without a message", () => {
+    const { container } = render(<FormErrorBanner message={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("renders the message as an alert", () => {
+    render(<FormErrorBanner message="Something went wrong. Please try again." />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Something went wrong. Please try again.");
+  });
+});

--- a/my-app/src/components/submit-button.tsx
+++ b/my-app/src/components/submit-button.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+
+const KBD_CLASS =
+  "border-white/20 bg-white/14 text-white shadow-[inset_0_-1px_0_rgba(255,255,255,0.18)]";
+
+interface SubmitButtonProps {
+  submitting: boolean;
+  /** Button text at rest, e.g. "Log Wear". */
+  label: string;
+  /** Button text while the mutation is in flight, e.g. "Logging...". */
+  busyLabel: string;
+}
+
+/** Dialog submit button with the Ctrl+Enter hint chips. */
+export function SubmitButton({ submitting, label, busyLabel }: SubmitButtonProps) {
+  return (
+    <Button type="submit" disabled={submitting} aria-keyshortcuts="Control+Enter">
+      <span>{submitting ? busyLabel : label}</span>
+      {!submitting && (
+        <KbdGroup aria-hidden="true" className="ml-1">
+          <Kbd className={KBD_CLASS}>Ctrl</Kbd>
+          <span className="text-white/65">+</span>
+          <Kbd className={KBD_CLASS}>⏎</Kbd>
+        </KbdGroup>
+      )}
+    </Button>
+  );
+}

--- a/my-app/src/components/wear-log-list.tsx
+++ b/my-app/src/components/wear-log-list.tsx
@@ -5,13 +5,12 @@ import { useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { cn } from "@/lib/utils";
+import { cn, reportApiError } from "@/lib/utils";
 import { EditWearLogDialog } from "@/components/edit-wear-log-dialog";
 import { MarkdownContent } from "@/components/markdown-content";
 import { Droplets, Calendar, Star, MessageSquare, Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-import { getApiErrorMessage } from "@/lib/utils";
 import { formatWearDate, formatWearTime } from "@/lib/format";
 
 interface WearLogListProps {
@@ -45,10 +44,7 @@ export function WearLogList({ logs }: WearLogListProps) {
       setDeletingId(null);
     } catch (err) {
       setDeletingId(null);
-      if (process.env.NODE_ENV !== "production") {
-        console.error("Failed to delete wear log:", err);
-      }
-      toast.error(getApiErrorMessage(err));
+      toast.error(reportApiError(err, "Failed to delete wear log:"));
     }
   };
 

--- a/my-app/src/components/wear-log-list.tsx
+++ b/my-app/src/components/wear-log-list.tsx
@@ -5,10 +5,11 @@ import { useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { cn, reportApiError } from "@/lib/utils";
+import { reportApiError } from "@/lib/utils";
+import { ConfirmDeleteButton } from "@/components/confirm-delete-button";
 import { EditWearLogDialog } from "@/components/edit-wear-log-dialog";
 import { MarkdownContent } from "@/components/markdown-content";
-import { Droplets, Calendar, Star, MessageSquare, Pencil, Trash2 } from "lucide-react";
+import { Droplets, Calendar, Star, MessageSquare, Pencil } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { formatWearDate, formatWearTime } from "@/lib/format";
@@ -125,31 +126,15 @@ export function WearLogList({ logs }: WearLogListProps) {
                   >
                     <Pencil className="h-3.5 w-3.5" />
                   </Button>
-                  <Button
-                    variant={deletingId === log._id ? "destructive" : "ghost"}
+                  <ConfirmDeleteButton
+                    confirming={deletingId === log._id}
                     onClick={() => handleDelete(log._id)}
                     onMouseLeave={() => setDeletingId(null)}
-                    aria-label={
-                      deletingId === log._id ? "Confirm delete wear log" : "Delete wear log"
-                    }
-                    className={cn(
-                      "h-8 transition-all duration-300 ease-out opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 shrink-0 overflow-hidden relative gap-0",
-                      deletingId === log._id ? "w-[100px] px-3" : "w-8 px-0 justify-center",
-                    )}
-                  >
-                    <Trash2 className="h-3.5 w-3.5 shrink-0 z-10" />
-                    <span
-                      aria-hidden={deletingId !== log._id}
-                      className={cn(
-                        "overflow-hidden transition-all duration-300 ease-out whitespace-nowrap text-xs flex items-center z-10",
-                        deletingId === log._id
-                          ? "w-[56px] ml-1.5 opacity-100"
-                          : "w-0 ml-0 opacity-0",
-                      )}
-                    >
-                      Confirm
-                    </span>
-                  </Button>
+                    idleLabel="Delete wear log"
+                    confirmLabel="Confirm delete wear log"
+                    size="compact"
+                    className="opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100"
+                  />
                 </div>
               </div>
             ))}

--- a/my-app/src/components/wear-log-list.tsx
+++ b/my-app/src/components/wear-log-list.tsx
@@ -12,6 +12,7 @@ import { Droplets, Calendar, Star, MessageSquare, Pencil, Trash2 } from "lucide-
 import { useState } from "react";
 import { toast } from "sonner";
 import { getApiErrorMessage } from "@/lib/utils";
+import { formatWearDate, formatWearTime } from "@/lib/format";
 
 interface WearLogListProps {
   logs: Doc<"wearLogs">[];
@@ -51,23 +52,6 @@ export function WearLogList({ logs }: WearLogListProps) {
     }
   };
 
-  const formatDate = (timestamp: number) => {
-    const d = new Date(timestamp);
-    return d.toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: d.getFullYear() !== new Date().getFullYear() ? "numeric" : undefined,
-    });
-  };
-
-  const formatTime = (timestamp: number) => {
-    const d = new Date(timestamp);
-    return d.toLocaleTimeString("en-US", {
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  };
-
   // Group logs by date
   const grouped = logs.reduce(
     (acc, log) => {
@@ -85,7 +69,7 @@ export function WearLogList({ logs }: WearLogListProps) {
         <div key={dateKey}>
           {groupIdx > 0 && <Separator className="mb-5" />}
           <p className="text-xs font-medium text-text-secondary uppercase tracking-wider mb-3">
-            {formatDate(dateLogs[0].wornAt)}
+            {formatWearDate(dateLogs[0].wornAt)}
           </p>
           <div className="space-y-3">
             {dateLogs.map((log, i) => (
@@ -106,7 +90,7 @@ export function WearLogList({ logs }: WearLogListProps) {
                       </span>
                     </div>
 
-                    <span className="text-xs text-text-secondary">{formatTime(log.wornAt)}</span>
+                    <span className="text-xs text-text-secondary">{formatWearTime(log.wornAt)}</span>
 
                     {log.context && (
                       <span className="text-xs text-text-secondary bg-surface-alt px-2.5 py-1 rounded-md">

--- a/my-app/src/components/wear-log-list.tsx
+++ b/my-app/src/components/wear-log-list.tsx
@@ -87,7 +87,9 @@ export function WearLogList({ logs }: WearLogListProps) {
                       </span>
                     </div>
 
-                    <span className="text-xs text-text-secondary">{formatWearTime(log.wornAt)}</span>
+                    <span className="text-xs text-text-secondary">
+                      {formatWearTime(log.wornAt)}
+                    </span>
 
                     {log.context && (
                       <span className="text-xs text-text-secondary bg-surface-alt px-2.5 py-1 rounded-md">

--- a/my-app/src/lib/constants.ts
+++ b/my-app/src/lib/constants.ts
@@ -1,5 +1,8 @@
 export const MAX_SPRAYS = 100;
 
+/** Sentinel for "no context selected" — Radix Select items can't use "" as a value. */
+export const NO_CONTEXT_VALUE = "__none__";
+
 export const CONTEXT_OPTIONS = [
   "Office",
   "Date Night",
@@ -9,4 +12,4 @@ export const CONTEXT_OPTIONS = [
   "Evening Out",
   "Travel",
   "Special Occasion",
-];
+] as const;

--- a/my-app/src/lib/format.test.ts
+++ b/my-app/src/lib/format.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { formatWearDate, formatWearTime } from "./format";
+
+const CURRENT_YEAR = new Date().getFullYear();
+
+describe("formatWearDate", () => {
+  test("omits the year for dates in the current year", () => {
+    const ts = new Date(CURRENT_YEAR, 5, 14, 12, 0).getTime(); // Jun 14
+    expect(formatWearDate(ts)).toBe("Jun 14");
+  });
+
+  test("includes the year for dates in other years", () => {
+    const ts = new Date(CURRENT_YEAR - 1, 0, 5, 12, 0).getTime(); // Jan 5 last year
+    expect(formatWearDate(ts)).toBe(`Jan 5, ${CURRENT_YEAR - 1}`);
+  });
+
+  test("prepends a short weekday when requested", () => {
+    const ts = new Date(CURRENT_YEAR - 1, 0, 5, 12, 0).getTime();
+    const result = formatWearDate(ts, { weekday: true });
+    expect(result).toMatch(/^\w{3}, Jan 5, \d{4}$/);
+  });
+});
+
+describe("formatWearTime", () => {
+  test("formats hour:minute with AM/PM", () => {
+    const ts = new Date(CURRENT_YEAR, 5, 14, 14, 30).getTime();
+    expect(formatWearTime(ts)).toBe("2:30 PM");
+  });
+});

--- a/my-app/src/lib/format.ts
+++ b/my-app/src/lib/format.ts
@@ -1,0 +1,22 @@
+/**
+ * Formats a wear-log timestamp as e.g. "Jun 14" (current year) or
+ * "Jan 5, 2025" (other years). Pass { weekday: true } to prepend a short
+ * weekday, e.g. "Mon, Jan 5, 2025".
+ */
+export function formatWearDate(timestamp: number, opts: { weekday?: boolean } = {}): string {
+  const d = new Date(timestamp);
+  return d.toLocaleDateString("en-US", {
+    weekday: opts.weekday ? "short" : undefined,
+    month: "short",
+    day: "numeric",
+    year: d.getFullYear() !== new Date().getFullYear() ? "numeric" : undefined,
+  });
+}
+
+/** Formats a wear-log timestamp as e.g. "2:30 PM". */
+export function formatWearTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}

--- a/my-app/src/lib/use-ctrl-enter-submit.test.tsx
+++ b/my-app/src/lib/use-ctrl-enter-submit.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRef } from "react";
+import { describe, expect, test, vi } from "vitest";
+import { useCtrlEnterSubmit } from "./use-ctrl-enter-submit";
+
+function TestForm({ submitting = false, onSubmit }: { submitting?: boolean; onSubmit: () => void }) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const handleKeyDown = useCtrlEnterSubmit(formRef, submitting);
+  return (
+    <form
+      ref={formRef}
+      onKeyDown={handleKeyDown}
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit();
+      }}
+    >
+      <input aria-label="field" />
+      <textarea aria-label="notes" />
+    </form>
+  );
+}
+
+describe("useCtrlEnterSubmit", () => {
+  test("Ctrl+Enter submits the form", async () => {
+    const onSubmit = vi.fn();
+    render(<TestForm onSubmit={onSubmit} />);
+    await userEvent.type(screen.getByLabelText("field"), "{Control>}{Enter}{/Control}");
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  test("Ctrl+Enter is ignored while submitting", async () => {
+    const onSubmit = vi.fn();
+    render(<TestForm submitting onSubmit={onSubmit} />);
+    await userEvent.type(screen.getByLabelText("field"), "{Control>}{Enter}{/Control}");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test("plain Enter on an input does not submit", async () => {
+    const onSubmit = vi.fn();
+    render(<TestForm onSubmit={onSubmit} />);
+    await userEvent.type(screen.getByLabelText("field"), "{Enter}");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test("plain Enter in a textarea inserts a newline and does not submit", async () => {
+    const onSubmit = vi.fn();
+    render(<TestForm onSubmit={onSubmit} />);
+    const textarea = screen.getByLabelText<HTMLTextAreaElement>("notes");
+    await userEvent.type(textarea, "a{Enter}b");
+    expect(textarea.value).toBe("a\nb");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/my-app/src/lib/use-ctrl-enter-submit.test.tsx
+++ b/my-app/src/lib/use-ctrl-enter-submit.test.tsx
@@ -4,7 +4,13 @@ import { useRef } from "react";
 import { describe, expect, test, vi } from "vitest";
 import { useCtrlEnterSubmit } from "./use-ctrl-enter-submit";
 
-function TestForm({ submitting = false, onSubmit }: { submitting?: boolean; onSubmit: () => void }) {
+function TestForm({
+  submitting = false,
+  onSubmit,
+}: {
+  submitting?: boolean;
+  onSubmit: () => void;
+}) {
   const formRef = useRef<HTMLFormElement>(null);
   const handleKeyDown = useCtrlEnterSubmit(formRef, submitting);
   return (

--- a/my-app/src/lib/use-ctrl-enter-submit.ts
+++ b/my-app/src/lib/use-ctrl-enter-submit.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useCallback, type KeyboardEvent, type RefObject } from "react";
+
+/**
+ * Shared dialog-form keyboard behavior:
+ * - Ctrl+Enter anywhere submits the form (unless a submit is in flight).
+ * - Plain Enter in a textarea inserts a newline as usual.
+ * - Plain Enter on text/number inputs is blocked so it never accidentally
+ *   submits. Buttons, Select triggers, and other interactive controls are
+ *   left unaffected so keyboard users can activate them normally.
+ */
+export function useCtrlEnterSubmit(
+  formRef: RefObject<HTMLFormElement | null>,
+  submitting: boolean,
+): (e: KeyboardEvent<HTMLFormElement>) => void {
+  return useCallback(
+    (e: KeyboardEvent<HTMLFormElement>) => {
+      if (e.key !== "Enter") return;
+
+      if ((e.target as HTMLElement).tagName === "TEXTAREA" && !e.ctrlKey) return;
+
+      if (e.ctrlKey && !e.shiftKey && !e.metaKey) {
+        if (submitting) return;
+        e.preventDefault();
+        formRef.current?.requestSubmit();
+        return;
+      }
+
+      if ((e.target as HTMLElement).tagName === "INPUT") {
+        e.preventDefault();
+      }
+    },
+    [formRef, submitting],
+  );
+}

--- a/my-app/src/lib/use-form-errors.test.tsx
+++ b/my-app/src/lib/use-form-errors.test.tsx
@@ -1,0 +1,32 @@
+// src/lib/use-form-errors.test.tsx
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { useFormErrors } from "./use-form-errors";
+
+describe("useFormErrors", () => {
+  test("clearError removes a single field error", () => {
+    const { result } = renderHook(() => useFormErrors());
+    act(() => result.current.setErrors({ name: "Required", sprays: "Too many" }));
+    act(() => result.current.clearError("name"));
+    expect(result.current.errors).toEqual({ sprays: "Too many" });
+  });
+
+  test("clearError on an absent field keeps state identity (no re-render churn)", () => {
+    const { result } = renderHook(() => useFormErrors());
+    act(() => result.current.setErrors({ name: "Required" }));
+    const before = result.current.errors;
+    act(() => result.current.clearError("missing"));
+    expect(result.current.errors).toBe(before);
+  });
+
+  test("resetErrors clears field errors and the form error", () => {
+    const { result } = renderHook(() => useFormErrors());
+    act(() => {
+      result.current.setErrors({ name: "Required" });
+      result.current.setFormError("Something went wrong");
+    });
+    act(() => result.current.resetErrors());
+    expect(result.current.errors).toEqual({});
+    expect(result.current.formError).toBeNull();
+  });
+});

--- a/my-app/src/lib/use-form-errors.ts
+++ b/my-app/src/lib/use-form-errors.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+/**
+ * Per-field validation errors plus a form-level error banner message,
+ * as used by the add/edit dialogs.
+ */
+export function useFormErrors() {
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const clearError = useCallback((field: string) => {
+    setErrors((prev) => {
+      if (!prev[field]) return prev;
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+  }, []);
+
+  const resetErrors = useCallback(() => {
+    setErrors({});
+    setFormError(null);
+  }, []);
+
+  return { errors, setErrors, clearError, formError, setFormError, resetErrors };
+}

--- a/my-app/src/lib/utils.test.ts
+++ b/my-app/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect } from "vitest";
-import { getApiErrorMessage, isFutureWornAtError } from "./utils";
+import { describe, test, expect, vi, afterEach } from "vitest";
+import { getApiErrorMessage, isFutureWornAtError, reportApiError } from "./utils";
 
 describe("getApiErrorMessage", () => {
   test("returns a user-friendly message for future-date server errors", () => {
@@ -37,5 +37,26 @@ describe("getApiErrorMessage", () => {
   test("returns generic fallback for unknown errors", () => {
     const err = new Error("some unexpected internal error");
     expect(getApiErrorMessage(err)).toBe("Something went wrong. Please try again.");
+  });
+});
+
+describe("reportApiError", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("returns the mapped user-facing message", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const err = new Error("Failed to fetch");
+    expect(reportApiError(err, "Failed to save:")).toBe(
+      "Network error. Please check your connection and try again.",
+    );
+  });
+
+  test("logs the raw error outside production", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const err = new Error("boom");
+    reportApiError(err, "Failed to save:");
+    expect(spy).toHaveBeenCalledWith("Failed to save:", err);
   });
 });

--- a/my-app/src/lib/utils.ts
+++ b/my-app/src/lib/utils.ts
@@ -13,7 +13,7 @@ export function isFutureWornAtError(err: unknown): boolean {
  * Maps API/mutation errors to user-friendly messages.
  * Recognizes rate-limit errors (ConvexError from @convex-dev/rate-limiter)
  * and network/offline errors; falls back to a generic message for everything
- * else.  Raw error details are only logged in non-production environments.
+ * else.
  */
 export function getApiErrorMessage(err: unknown): string {
   // Rate-limit errors thrown by @convex-dev/rate-limiter with throws:true

--- a/my-app/src/lib/utils.ts
+++ b/my-app/src/lib/utils.ts
@@ -5,16 +5,16 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+export function isFutureWornAtError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes("wornAt cannot be in the future");
+}
+
 /**
  * Maps API/mutation errors to user-friendly messages.
  * Recognizes rate-limit errors (ConvexError from @convex-dev/rate-limiter)
  * and network/offline errors; falls back to a generic message for everything
  * else.  Raw error details are only logged in non-production environments.
  */
-export function isFutureWornAtError(err: unknown): boolean {
-  return err instanceof Error && err.message.includes("wornAt cannot be in the future");
-}
-
 export function getApiErrorMessage(err: unknown): string {
   // Rate-limit errors thrown by @convex-dev/rate-limiter with throws:true
   // arrive as a ConvexError whose .data has { kind: "RateLimited", retryAfter }
@@ -41,4 +41,15 @@ export function getApiErrorMessage(err: unknown): string {
   }
 
   return "Something went wrong. Please try again.";
+}
+
+/**
+ * Dev-logs the raw error and returns the user-facing message for it.
+ * Callers decide how to surface the message (toast, form banner, field error).
+ */
+export function reportApiError(err: unknown, logLabel: string): string {
+  if (process.env.NODE_ENV !== "production") {
+    console.error(logLabel, err);
+  }
+  return getApiErrorMessage(err);
 }


### PR DESCRIPTION
## Summary

Pure refactor, zero behavior change. Kills the copy-paste across the three form dialogs, the two confirm-delete buttons, and the Convex mutation boilerplate.

**Frontend extractions** (`src/lib/`, `src/components/`):
- `useFormErrors` + `useCtrlEnterSubmit` hooks (previously copied verbatim in all 3 dialogs)
- `FormField`, `SubmitButton`, `FormErrorBanner`, `ContextSelect`, `MarkdownHint` components
- `formatWearDate`/`formatWearTime` shared formatters
- `ConfirmDeleteButton` (two-step expanding delete, was duplicated in bottle-detail + wear-log-list)
- `reportApiError` (dev-log + message mapping half of every catch block)

**Convex extractions**:
- `getOwnedDoc` ownership helper (6 mutations; thrown error strings byte-identical)
- `buildPatch` (null-clears/undefined-skips patch builder for both update mutations)
- `assertValidWearLogStrings` (dedupes comment/context length checks)

Dialogs shrink ~1050 → ~600 lines. Plan: `docs/superpowers/plans/2026-07-05-shared-components-refactor.md` (not in this branch).

**Known accepted tweaks** (called out in review):
- add-bottle Size error line moves `top-full mt-1` → `-bottom-3` (~0.5rem nudge)
- Brand field gains an inert reserved error slot via FormField
- confirm-delete "Confirm" span now `aria-hidden={!confirming}` at both sites (was hard-coded `true` in bottle-detail)

## Test plan

- [x] Full suite: 164/164 vitest tests (17 files) across edge-runtime + jsdom projects
- [x] `tsc --noEmit`, `eslint`, `prettier --check` all clean
- [x] Per-task + whole-branch code review (verdict: ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)