### PR TITLE
MCP spike: pin deps + verified mcp-handler/jose findings

### DIFF
--- a/docs/mcp-server-plan.md
+++ b/docs/mcp-server-plan.md
@@ -1,0 +1,287 @@
+# MCP Server Plan (issue #65)
+
+## 1. Context & goals
+
+Issue #65: "Expose CRUD operations and logging via MCP to agents."
+
+Users should be able to connect their own AI agents — claude.ai (web/desktop), Claude Code, ChatGPT, Codex CLI, openclaw/hermes — to a remote MCP server that lets those agents:
+
+1. **CRUD** their bottle collection and wear logs (add a bottle from chat, log a wear, edit, delete).
+2. **Get transformative insights** the web app doesn't render: summaries, rotation gaps, seasonal patterns, "what should I wear tonight", cost-per-wear analysis, etc.
+
+Insights are computed by the **connecting agent**, not by us. The server's job is to expose well-shaped data tools so the agent can do one-shot analysis without paging through raw rows. No server-side LLM calls → no per-call AI cost for us.
+
+### Decisions
+
+| Decision | Choice |
+|---|---|
+| Auth | **Full OAuth 2.1 from day one** (required by claude.ai + ChatGPT connectors) plus personal access tokens (PATs) for header-based CLI clients |
+| Hosting | **Next.js route on Vercel** via `mcp-handler` (streamable HTTP, stateless — no Redis, no SSE transport) |
+| Tool scope | **CRUD + insight-shaped read tools** (stats, filtered history, compact snapshot); no server-side AI |
+
+### Viability & cost
+
+- **Viable: yes.** One architectural unlock (§3.1) means the entire existing Convex data layer is reused unchanged. The real work is the OAuth 2.1 authorization server, which is well-specified (RFC 6749/7591/8414/9728 + PKCE) and testable endpoint-by-endpoint.
+- **Cost: ~zero incremental.** MCP calls = ordinary Vercel serverless invocations + Convex function calls (same free tier the web app uses; Convex free tier is 1M function calls/mo). OAuth access-token verification is a *local* JWT signature check — no DB hit per MCP request. PAT path adds one small indexed Convex query per request. New tables store byte-scale rows. No LLM spend ever. Only at-scale risk is an agent polling aggressively burning quota — the existing per-user rate limiter already covers writes, and we add limits on the OAuth endpoints.
+- **Effort: ~4.5–5 focused days** across 6 phases.
+
+## 2. Current state (verified)
+
+- Next.js 16 App Router in `my-app/`, Vercel-hosted, Bun, TypeScript, Tailwind 4.
+- Backend: **Convex** (`convex@^1.42`). Tables `bottles` + `wearLogs` (`convex/schema.ts`).
+- Auth: **Convex Auth** (`@convex-dev/auth@0.0.91`) with Google OAuth only; browser-session based; `convex/http.ts` mounts only the OAuth callback. No API tokens, no REST surface, no MCP anywhere.
+- Data access: `convex/bottles.ts` (list/get/add/update/delete/toggleFavorite) and `convex/wearLogs.ts` (listBottleStats/listWearLogs/listWearLogsByBottle/get/add/update/delete). Every function resolves the caller via `getUserId`/`getOptionalUserId` (`convex/helpers.ts`), verifies ownership via `getOwnedDoc`, applies partial updates via `buildPatch` (`convex/patch.ts`), validates inline (`assertValidBottleInput`, `assertValidWornAt`, …), and rate-limits writes via `convex/rateLimits.ts`.
+- Middleware `src/proxy.ts`: only `/` is protected; matcher excludes dotted paths (so `/.well-known/*` bypasses it) and passes `/api/*` through without redirects.
+- Tests: Vitest + `convex-test`, edge-runtime env; `convex/test.setup.ts` already fakes identities as `subject: "${userId}|testSession"`.
+
+## 3. Architecture
+
+### 3.1 The key unlock: `customJwt` provider → zero data-layer refactor
+
+Two verified facts drive the whole design:
+
+1. `getAuthUserId()` in `@convex-dev/auth@0.0.91` is literally `identity.subject.split("|")[0]` — no session lookup at query time.
+2. Convex supports registering additional **`customJwt` auth providers** (`{type: "customJwt", applicationID, issuer, jwks, algorithm}`) alongside Convex Auth. JWTs from that issuer surface through `ctx.auth.getUserIdentity()` exactly like Convex Auth's own.
+
+So: we mint OAuth access tokens as **RS256 JWTs under a dedicated MCP keypair** (not reusing Convex Auth's `JWT_PRIVATE_KEY` — cleaner key hygiene, no coupling to its rotation), with `sub = "${userId}|mcp:${grantId}"`. Register our issuer + JWKS in `convex/auth.config.ts`. Then MCP tool handlers simply do `ConvexHttpClient.setAuth(accessToken)` and call the **existing public functions unchanged** — `getUserId`, `getOwnedDoc`, all validators, and all rate limits apply automatically.
+
+```ts
+// convex/auth.config.ts (after)
+const authConfig = {
+  providers: [
+    { domain: process.env.CONVEX_SITE_URL, applicationID: "convex" },
+    {
+      type: "customJwt",
+      applicationID: "fragrances-mcp",
+      issuer: process.env.MCP_JWT_ISSUER,   // https://<app-domain>
+      jwks: process.env.MCP_JWKS_URL,       // https://<app-domain>/api/oauth/jwks
+      algorithm: "RS256",
+    },
+  ],
+};
+```
+
+Access-token claims: `sub = userId|mcp:grantId`, `iss = MCP_JWT_ISSUER`, `aud = "fragrances-mcp"`, `exp` = 15 min, plus `client_id` and `scope`.
+
+Rejected alternatives:
+- *Opaque tokens + token-arg Convex functions*: would force a parallel "takes token" variant of every function — max churn, no security win.
+- *Reusing Convex Auth's `JWT_PRIVATE_KEY`*: works (fabricated sessionId is never checked) but means copying Convex's signing key into Vercel env and coupling to its internals.
+
+### 3.2 OAuth 2.1 authorization server (lives in the Next.js app)
+
+Everything on one origin (Vercel app domain = issuer = resource host):
+
+```
+Agent (claude.ai / ChatGPT / Claude Code)
+  │ 1. GET /api/mcp → 401 + WWW-Authenticate → resource metadata
+  │ 2. GET /.well-known/oauth-protected-resource[/api/mcp]   (RFC 9728)
+  │ 3. GET /.well-known/oauth-authorization-server            (RFC 8414)
+  │ 4. POST /api/oauth/register                               (RFC 7591 DCR, public client, no secret)
+  │ 5. Browser → /oauth/authorize?...&code_challenge=S256:…
+  │      ├─ not signed in → redirect /signin?redirect=… → Google → back
+  │      └─ consent page → approve → 302 redirect_uri?code=…
+  │ 6. POST /api/oauth/token (code + code_verifier) → { access_token (JWT, 15m),
+  │                                                     refresh_token (opaque, rotated) }
+  │ 7. MCP requests with Authorization: Bearer <JWT>
+  └ 8. POST /api/oauth/token (refresh_token grant) when expired
+```
+
+- **PKCE S256 required**; `token_endpoint_auth_method: "none"` (public clients, per MCP spec).
+- **Consent page** (`/oauth/authorize`, server component): requires the existing Convex Auth browser session; shows client name (from `oauthClients`) + signed-in email; approval runs a server action that mints the auth code via an authed Convex mutation.
+- **Refresh tokens**: opaque, SHA-256-hashed in Convex, **rotated on every use**; reuse of a rotated token revokes the whole grant (stolen-token detection). 90-day expiry.
+- **Revocation model**: access tokens expire in 15 min (not individually revocable); grants + refresh tokens + PATs revocable instantly from settings UI.
+- **Crypto placement**: Convex's default runtime lacks async `crypto.subtle`, so all hashing/randomness happens in Next.js route handlers; Convex functions only store and compare pre-computed hashes.
+
+### 3.3 Dual-mode bearer verification
+
+`src/lib/mcp/verify-token.ts`, plugged into `withMcpAuth`:
+
+```ts
+export async function verifyMcpToken(_req: Request, bearer?: string): Promise<McpAuthInfo | undefined> {
+  if (!bearer) return undefined;
+
+  if (bearer.startsWith("fgt_")) {
+    // Personal access token: hash → Convex lookup → 5-min bridge JWT
+    const tokenHash = await sha256Hex(bearer);
+    const pat = await convex.query(api.apiTokens.validate, { tokenHash }); // null if revoked/expired
+    if (!pat) return undefined;
+    const convexToken = await mintConvexJwt(pat.userId, `pat:${pat.tokenId}`, 300);
+    return { token: bearer, clientId: "personal-access-token", scopes: pat.scopes,
+             extra: { userId: pat.userId, convexToken } };
+  }
+
+  // OAuth access token: local JWT verify, no DB hit; the JWT IS the Convex credential
+  const { payload } = await jwtVerify(bearer, await getPublicKey(), {
+    issuer: process.env.MCP_JWT_ISSUER, audience: "fragrances-mcp",
+  });
+  const [userId] = (payload.sub as string).split("|");
+  return { token: bearer, clientId: payload.client_id as string,
+           scopes: ((payload.scope as string) ?? "").split(" ").filter(Boolean),
+           extra: { userId, convexToken: bearer } };
+}
+```
+
+PAT format: `fgt_` + 32 random bytes base64url. Shown once at creation; only the hash persists.
+
+### 3.4 MCP endpoint
+
+`src/app/api/[transport]/route.ts` → serves `/api/mcp`:
+
+```ts
+const handler = createMcpHandler(
+  (server) => {
+    // NOTE (spike C2): use registerTool, NOT the deprecated server.tool(...) —
+    // see docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md.
+    server.registerTool("add_bottle",
+      { description: "Add a fragrance bottle to the user's collection…", inputSchema: addBottleShape },
+      async (args, { authInfo }) => {
+        const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+        convex.setAuth((authInfo!.extra as McpExtra).convexToken);
+        const id = await convex.mutation(api.bottles.addBottle, args);
+        return { content: [{ type: "text", text: JSON.stringify({ bottleId: id }) }] };
+      });
+    // …12 more tools, same shape
+  },
+  {},
+  { basePath: "/api", maxDuration: 60 },
+);
+const authed = withMcpAuth(handler, verifyMcpToken, {
+  required: true,
+  resourceMetadataPath: "/.well-known/oauth-protected-resource",
+});
+export { authed as GET, authed as POST };
+```
+
+Tool handler errors: catch `ConvexError`/`Error` and return `{ isError: true, content: [{type:"text", text: message}] }` so agents can self-correct (e.g. bad ID, validation bound, rate limit).
+
+## 4. Data model — 5 new Convex tables
+
+| Table | Fields | Indexes | Notes |
+|---|---|---|---|
+| `oauthClients` | `clientId` (32B hex), `clientName`, `redirectUris: string[]`, `tokenEndpointAuthMethod: "none"`, `createdAt` | `by_client_id` | From DCR. redirect URIs must be `https:` or `http://localhost*` |
+| `oauthAuthCodes` | `codeHash`, `clientId`, `userId`, `redirectUri`, `codeChallenge`, `scope`, `resource?`, `expiresAt` (10 min), `usedAt?` | `by_code_hash` | Single-use enforced via `usedAt` |
+| `oauthGrants` | `userId`, `clientId`, `clientName` (denormalized), `scope`, `createdAt`, `lastUsedAt?`, `revokedAt?` | `by_user`, `by_user_client` | Backs the settings "Connected apps" list |
+| `oauthRefreshTokens` | `tokenHash`, `grantId`, `userId`, `clientId`, `expiresAt` (90 d), `revokedAt?`, `replacedBy?` | `by_token_hash`, `by_grant` | Rotation chain; reuse detection |
+| `personalAccessTokens` | `userId`, `tokenHash`, `name`, `scopes`, `createdAt`, `lastUsedAt?`, `expiresAt?`, `revokedAt?` | `by_token_hash`, `by_user` | Header-auth clients |
+
+All secrets stored **hashed only**; raw values returned exactly once.
+
+## 5. Tool surface (13 tools)
+
+### Reusing existing Convex functions unchanged
+
+| Tool | Input schema (zod, mirrors server bounds) | Convex fn |
+|---|---|---|
+| `list_bottles` | `{}` | `api.bottles.listBottles` |
+| `get_bottle` | `{ bottleId: string }` | `api.bottles.getBottle` |
+| `add_bottle` | `{ name: 1–200, brand? ≤200, sizeMl? >0 ≤10000, tags? ≤20×≤50, comments? ≤2000 }` | `api.bottles.addBottle` |
+| `update_bottle` | same, all optional; clearable fields `.nullable()` (null clears — matches `buildPatch`) + `bottleId` | `api.bottles.updateBottle` |
+| `delete_bottle` | `{ bottleId }` (cascades wear logs — say so in description) | `api.bottles.deleteBottle` |
+| `toggle_favorite` | `{ bottleId }` | `api.bottles.toggleFavorite` |
+| `add_wear_log` | `{ bottleId, wornAt: epoch-ms (description explains ISO→ms), sprays: int 1–100, context? ≤200, rating? 1–10, comment? ≤2000 }` | `api.wearLogs.addWearLog` |
+| `update_wear_log` | partial, `.nullable()` clearables + `wearLogId` | `api.wearLogs.updateWearLog` |
+| `delete_wear_log` | `{ wearLogId }` | `api.wearLogs.deleteWearLog` |
+
+IDs pass through as opaque strings (Convex `v.id()` validates); descriptions tell agents to get IDs from `list_bottles`. Zod gives early feedback; Convex validators stay authoritative.
+
+### New insight queries — `convex/insights.ts`
+
+| Tool | Input | Behavior |
+|---|---|---|
+| `list_wear_logs` | `{ bottleId?, from?: ms, to?: ms, limit: int ≤500 = 100 }` | Range query on `by_user_time` / `by_user_bottle_time` (`.gte/.lte` + `.take`) |
+| `get_collection_stats` | `{}` | Per-bottle `{name, brand, wears, sprays, avgRating, lastWornAt}` (reuse `listBottleStats` aggregation) + totals: bottle count, total wears/sprays, most/least worn, favorites, unworn bottles |
+| `get_collection_snapshot` | `{ recentLogsPerBottle: int ≤20 = 5 }` | Compact full export — every bottle + stats + N recent logs each. Built for one-shot agent analysis (summaries, rotation gaps, seasonal patterns) |
+
+### Rate limits (`convex/rateLimits.ts` additions)
+
+| Limit | Key | Rate |
+|---|---|---|
+| `oauthRegister` | IP (`x-forwarded-for` passed from route) | ~5/hour |
+| `oauthTokenExchange` | IP | ~30/min |
+| `createApiToken` | user | small burst |
+
+Existing per-user write limits (addBottle, addWearLog, …) apply to MCP traffic automatically.
+
+## 6. Files
+
+**Packages to add:** `mcp-handler@1.1.0`, `@modelcontextprotocol/sdk@1.26.0` (mcp-handler pins this **exact** peer — do not float), `zod@^4` (spike C1: `zod@^3` triggers `TS2589`), `jose`. Verified pins in `docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md`.
+
+**Env vars:**
+- Vercel: `MCP_JWT_PRIVATE_KEY` (PKCS8 PEM), `NEXT_PUBLIC_APP_URL` (origin/issuer).
+- Convex dashboard: `MCP_JWT_ISSUER`, `MCP_JWKS_URL`.
+- Keypair generated by a one-off documented script (not committed).
+
+```
+my-app/convex/
+  schema.ts                  (mod) +5 tables
+  auth.config.ts             (mod) +customJwt provider
+  rateLimits.ts              (mod) +3 limits
+  oauth.ts                   (new) registerClient, getClientPublic, createAuthCode (authed),
+                                   exchangeAuthCode (single-use + PKCE-hash compare),
+                                   rotateRefreshToken (reuse ⇒ revoke grant),
+                                   listGrants (authed), revokeGrant (authed)
+  apiTokens.ts               (new) create (authed) / validate (by hash) / list / revoke
+  insights.ts                (new) listWearLogsFiltered, collectionStats, collectionSnapshot
+  oauth.test.ts apiTokens.test.ts insights.test.ts   (new, convex-test)
+  crons.ts                   (new, optional) purge expired codes / rotated tokens
+
+my-app/src/app/
+  api/[transport]/route.ts                                   (new) MCP endpoint /api/mcp
+  api/oauth/register/route.ts                                (new) RFC 7591 DCR
+  api/oauth/token/route.ts                                   (new) code + refresh grants, PKCE, JWT mint
+  api/oauth/jwks/route.ts                                    (new) public JWKS
+  .well-known/oauth-authorization-server/route.ts            (new) RFC 8414 (+CORS/OPTIONS)
+  .well-known/oauth-protected-resource/[[...path]]/route.ts  (new) RFC 9728 root + /api/mcp variant
+  oauth/authorize/page.tsx (+ consent-form.tsx, actions.ts)  (new) consent screen
+  settings/connections/page.tsx (+ client components)        (new) grants + PATs UI
+
+my-app/src/lib/mcp/
+  tokens.ts            (new) sha256Hex, randomToken, mintConvexJwt, getPublicKey
+  verify-token.ts      (new) dual-mode verifier
+  oauth-validation.ts  (new) redirect_uri exact match, PKCE compute, request parsing (+unit tests)
+
+my-app/src/proxy.ts                          (mod) protect /oauth/authorize; keep /api/* passing through
+my-app/src/app/signin/page.tsx
+my-app/src/components/sign-in-screen.tsx     (mod) honor ?redirect= via signIn("google", { redirectTo })
+```
+
+Reused as-is: `getUserId`/`getOwnedDoc` (`convex/helpers.ts`), `buildPatch` (`convex/patch.ts`), inline validators, `rateLimits.ts`, `test.setup.ts` identity helper.
+
+## 7. Execution: sub-plans (~4.5–5 days)
+
+This document is the **epic architecture spec**. Implementation is broken into five executable checkbox plans in `docs/superpowers/plans/` (run in order; 1 must finish first — its findings may correct API assumptions in 2–4; 3 and 4 can run in parallel after 2):
+
+- [ ] **1. Compatibility spike (0.5d)** — [`2026-07-06-mcp-1-compat-spike.md`](superpowers/plans/2026-07-06-mcp-1-compat-spike.md): pin `mcp-handler`/SDK/zod/jose, verify tool-registration API (`registerTool` vs `tool`), `withMcpAuth`/401 shape, `authInfo.extra` passthrough, jose RS256+JWKS recipe. Produces findings doc `2026-07-06-mcp-0-spike-findings.md`.
+- [ ] **2. OAuth + token foundation (1.5d)** — [`2026-07-06-mcp-2-oauth-foundation.md`](superpowers/plans/2026-07-06-mcp-2-oauth-foundation.md): tables, crypto/JWT helpers (raw secrets + hashing in Next only; Convex compares hashes), `oauth.ts`/`apiTokens.ts` test-first (single-use codes, PKCE mismatch, rotation reuse revocation, PAT revocation), customJwt provider, JWKS/metadata/DCR/token endpoints with exact RFC 6749 error semantics + CORS.
+- [ ] **3. Insights + MCP tools (1d)** — [`2026-07-06-mcp-3-insights-mcp-tools.md`](superpowers/plans/2026-07-06-mcp-3-insights-mcp-tools.md): `insights.ts` (new aggregation — `listBottleStats` lacks `lastWornAt` and stays untouched), dual-mode verifier, zod schemas, `/api/mcp` with 12 tools (13 in §5 double-counts `list_wear_logs`). Scopes carried, not enforced (v1, §10).
+- [ ] **4. Consent + sign-in redirect + settings UI (1d)** — [`2026-07-06-mcp-4-consent-settings-ui.md`](superpowers/plans/2026-07-06-mcp-4-consent-settings-ui.md): safe `?redirect=` passthrough (sign-in currently always lands on `/`), `/oauth/authorize` with locked render-vs-bounce error semantics + `state` passthrough, `/settings/connections` (first settings route) + header nav.
+- [ ] **5. Verification + docs (0.5–1d)** — [`2026-07-06-mcp-5-verification-docs.md`](superpowers/plans/2026-07-06-mcp-5-verification-docs.md): smoke script, inspector/Claude Code/claude.ai/ChatGPT checklists, local-JWKS strategy (dedicated dev keypair published via `MCP_EXTRA_PUBLIC_JWKS` — no private-key reuse), README + key rotation docs.
+
+## 8. Verification
+
+- CI parity in `my-app/`: `bun run typecheck && bun run lint && bun run test:run && bun run build`.
+- Endpoint-level: curl the metadata, DCR, and token routes; assert error paths (bad PKCE, reused code, revoked PAT).
+- End-to-end local: `bun dev` + `bunx convex dev`; `npx @modelcontextprotocol/inspector` → `http://localhost:3000/api/mcp` (exercises 401 → discovery → DCR → PKCE → consent → tools).
+- Claude Code, both auth modes:
+  - `claude mcp add --transport http fragrances https://<app>/api/mcp` (OAuth)
+  - `claude mcp add --transport http fragrances https://<app>/api/mcp --header "Authorization: Bearer fgt_…"` (PAT)
+- Production: claude.ai custom connector + ChatGPT developer-mode connector; run "summarize my collection / what should I wear tonight" prompts and confirm insight tools fire.
+- **Local-dev caveat:** Convex Cloud must fetch our JWKS, and localhost is unreachable from it. Options: point the dev deployment's `MCP_JWKS_URL` at the deployed prod JWKS (same keypair), or tunnel (cloudflared). Document the chosen route in README.
+
+## 9. Risks & mitigations
+
+| # | Risk | Mitigation |
+|---|---|---|
+| 1 | `sub = "userId\|…"` split is a Convex Auth internal | Version pinned; repo tests already depend on the format — a breaking bump fails loudly |
+| 2 | MCP tokens are full Convex credentials (scopes not enforced Convex-side) | Acceptable now (all functions are user-scoped). Future: enforce `scope` claim via `ctx.auth.getUserIdentity()` custom claims |
+| 3 | `mcp-handler` API drift (`withMcpAuth`, metadata helpers) | ~~Verify against installed version~~ **Verified in spike (C4):** `withMcpAuth` present; RFC 9728 route uses shipped `protectedResourceHandler` + `metadataCorsOptionsRequestHandler` helpers. Only RFC 8414 auth-server metadata is hand-rolled |
+| 4 | claude.ai/ChatGPT connector quirks (path-suffixed PRM lookups, CORS on metadata, exact redirect URIs) | Catch-all PRM route; CORS + OPTIONS on all metadata; inspector-first testing |
+| 5 | Local-dev JWKS reachability | See §8 caveat |
+| 6 | DCR spam / abuse | IP rate limits; optional cron purging expired codes + stale unused clients |
+
+## 10. Explicitly out of scope (v1)
+
+- Server-side AI/summaries (agent does it).
+- Fine-grained OAuth scopes enforced in Convex (single implicit `read write` scope in v1; claim carried in token for future use).
+- MCP resources/prompts primitives — tools only.
+- SSE transport (streamable HTTP only; no Redis).

--- a/docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
+++ b/docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
@@ -53,5 +53,11 @@ Wrapped the handler with `withMcpAuth(handler, verifyStub, { required: true, res
 - **`authInfo.extra` PASSTHROUGH: PASS.** The tool callback received `authInfo.extra` intact: the `ping` echo returned `{"pong":"hi","extra":{"userId":"spike-user","convexToken":"spike-jwt"}}`. **The WeakMap fallback in the plan is NOT needed** — `verify-token.ts` can return `extra:{userId,convexToken}` and tool handlers read it directly via `(args, { authInfo }) => (authInfo!.extra as McpExtra)`.
 - Verifier signature confirmed at runtime: `(req: Request, bearerToken?: string) => AuthInfo | undefined | Promise<...>`; returning `undefined` yields the 401 above.
 
+### jose RS256 sign/verify with local JWKS (Task 5, `scripts/spike-jose.mjs`)
+
+End-to-end recipe validated (epic §3.1 token strategy, minus Convex): `generateKeyPair('RS256',{extractable:true})` → `exportPKCS8` → round-trip `importPKCS8` → `exportJWK` (strip `d,p,q,dp,dq,qi`, add `kid/alg/use`) → `SignJWT(...).sign()` → `createLocalJWKSet` → `jwtVerify`. Final: `VERIFIED user123|mcp:grant456 spike read write`.
+
+**⚠️ Recipe correction (jose v6.2.3):** `importPKCS8(pkcs8, 'RS256')` returns a **non-extractable** `CryptoKey`, so the subsequent `exportJWK(signingKey)` throws `TypeError: non-extractable CryptoKey cannot be exported as a JWK`. Fix used and **required in sub-plan 2's `tokens.ts`**: `importPKCS8(pkcs8, 'RS256', { extractable: true })`. (Alternative for the app: derive the public JWK once at key-generation time and store it separately, so the runtime signing key can stay non-extractable — cleaner key hygiene. Either works; extractable-import is the minimal change.)
+
 ## Downstream plan corrections
 (filled by Task 6)

--- a/docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
+++ b/docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
@@ -5,10 +5,12 @@
 |---|---|
 | mcp-handler | 1.1.0 |
 | @modelcontextprotocol/sdk | 1.26.0 |
-| zod | 3.25.76 |
+| zod | **4.3.6** (see zod finding below — `^3` breaks the build) |
 | jose | 6.2.3 |
 
-**Note:** `mcp-handler@1.1.0` declares an **exact** non-optional peer `@modelcontextprotocol/sdk@1.26.0`. Installing `zod@^3 jose` alongside first pulled sdk `1.29.0` (bun warned: `incorrect peer dependency`). Downgraded sdk to `1.26.0` to match the peer and avoid two sdk instances in the module graph. zod resolved to `3.25.76` (major 3, satisfies sdk peer `^3.25 || ^4.0`). No `zod@^3.25` override needed.
+**Notes:**
+- `mcp-handler@1.1.0` declares an **exact** non-optional peer `@modelcontextprotocol/sdk@1.26.0`. Installing `zod jose` alongside first pulled sdk `1.29.0` (bun warned: `incorrect peer dependency`). Downgraded sdk to `1.26.0` to match the peer and avoid two sdk instances in the module graph.
+- zod was first pinned at `^3` (resolved 3.25.76) per the epic, but that **fails typecheck** — see the zod-version finding under "API surface". Re-pinned to `^4` (resolved 4.3.6), which the sdk peer `"^3.25 || ^4.0"` allows.
 
 ## API surface (each answer cites a node_modules path)
 
@@ -25,6 +27,21 @@
 4. **Tool callback = `(args, extra)`** where `extra: RequestHandlerExtra` carrying `authInfo?: AuthInfo` (`shared/protocol.d.ts:181`) → destructure `(args, { authInfo }) => …`. `AuthInfo` (`server/auth/types.d.ts`): `token`, `clientId`, `scopes: string[]`, `expiresAt?`, `resource?: URL`, **`extra?: Record<string, unknown>`** (passthrough field present in the type; runtime survival → Task 4).
 7. **`CallToolResult`** (`types.d.ts:2491-2593`): `content: [{type:"text", text:string} | image | audio | …]`, optional `isError?: boolean`, optional `structuredContent?`. Epic's `{ content:[{type:"text",text}], isError? }` return is accepted.
 8. **Route export:** handler is `(request: Request) => Promise<Response>` → `export { authed as GET, authed as POST }`. Stateless is the default (`sessionIdGenerator?: undefined`); no `DELETE` export needed (no session teardown in stateless streamable HTTP). SSE can be turned off via `disableSse: true`.
+
+### ⚠️ zod version (BLOCKER FOUND — corrects epic + this sub-plan Task 1)
+
+**`zod@^3` (resolved 3.25.76) breaks the build:** `registerTool` (and the deprecated `tool()`) both raise `TS2589: Type instantiation is excessively deep and possibly infinite` under `tsc 5.9.3` + `@modelcontextprotocol/sdk@1.26.0`. Reproduced with the canonical raw-shape form, the deprecated form, and an explicitly-typed shape — the deep instantiation is inside the SDK's own `zod-compat` generic machinery, not our call site. zod 3.25.x is the heavy "bridge" release.
+
+**Fix: pin `zod@^4` (resolved 4.3.6).** The SDK peer is `"^3.25 || ^4.0"`, so v4 is supported; the canonical `registerTool(name, {description, inputSchema:{...}}, cb)` then typechecks and builds clean. zod was not previously an app dependency (only the MCP surface uses it) → no cross-cutting risk. **Downstream: sub-plans 2–3 must author zod schemas with the v4 API** (watch `.nullable()` clearables, error/message options which changed from v3).
+
+### Walking-skeleton route behavior (Task 3, `src/app/api/[transport]/route.ts`)
+
+Dynamic `[transport]` segment + `basePath: "/api"` serves **`POST /api/mcp`**. Verified via curl against `bun dev` (no auth yet):
+
+- `tools/list` → **HTTP 200**, `content-type: text/event-stream`. Body is SSE-framed even for a one-shot POST: `event: message\ndata: {"result":{"tools":[…]},"jsonrpc":"2.0","id":1}`. **No prior `initialize` call and no `mcp-session-id` header required** in stateless mode. The zod shape is surfaced as JSON Schema draft-07 (`{type:"object",properties:{message:{type:"string"}},required:["message"]}`), and each tool carries `execution.taskSupport:"forbidden"`.
+- `tools/call` `ping{message:"hi"}` → `data: {"result":{"content":[{"type":"text","text":"pong: hi"}]},"jsonrpc":"2.0","id":2}`.
+- Clients MUST send `Accept: application/json, text/event-stream` (the SDK negotiates SSE framing).
+- MCP inspector (Task 3 step 4) not run — headless session, no browser; curl exercises the same JSON-RPC transport.
 
 ## Downstream plan corrections
 (filled by Task 6)

--- a/docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
+++ b/docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
@@ -11,7 +11,20 @@
 **Note:** `mcp-handler@1.1.0` declares an **exact** non-optional peer `@modelcontextprotocol/sdk@1.26.0`. Installing `zod@^3 jose` alongside first pulled sdk `1.29.0` (bun warned: `incorrect peer dependency`). Downgraded sdk to `1.26.0` to match the peer and avoid two sdk instances in the module graph. zod resolved to `3.25.76` (major 3, satisfies sdk peer `^3.25 || ^4.0`). No `zod@^3.25` override needed.
 
 ## API surface (each answer cites a node_modules path)
-(filled by Tasks 2–5)
+
+### mcp-handler (`node_modules/mcp-handler/dist/index.d.ts`)
+
+1. **`createMcpHandler`** = re-export of `createMcpRouteHandler(initializeServer, serverOptions?, config?)` (`index.d.ts:121,209`). Setup callback receives an SDK `McpServer`. `Config` keys (`index.d.ts:45-106`): `basePath` ✓, `maxDuration` ✓ (default 60), `verboseLogs` ✓ (default false), `redisUrl?` (**optional**, defaults to `REDIS_URL`/`KV_URL` env), `onEvent?`, `disableSse?`, `sessionIdGenerator?: undefined`, plus deprecated `streamableHttpEndpoint`/`sseEndpoint`/`sseMessageEndpoint`. **Redis is NOT required → stateless streamable-HTTP works with an empty/omitted `redisUrl`.** Epic assumption holds.
+5. **`withMcpAuth(handler, verifyToken, opts)`** (`index.d.ts:128-142`). `verifyToken: (req: Request, bearerToken?: string) => AuthInfo | undefined | Promise<AuthInfo | undefined>`. Opts: `required?`, `resourceMetadataPath?`, `requiredScopes?`, `resourceUrl?`. Exported as both `withMcpAuth` and `experimental_withMcpAuth` (`index.d.ts:209`) — epic's `withMcpAuth` name is valid. Also augments global `Request` with `auth?: AuthInfo` (`index.d.ts:123-127`). Runtime 401 shape → Task 4.
+6. **Metadata helpers EXIST** (`index.d.ts:157-207`): `protectedResourceHandler({authServerUrls, resourceUrl?})`, `generateProtectedResourceMetadata({authServerUrls, resourceUrl, additionalMetadata?})`, `metadataCorsOptionsRequestHandler()`, plus `getPublicOrigin(req)`/`getPublicUrl(req)`. **Correction vs epic risk #3: the RFC 9728 protected-resource route need NOT be hand-rolled — use `protectedResourceHandler` + `metadataCorsOptionsRequestHandler`.** (No helper for RFC 8414 authorization-server metadata — that route stays hand-rolled.)
+
+### @modelcontextprotocol/sdk (`node_modules/@modelcontextprotocol/sdk/dist/esm/...`)
+
+2. **Registration: use `registerTool`.** Every `server.tool(...)` overload is `@deprecated Use registerTool instead` (`server/mcp.d.ts:110-146`). Non-deprecated: `registerTool(name, config, cb)` (`server/mcp.d.ts:150-157`). **Correction: epic §3.4 uses `server.tool(name, desc, shape, cb)` (deprecated) — switch to `registerTool`.**
+3. **`registerTool` config** (`server/mcp.d.ts:150-157`): `{ title?, description?, inputSchema?, outputSchema?, annotations?, _meta? }`. `inputSchema` is a zod **raw shape object** (`ZodRawShapeCompat`, e.g. `{ message: z.string() }`) — **not** `z.object(...)`. Callback arg is `ShapeOutput<Args>` (`server/mcp.d.ts:250`).
+4. **Tool callback = `(args, extra)`** where `extra: RequestHandlerExtra` carrying `authInfo?: AuthInfo` (`shared/protocol.d.ts:181`) → destructure `(args, { authInfo }) => …`. `AuthInfo` (`server/auth/types.d.ts`): `token`, `clientId`, `scopes: string[]`, `expiresAt?`, `resource?: URL`, **`extra?: Record<string, unknown>`** (passthrough field present in the type; runtime survival → Task 4).
+7. **`CallToolResult`** (`types.d.ts:2491-2593`): `content: [{type:"text", text:string} | image | audio | …]`, optional `isError?: boolean`, optional `structuredContent?`. Epic's `{ content:[{type:"text",text}], isError? }` return is accepted.
+8. **Route export:** handler is `(request: Request) => Promise<Response>` → `export { authed as GET, authed as POST }`. Stateless is the default (`sessionIdGenerator?: undefined`); no `DELETE` export needed (no session teardown in stateless streamable HTTP). SSE can be turned off via `disableSse: true`.
 
 ## Downstream plan corrections
 (filled by Task 6)

--- a/docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
+++ b/docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
@@ -60,4 +60,16 @@ End-to-end recipe validated (epic §3.1 token strategy, minus Convex): `generate
 **⚠️ Recipe correction (jose v6.2.3):** `importPKCS8(pkcs8, 'RS256')` returns a **non-extractable** `CryptoKey`, so the subsequent `exportJWK(signingKey)` throws `TypeError: non-extractable CryptoKey cannot be exported as a JWK`. Fix used and **required in sub-plan 2's `tokens.ts`**: `importPKCS8(pkcs8, 'RS256', { extractable: true })`. (Alternative for the app: derive the public JWK once at key-generation time and store it separately, so the runtime signing key can stay non-extractable — cleaner key hygiene. Either works; extractable-import is the minimal change.)
 
 ## Downstream plan corrections
-(filled by Task 6)
+
+| # | Assumption (epic/sub-plans) | Verified reality | Edit target |
+|---|---|---|---|
+| C1 | `zod@^3` (epic §6, this sub-plan Task 1) | `3.25.76` raises `TS2589` with sdk 1.26 `registerTool`; **`zod@^4` (4.3.6) builds clean** | epic §6 packages; sub-plans 2–3 author schemas with zod v4 API |
+| C2 | Tool registration `server.tool(name, desc, shape, cb)` (epic §3.4) | `tool()` is `@deprecated` AND also TS2589-prone; **use `server.registerTool(name, {description, inputSchema:{…}}, cb)`** | epic §3.4 code block; sub-plan 3 |
+| C3 | sdk "latest" implied | mcp-handler peer pins **exact `@modelcontextprotocol/sdk@1.26.0`**; pin it, don't float | epic §6; sub-plan 1 (done) |
+| C4 | Metadata routes "hand-roll" (epic risk #3) | Helpers ship: **`protectedResourceHandler` + `metadataCorsOptionsRequestHandler` + `generateProtectedResourceMetadata`**. Use them for the RFC 9728 route. RFC 8414 auth-server metadata has NO helper → still hand-rolled | epic §6 / risk #3; sub-plan 4 metadata routes |
+| C5 | `authInfo.extra` might not survive → WeakMap fallback (sub-plan 1 Task 4) | **`extra` survives passthrough** to tool callback. No WeakMap needed | sub-plan 3 `verify-token.ts` contract |
+| C6 | jose recipe `importPKCS8(pkcs8, alg)` (sub-plan 1 Task 5, epic §3.1) | Returns **non-extractable** key → `exportJWK` throws. Need **`importPKCS8(pkcs8, 'RS256', { extractable: true })`** (or derive public JWK at keygen) | sub-plan 2 `tokens.ts` |
+| C7 | Response body shape unspecified | Stateless streamable HTTP returns **`content-type: text/event-stream`** (SSE-framed `event: message\ndata: {...}`); clients MUST send `Accept: application/json, text/event-stream`; no `initialize`/`mcp-session-id` prereq | epic §8 curls already include the Accept header — no change, just noted |
+| C8 | 401 `WWW-Authenticate` must carry `resource_metadata` (epic flow step 1) | Confirmed verbatim: `Bearer error="invalid_token", …, resource_metadata="<origin>/.well-known/oauth-protected-resource"` | none (matches) |
+
+**Net:** two hard blockers fixed (C1 zod, C6 jose), one deprecation switch (C2), one nice-to-have (C4 helpers reduce hand-rolled code), one de-risk (C5 no WeakMap). Auth flow + token strategy validated end to end minus Convex.

--- a/docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
+++ b/docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
@@ -43,5 +43,15 @@ Dynamic `[transport]` segment + `basePath: "/api"` serves **`POST /api/mcp`**. V
 - Clients MUST send `Accept: application/json, text/event-stream` (the SDK negotiates SSE framing).
 - MCP inspector (Task 3 step 4) not run — headless session, no browser; curl exercises the same JSON-RPC transport.
 
+### `withMcpAuth` runtime behavior (Task 4)
+
+Wrapped the handler with `withMcpAuth(handler, verifyStub, { required: true, resourceMetadataPath: "/.well-known/oauth-protected-resource" })` and a stub verifier accepting only `Bearer test-token`.
+
+- **401 path (no/invalid bearer):** `HTTP/1.1 401 Unauthorized` with
+  `www-authenticate: Bearer error="invalid_token", error_description="No authorization provided", resource_metadata="http://localhost:3000/.well-known/oauth-protected-resource"`.
+  The header **includes `resource_metadata="…"`** pointing at `<origin>` + the configured `resourceMetadataPath` → epic discovery-flow step 1 works as designed. Origin is derived from proxy headers / request URL (`getPublicOrigin`).
+- **`authInfo.extra` PASSTHROUGH: PASS.** The tool callback received `authInfo.extra` intact: the `ping` echo returned `{"pong":"hi","extra":{"userId":"spike-user","convexToken":"spike-jwt"}}`. **The WeakMap fallback in the plan is NOT needed** — `verify-token.ts` can return `extra:{userId,convexToken}` and tool handlers read it directly via `(args, { authInfo }) => (authInfo!.extra as McpExtra)`.
+- Verifier signature confirmed at runtime: `(req: Request, bearerToken?: string) => AuthInfo | undefined | Promise<...>`; returning `undefined` yields the 401 above.
+
 ## Downstream plan corrections
 (filled by Task 6)

--- a/docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
+++ b/docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
@@ -1,0 +1,17 @@
+# MCP Spike Findings (sub-plan 0 — consumed by sub-plans 2–4)
+
+## Pinned versions
+| Package | Resolved version |
+|---|---|
+| mcp-handler | 1.1.0 |
+| @modelcontextprotocol/sdk | 1.26.0 |
+| zod | 3.25.76 |
+| jose | 6.2.3 |
+
+**Note:** `mcp-handler@1.1.0` declares an **exact** non-optional peer `@modelcontextprotocol/sdk@1.26.0`. Installing `zod@^3 jose` alongside first pulled sdk `1.29.0` (bun warned: `incorrect peer dependency`). Downgraded sdk to `1.26.0` to match the peer and avoid two sdk instances in the module graph. zod resolved to `3.25.76` (major 3, satisfies sdk peer `^3.25 || ^4.0`). No `zod@^3.25` override needed.
+
+## API surface (each answer cites a node_modules path)
+(filled by Tasks 2–5)
+
+## Downstream plan corrections
+(filled by Task 6)

--- a/docs/superpowers/plans/2026-07-06-mcp-1-compat-spike.md
+++ b/docs/superpowers/plans/2026-07-06-mcp-1-compat-spike.md
@@ -1,0 +1,387 @@
+# MCP Sub-plan 1/5: mcp-handler Compatibility Spike Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Epic:** `docs/mcp-server-plan.md` (issue #65). This is sub-plan 1 of 5 and MUST run first — its findings can change route/tool/auth details in sub-plans 2–4.
+
+**Goal:** Pin the MCP dependency stack, verify every `mcp-handler` / MCP SDK / jose API assumption the epic makes, and record the verified facts in a findings doc that downstream sub-plans reconcile against.
+
+**Architecture:** Throwaway-ish spike on a branch: install deps, read the installed package's types (not web docs), stand up a minimal `/api/mcp` route with one `ping` tool, probe auth wiring and metadata helpers with curl + MCP inspector, and probe jose RS256 sign/verify. Deliverables that merge to main: `package.json` dep pins + the findings doc. The scaffold route stays on the branch as reference for sub-plan 3.
+
+**Tech Stack:** Next.js 16.2.6 (App Router), Bun 1.3.10, `mcp-handler`, `@modelcontextprotocol/sdk`, `zod@^3`, `jose`.
+
+## Global Constraints
+
+- All commands run from `/home/code/fragrances-tracker/my-app` unless stated otherwise.
+- Package manager is **bun**: `bun add`, `bun run typecheck`, `bun run lint`, `bun run test:run`, `bun run build`.
+- Work on branch `spike/mcp-handler` cut from `main`.
+- **Read the installed package, not memory or web docs.** Every answer in the findings doc must cite a file path inside `node_modules/`.
+- The findings doc lives at `docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md` (numbered 0 so it sorts before the sub-plans that consume it).
+- Do not touch Convex files in this sub-plan. No schema changes, no auth.config changes.
+- Commit after every task (`chore:` / `docs:` prefixes).
+
+---
+
+### Task 1: Install and pin dependencies
+
+**Files:**
+- Modify: `my-app/package.json`
+- Create: `docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md` (skeleton)
+
+**Interfaces:**
+- Produces: exact pinned versions of `mcp-handler`, `@modelcontextprotocol/sdk`, `zod`, `jose` — every later sub-plan installs nothing and relies on these pins.
+
+- [ ] **Step 1: Create the spike branch**
+
+```bash
+git checkout -b spike/mcp-handler
+```
+
+- [ ] **Step 2: Install the four packages**
+
+```bash
+cd /home/code/fragrances-tracker/my-app
+bun add mcp-handler @modelcontextprotocol/sdk zod@^3 jose
+```
+
+Note: `zod` must stay on major 3 — `@modelcontextprotocol/sdk` declares a zod v3 peer range. If bun resolves zod 4, force `zod@^3.25` explicitly.
+
+- [ ] **Step 3: Record resolved versions**
+
+```bash
+bun pm ls | grep -E "mcp-handler|@modelcontextprotocol/sdk|zod|jose"
+```
+
+Create the findings doc skeleton with the output:
+
+```markdown
+# MCP Spike Findings (sub-plan 0 — consumed by sub-plans 2–4)
+
+## Pinned versions
+| Package | Resolved version |
+|---|---|
+| mcp-handler | <fill from bun pm ls> |
+| @modelcontextprotocol/sdk | <fill> |
+| zod | <fill> |
+| jose | <fill> |
+
+## API surface (each answer cites a node_modules path)
+(filled by Tasks 2–5)
+
+## Downstream plan corrections
+(filled by Task 6)
+```
+
+- [ ] **Step 4: Verify the repo still builds with the new deps**
+
+```bash
+bun run typecheck && bun run build
+```
+
+Expected: both pass (no source uses the new packages yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json bun.lock ../docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
+git commit -m "chore: pin mcp-handler, mcp sdk, zod, jose for MCP spike"
+```
+
+---
+
+### Task 2: Audit the installed `mcp-handler` API surface
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md`
+
+**Interfaces:**
+- Produces: answered checklist below. Sub-plan 3 writes `src/app/api/[transport]/route.ts` and `src/lib/mcp/verify-token.ts` directly from these answers.
+
+- [ ] **Step 1: Locate the type declarations**
+
+```bash
+ls node_modules/mcp-handler/dist/
+cat node_modules/mcp-handler/package.json | grep -A5 '"exports"'
+```
+
+- [ ] **Step 2: Answer every question below by reading the `.d.ts` / source files; paste exact signatures into the findings doc**
+
+Checklist (each row becomes a findings entry with the copied signature and file path):
+
+1. `createMcpHandler` — exact signature: order and types of (server-setup callback, server options, handler config). Which config keys exist: `basePath`? `maxDuration`? `verboseLogs`? Redis-related keys and whether they are optional (epic assumes stateless, no Redis).
+2. Tool registration — does the `server` passed to the setup callback expose `registerTool(name, {description, inputSchema}, cb)`, `tool(name, description, shape, cb)`, or both? Which is non-deprecated in the pinned SDK version? The epic §3.4 uses `server.tool(...)`; the reviewer flagged current docs show `registerTool(...)`. **Record the one to use.**
+3. `inputSchema` shape — does the chosen registration method take a zod **raw shape object** (`{ name: z.string() }`) or a `z.object(...)`? Cite the type.
+4. Tool callback — exact second-arg type. Confirm `authInfo` is present and locate the `AuthInfo` type: fields `token`, `clientId`, `scopes`, `expiresAt?`, `extra?`. Confirm `extra` is a passthrough `Record<string, unknown>` that survives from the verifier to the tool callback.
+5. `withMcpAuth` — exact signature: (handler, verifier, options). Verifier return type (`AuthInfo | undefined | Promise<...>`?). Options: `required`, `resourceMetadataPath`, anything else. What HTTP response does it emit on missing/invalid token — status and exact `WWW-Authenticate` header shape.
+6. Metadata helpers — do `protectedResourceHandler` / `metadataCorsOptionsRequestHandler` (or similarly named exports) exist? Signatures. If absent, record "hand-roll metadata routes" (epic risk #3 already accepts this).
+7. Return type of tool callbacks — confirm `{ content: [{type: "text", text: string}], isError?: boolean }` is accepted; cite the `CallToolResult` type.
+8. Route export shape — what the README/types say about `export { handler as GET, handler as POST }` and whether DELETE is needed for streamable HTTP session teardown in stateless mode.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ../docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
+git commit -m "docs: record mcp-handler API audit in spike findings"
+```
+
+---
+
+### Task 3: Walking-skeleton MCP route with a `ping` tool (no auth)
+
+**Files:**
+- Create: `my-app/src/app/api/[transport]/route.ts`
+
+**Interfaces:**
+- Produces: verified route shape (dynamic `[transport]` segment serving `/api/mcp`) and verified JSON-RPC request/response behavior, recorded in findings.
+
+- [ ] **Step 1: Write the minimal route**
+
+Use the registration method Task 2 selected. If Task 2 chose `registerTool`:
+
+```ts
+// src/app/api/[transport]/route.ts
+import { createMcpHandler } from "mcp-handler";
+import { z } from "zod";
+
+const handler = createMcpHandler(
+  (server) => {
+    server.registerTool(
+      "ping",
+      {
+        description: "Health check. Echoes the message back.",
+        inputSchema: { message: z.string() },
+      },
+      async ({ message }) => ({
+        content: [{ type: "text", text: `pong: ${message}` }],
+      }),
+    );
+  },
+  {},
+  { basePath: "/api", maxDuration: 60, verboseLogs: true },
+);
+
+export { handler as GET, handler as POST };
+```
+
+(Adjust to the exact signatures Task 2 recorded — that is the point of the spike.)
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS. If the epic's assumed config keys (`basePath`, `maxDuration`) fail, record the corrected keys in findings.
+
+- [ ] **Step 3: Exercise with curl (dev server running: `bun dev` in one terminal)**
+
+```bash
+curl -si -X POST http://localhost:3000/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+Record in findings: HTTP status, content type (JSON vs `text/event-stream`), whether a prior `initialize` call or `mcp-session-id` header is required in stateless mode, and the exact body shape. Then:
+
+```bash
+curl -s -X POST http://localhost:3000/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"ping","arguments":{"message":"hi"}}}'
+```
+
+Expected: a result containing `pong: hi`. Record actual behavior either way.
+
+- [ ] **Step 4: Exercise with the MCP inspector**
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+Connect to `http://localhost:3000/api/mcp` with transport "Streamable HTTP". Verify `ping` is listed and callable. Record any quirks (e.g. required headers).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/
+git commit -m "chore: walking-skeleton MCP route with ping tool (spike)"
+```
+
+---
+
+### Task 4: Probe `withMcpAuth` — 401 shape and `authInfo.extra` passthrough
+
+**Files:**
+- Modify: `my-app/src/app/api/[transport]/route.ts`
+
+**Interfaces:**
+- Produces: verified 401 + `WWW-Authenticate` behavior and verified `authInfo.extra` availability inside tool callbacks. Sub-plan 3's `verify-token.ts` contract depends on this.
+
+- [ ] **Step 1: Wrap the handler with a stub verifier**
+
+```ts
+// additions to src/app/api/[transport]/route.ts
+import { withMcpAuth } from "mcp-handler";
+
+const verifyStub = async (_req: Request, bearer?: string) => {
+  if (bearer !== "test-token") return undefined;
+  return {
+    token: bearer,
+    clientId: "spike-client",
+    scopes: ["read", "write"],
+    extra: { userId: "spike-user", convexToken: "spike-jwt" },
+  };
+};
+
+const authed = withMcpAuth(handler, verifyStub, {
+  required: true,
+  resourceMetadataPath: "/.well-known/oauth-protected-resource",
+});
+
+export { authed as GET, authed as POST };
+```
+
+(Remove the previous bare export. Adjust option names to Task 2 findings.)
+
+Also change the `ping` tool callback to echo auth info, so passthrough is observable:
+
+```ts
+async ({ message }, { authInfo }) => ({
+  content: [
+    {
+      type: "text",
+      text: JSON.stringify({ pong: message, extra: authInfo?.extra ?? null }),
+    },
+  ],
+}),
+```
+
+- [ ] **Step 2: Verify the 401 path**
+
+```bash
+curl -si -X POST http://localhost:3000/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+Expected: HTTP 401. Record the exact `WWW-Authenticate` header value (the epic's discovery flow step 1 depends on it containing `resource_metadata="..."`).
+
+- [ ] **Step 3: Verify the authed path and `extra` passthrough**
+
+```bash
+curl -s -X POST http://localhost:3000/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer test-token" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"ping","arguments":{"message":"hi"}}}'
+```
+
+Expected: result text contains `"extra":{"userId":"spike-user","convexToken":"spike-jwt"}`. Record PASS/FAIL and the actual shape in findings. **If `extra` does not survive, the fallback design (record it): stash the verified info in a request-scoped WeakMap keyed by the token string, looked up inside tool handlers.**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/ ../docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md
+git commit -m "chore: probe withMcpAuth 401 + authInfo.extra passthrough (spike)"
+```
+
+---
+
+### Task 5: Probe jose RS256 sign/verify with a local JWKS
+
+**Files:**
+- Create: `my-app/scripts/spike-jose.mjs`
+
+**Interfaces:**
+- Produces: verified recipe for (a) generating an RSA keypair, (b) exporting a public JWK by stripping private fields, (c) signing a JWT with `kid`, (d) verifying via `createLocalJWKSet`. Sub-plan 2's `tokens.ts` and JWKS route copy this recipe verbatim.
+
+- [ ] **Step 1: Write the probe script**
+
+```js
+// scripts/spike-jose.mjs
+import { generateKeyPair, exportPKCS8, exportJWK, SignJWT, jwtVerify, createLocalJWKSet, importPKCS8 } from "jose";
+
+const { privateKey } = await generateKeyPair("RS256", { extractable: true });
+const pkcs8 = await exportPKCS8(privateKey);
+
+// Round-trip through PKCS8 the way the app will (env var → importPKCS8).
+const signingKey = await importPKCS8(pkcs8, "RS256");
+
+// Public JWK = private JWK minus private fields.
+const jwk = await exportJWK(signingKey);
+delete jwk.d; delete jwk.p; delete jwk.q; delete jwk.dp; delete jwk.dq; delete jwk.qi;
+const publicJwk = { ...jwk, kid: "mcp-1", alg: "RS256", use: "sig" };
+
+const token = await new SignJWT({ client_id: "spike", scope: "read write" })
+  .setProtectedHeader({ alg: "RS256", kid: "mcp-1" })
+  .setSubject("user123|mcp:grant456")
+  .setIssuer("http://localhost:3000")
+  .setAudience("fragrances-mcp")
+  .setIssuedAt()
+  .setExpirationTime("15m")
+  .sign(signingKey);
+
+const jwks = createLocalJWKSet({ keys: [publicJwk] });
+const { payload } = await jwtVerify(token, jwks, {
+  issuer: "http://localhost:3000",
+  audience: "fragrances-mcp",
+});
+console.log("VERIFIED", payload.sub, payload.client_id, payload.scope);
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+bun scripts/spike-jose.mjs
+```
+
+Expected: `VERIFIED user123|mcp:grant456 spike read write`. Record PASS in findings (this validates the epic §3.1 token strategy end to end, minus Convex).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/spike-jose.mjs
+git commit -m "chore: probe jose RS256 sign/verify with local JWKS (spike)"
+```
+
+---
+
+### Task 6: Finalize findings and reconcile downstream plans
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md`
+- Possibly modify: `docs/mcp-server-plan.md`, sub-plans 2–4
+
+**Interfaces:**
+- Produces: a "Downstream plan corrections" section listing every place where reality differed from the epic's assumptions, plus the edits applied.
+
+- [ ] **Step 1: Fill the "Downstream plan corrections" section**
+
+For each divergence found in Tasks 2–5 (tool registration method, config keys, 401 header shape, `extra` passthrough, metadata helpers), write one line: *assumption → verified reality → which sub-plan/section to edit*.
+
+- [ ] **Step 2: Apply the edits to the epic and sub-plans 2–4**
+
+Edit the affected code blocks in `docs/mcp-server-plan.md` §3.3/§3.4 and in sub-plans 2–4 so no downstream worker inherits a falsified assumption.
+
+- [ ] **Step 3: Run repo checks**
+
+```bash
+bun run typecheck && bun run lint && bun run test:run && bun run build
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit and open the spike PR**
+
+```bash
+git add -A
+git commit -m "docs: finalize MCP spike findings and reconcile sub-plans"
+git push -u origin spike/mcp-handler
+gh pr create --title "MCP spike: pin deps + verified mcp-handler/jose findings" --body "Sub-plan 1/5 of docs/mcp-server-plan.md (issue #65). Merges dep pins + findings doc; scaffold route stays as reference for sub-plan 3.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+Note for the merger: `package.json`/`bun.lock`, the findings doc, and plan edits are the mergeable payload. `src/app/api/[transport]/route.ts` and `scripts/spike-jose.mjs` may merge too (harmless: route requires the stub token, script is inert) or be dropped in review — sub-plans 2–3 rewrite both.

--- a/docs/superpowers/plans/2026-07-06-mcp-2-oauth-foundation.md
+++ b/docs/superpowers/plans/2026-07-06-mcp-2-oauth-foundation.md
@@ -1,0 +1,1851 @@
+# MCP Sub-plan 2/5: OAuth + Token Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Epic:** `docs/mcp-server-plan.md` (issue #65). Sub-plan 2 of 5. Requires sub-plan 1's findings doc (`2026-07-06-mcp-0-spike-findings.md`) to be merged. Sub-plan 3 (MCP tools) and 4 (UI) build on this.
+
+> **⚠️ Spike corrections (from `2026-07-06-mcp-0-spike-findings.md` — apply while implementing):**
+> - **C6 (jose):** `tokens.ts` `getPublicKey`/JWK export must import the signing key extractable — `importPKCS8(pem, 'RS256', { extractable: true })` — or `exportJWK` throws `non-extractable CryptoKey`. Verified recipe: `scripts/spike-jose.mjs`.
+> - **C1 (zod):** pinned **`zod@^4`** (4.3.6), not `^3` — write all schemas with the zod v4 API.
+> - **C3 (sdk):** `@modelcontextprotocol/sdk` pinned **exact 1.26.0** (mcp-handler peer). Already in `package.json` from sub-plan 1 — install nothing.
+> - **C4 (metadata helpers):** the RFC 9728 protected-resource route can use mcp-handler's `protectedResourceHandler` + `metadataCorsOptionsRequestHandler` instead of hand-rolling. The RFC 8414 authorization-server metadata route still hand-rolled (no helper).
+
+**Goal:** Build the complete OAuth 2.1 + PAT token backend: 5 Convex tables, crypto/JWT helpers, Convex OAuth/PAT functions (test-first), the `customJwt` Convex auth provider, and the Next.js endpoints — JWKS, RFC 8414 + RFC 9728 metadata, RFC 7591 DCR, and the token endpoint (auth-code + refresh grants).
+
+**Architecture:** Crypto placement rule (applies to every task): **Next.js route handlers generate all raw secrets (auth codes, refresh tokens, PATs, client IDs) and compute SHA-256 hashes; Convex functions only store and compare pre-computed hashes/strings — they never see raw secrets and never do crypto.** Access tokens are RS256 JWTs (`sub = "${userId}|mcp:${grantId}"`, 15 min TTL) minted in Next under a dedicated MCP keypair and verified by Convex via a registered `customJwt` provider fetching our JWKS. Refresh tokens/PATs are opaque, stored hashed, refresh rotated on every use with reuse-detection revoking the whole grant.
+
+**Tech Stack:** Convex 1.42 (+ convex-test), Next.js 16 App Router route handlers, jose (versions pinned by sub-plan 1), Bun, Vitest edge-runtime.
+
+## Global Constraints
+
+- All commands run from `/home/code/fragrances-tracker/my-app`.
+- Package manager is **bun**; test with `bun run test:run <path>`; full gate is `bun run typecheck && bun run lint && bun run test:run && bun run build`.
+- Branch: `feat/mcp-oauth-foundation` cut from `main` after the spike PR merges. **Install no packages** — sub-plan 1 pinned everything.
+- Convex tests use `setupTest()` / `createTestUser()` from `convex/test.setup.ts`; convex + `src/**/*.test.ts` files run in the edge-runtime Vitest project (no Node-only APIs; `crypto.subtle` is available).
+- Scope model (locked for v1): every grant/PAT carries the single scope string **`"read write"`**; it is embedded in tokens and stored, but **not enforced per-tool or Convex-side** (epic §10). Do not build scope-checking machinery.
+- All secret-bearing responses set `Cache-Control: no-store` + `Pragma: no-cache`.
+- OAuth error bodies are always JSON `{ "error": string, "error_description"?: string }` per RFC 6749 §5.2.
+- Reconcile every `mcp-handler`-adjacent assumption against the spike findings doc before coding (the findings doc's "Downstream plan corrections" section was supposed to have patched this file already — if a code block here contradicts findings, findings win).
+- Commit after every task (`feat:` / `test:` prefixes).
+
+---
+
+### Task 1: Keypair script + env vars
+
+**Files:**
+- Create: `my-app/scripts/generate-mcp-keypair.mjs`
+- Modify: `my-app/.env.local` (not committed; gitignored)
+
+**Interfaces:**
+- Produces: env contract used by every later task —
+  - Vercel/Next side: `MCP_JWT_PRIVATE_KEY` (PKCS8 PEM), `NEXT_PUBLIC_APP_URL` (origin, no trailing slash, doubles as JWT issuer), optional `MCP_EXTRA_PUBLIC_JWKS` (JSON array of extra public JWKs — used by sub-plan 5's local-dev strategy).
+  - Convex dashboard side: `MCP_JWT_ISSUER` (= app origin), `MCP_JWKS_URL` (= `<origin>/api/oauth/jwks`).
+
+- [ ] **Step 1: Write the generator script** (adapted from the spike's verified jose recipe)
+
+```js
+// scripts/generate-mcp-keypair.mjs
+// One-off: generates the MCP signing keypair. Run per environment; never commit output.
+//   bun scripts/generate-mcp-keypair.mjs
+import { generateKeyPair, exportPKCS8, exportJWK } from "jose";
+
+const kid = process.argv[2] ?? "mcp-1";
+const { privateKey } = await generateKeyPair("RS256", { extractable: true });
+const pkcs8 = await exportPKCS8(privateKey);
+const jwk = await exportJWK(privateKey);
+for (const f of ["d", "p", "q", "dp", "dq", "qi"]) delete jwk[f];
+
+console.log("── MCP_JWT_PRIVATE_KEY (set in Vercel / .env.local) ──");
+console.log(pkcs8);
+console.log("── Public JWK (informational; served by /api/oauth/jwks) ──");
+console.log(JSON.stringify({ ...jwk, kid, alg: "RS256", use: "sig" }, null, 2));
+```
+
+- [ ] **Step 2: Run it and set local env**
+
+```bash
+bun scripts/generate-mcp-keypair.mjs
+```
+
+Append to `.env.local` (PEM as a quoted multi-line value or with literal `\n`):
+
+```bash
+MCP_JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+```
+
+In the Convex **dev** deployment dashboard set `MCP_JWT_ISSUER=http://localhost:3000` and `MCP_JWKS_URL` per sub-plan 5's local-dev decision (Convex Cloud cannot reach localhost — sub-plan 5 Task 1 documents the chosen JWKS hosting; for now the value can point at the future prod JWKS URL, it is only consumed at request-verification time).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/generate-mcp-keypair.mjs
+git commit -m "feat: add MCP keypair generation script"
+```
+
+---
+
+### Task 2: Schema — 5 new tables
+
+**Files:**
+- Modify: `my-app/convex/schema.ts` (append after `wearLogs`)
+
+**Interfaces:**
+- Produces: tables + indexes exactly as below; Tasks 5–7 and sub-plans 3–4 depend on these field names.
+
+- [ ] **Step 1: Append the tables**
+
+```ts
+// convex/schema.ts — append inside defineSchema({...}) after wearLogs
+
+  // ── MCP OAuth 2.1 + PAT tables. Secret-bearing fields store SHA-256 hex
+  // hashes only; raw values are generated in Next.js and never reach Convex.
+  oauthClients: defineTable({
+    clientId: v.string(),
+    clientName: v.string(),
+    redirectUris: v.array(v.string()),
+    tokenEndpointAuthMethod: v.literal("none"),
+    createdAt: v.number(),
+  }).index("by_client_id", ["clientId"]),
+
+  oauthAuthCodes: defineTable({
+    codeHash: v.string(),
+    clientId: v.string(),
+    userId: v.id("users"),
+    redirectUri: v.string(),
+    codeChallenge: v.string(), // S256 challenge, compared as an opaque string
+    scope: v.string(),
+    resource: v.optional(v.string()),
+    expiresAt: v.number(),
+    usedAt: v.optional(v.number()),
+  }).index("by_code_hash", ["codeHash"]),
+
+  oauthGrants: defineTable({
+    userId: v.id("users"),
+    clientId: v.string(),
+    clientName: v.string(), // denormalized for the settings UI
+    scope: v.string(),
+    createdAt: v.number(),
+    lastUsedAt: v.optional(v.number()),
+    revokedAt: v.optional(v.number()),
+  })
+    .index("by_user", ["userId"])
+    .index("by_user_client", ["userId", "clientId"]),
+
+  oauthRefreshTokens: defineTable({
+    tokenHash: v.string(),
+    grantId: v.id("oauthGrants"),
+    userId: v.id("users"),
+    clientId: v.string(),
+    expiresAt: v.number(),
+    revokedAt: v.optional(v.number()),
+    replacedBy: v.optional(v.id("oauthRefreshTokens")), // rotation chain
+  })
+    .index("by_token_hash", ["tokenHash"])
+    .index("by_grant", ["grantId"]),
+
+  personalAccessTokens: defineTable({
+    userId: v.id("users"),
+    tokenHash: v.string(),
+    name: v.string(),
+    scopes: v.array(v.string()),
+    createdAt: v.number(),
+    lastUsedAt: v.optional(v.number()),
+    expiresAt: v.optional(v.number()),
+    revokedAt: v.optional(v.number()),
+  })
+    .index("by_token_hash", ["tokenHash"])
+    .index("by_user", ["userId"]),
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+bun run typecheck && bun run test:run convex/
+```
+
+Expected: PASS (existing suites unaffected; `convex-test` picks the schema up automatically).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add convex/schema.ts
+git commit -m "feat: add OAuth client/code/grant/refresh-token and PAT tables"
+```
+
+---
+
+### Task 3: `src/lib/mcp/tokens.ts` — hashing, random tokens, JWT mint, JWKS derivation
+
+**Files:**
+- Create: `my-app/src/lib/mcp/tokens.ts`
+- Create: `my-app/src/lib/mcp/tokens.test.ts` (edge-runtime project — `.ts`, not `.tsx`)
+
+**Interfaces:**
+- Produces (consumed by Tasks 8–10, sub-plan 3's verifier, sub-plan 4's consent action and PAT dialog):
+  - `sha256Hex(input: string): Promise<string>`
+  - `randomToken(bytes?: number): string` — base64url, default 32 bytes; PATs are `"fgt_" + randomToken()`
+  - `randomHex(bytes?: number): string` — default 16; used for `client_id`
+  - `mintAccessToken(opts: { userId: string; grantId: string; clientId: string; scope: string; ttlSeconds?: number; privateKeyPem?: string; issuer?: string }): Promise<string>` — `sub = "${userId}|mcp:${grantId}"`, default TTL 900
+  - `mintPatBridgeToken(opts: { userId: string; tokenId: string; privateKeyPem?: string; issuer?: string }): Promise<string>` — `sub = "${userId}|pat:${tokenId}"`, TTL 300
+  - `getPublicJwks(privateKeyPem?: string): Promise<{ keys: object[] }>` — derived public JWK (+ `MCP_EXTRA_PUBLIC_JWKS` entries appended)
+  - Constants: `MCP_JWT_AUDIENCE = "fragrances-mcp"`, `MCP_JWT_KID = "mcp-1"`, `ACCESS_TOKEN_TTL_SECONDS = 900`, `PAT_PREFIX = "fgt_"`
+- Key/issuer params default to `process.env.MCP_JWT_PRIVATE_KEY` / `process.env.NEXT_PUBLIC_APP_URL`; tests pass explicit values.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/mcp/tokens.test.ts
+import { describe, expect, test } from "vitest";
+import { exportPKCS8, generateKeyPair, jwtVerify, createLocalJWKSet } from "jose";
+import {
+  sha256Hex,
+  randomToken,
+  randomHex,
+  mintAccessToken,
+  mintPatBridgeToken,
+  getPublicJwks,
+  MCP_JWT_AUDIENCE,
+} from "./tokens";
+
+const ISSUER = "https://example.test";
+
+async function testPem(): Promise<string> {
+  const { privateKey } = await generateKeyPair("RS256", { extractable: true });
+  return await exportPKCS8(privateKey);
+}
+
+describe("sha256Hex", () => {
+  test("hashes to the known vector for 'abc'", async () => {
+    expect(await sha256Hex("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  });
+});
+
+describe("randomToken / randomHex", () => {
+  test("randomToken is base64url and unique", () => {
+    const a = randomToken();
+    expect(a).toMatch(/^[A-Za-z0-9_-]{43}$/); // 32 bytes → 43 base64url chars
+    expect(randomToken()).not.toBe(a);
+  });
+
+  test("randomHex is lowercase hex of requested length", () => {
+    expect(randomHex(16)).toMatch(/^[0-9a-f]{32}$/);
+  });
+});
+
+describe("mintAccessToken", () => {
+  test("mints an RS256 JWT verifiable via the derived JWKS with expected claims", async () => {
+    const pem = await testPem();
+    const token = await mintAccessToken({
+      userId: "user123",
+      grantId: "grant456",
+      clientId: "client789",
+      scope: "read write",
+      privateKeyPem: pem,
+      issuer: ISSUER,
+    });
+    const jwks = createLocalJWKSet(await getPublicJwks(pem));
+    const { payload, protectedHeader } = await jwtVerify(token, jwks, {
+      issuer: ISSUER,
+      audience: MCP_JWT_AUDIENCE,
+    });
+    expect(protectedHeader.alg).toBe("RS256");
+    expect(payload.sub).toBe("user123|mcp:grant456");
+    expect(payload.client_id).toBe("client789");
+    expect(payload.scope).toBe("read write");
+    const ttl = (payload.exp as number) - (payload.iat as number);
+    expect(ttl).toBe(900);
+  });
+
+  test("token signed by one key fails verification against another key's JWKS", async () => {
+    const pemA = await testPem();
+    const pemB = await testPem();
+    const token = await mintAccessToken({
+      userId: "u",
+      grantId: "g",
+      clientId: "c",
+      scope: "read write",
+      privateKeyPem: pemA,
+      issuer: ISSUER,
+    });
+    const jwksB = createLocalJWKSet(await getPublicJwks(pemB));
+    await expect(
+      jwtVerify(token, jwksB, { issuer: ISSUER, audience: MCP_JWT_AUDIENCE }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("mintPatBridgeToken", () => {
+  test("uses pat-prefixed subject and 300s TTL", async () => {
+    const pem = await testPem();
+    const token = await mintPatBridgeToken({
+      userId: "user123",
+      tokenId: "tok789",
+      privateKeyPem: pem,
+      issuer: ISSUER,
+    });
+    const jwks = createLocalJWKSet(await getPublicJwks(pem));
+    const { payload } = await jwtVerify(token, jwks, { issuer: ISSUER, audience: MCP_JWT_AUDIENCE });
+    expect(payload.sub).toBe("user123|pat:tok789");
+    expect((payload.exp as number) - (payload.iat as number)).toBe(300);
+  });
+});
+
+describe("getPublicJwks", () => {
+  test("contains no private-key fields and carries kid/alg/use", async () => {
+    const { keys } = await getPublicJwks(await testPem());
+    expect(keys).toHaveLength(1);
+    const k = keys[0] as Record<string, unknown>;
+    for (const f of ["d", "p", "q", "dp", "dq", "qi"]) expect(k[f]).toBeUndefined();
+    expect(k.kid).toBe("mcp-1");
+    expect(k.alg).toBe("RS256");
+    expect(k.use).toBe("sig");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:run src/lib/mcp/tokens.test.ts`
+Expected: FAIL — cannot resolve `./tokens`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/mcp/tokens.ts
+// Crypto + JWT helpers for the MCP OAuth server. Isomorphic (Web Crypto only):
+// runs in Next.js route handlers, server actions, edge-runtime tests, and the
+// browser (PAT generation in the settings UI). Convex functions never import
+// this — they only ever receive pre-computed hashes.
+import { SignJWT, importPKCS8, exportJWK } from "jose";
+
+export const MCP_JWT_AUDIENCE = "fragrances-mcp";
+export const MCP_JWT_KID = "mcp-1";
+export const ACCESS_TOKEN_TTL_SECONDS = 900; // 15 min
+export const PAT_BRIDGE_TTL_SECONDS = 300; // 5 min
+export const PAT_PREFIX = "fgt_";
+
+export async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function randomBytes(n: number): Uint8Array {
+  const bytes = new Uint8Array(n);
+  crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+/** Opaque secret (refresh tokens, auth codes, PAT bodies): base64url, no padding. */
+export function randomToken(bytes = 32): string {
+  const bin = String.fromCharCode(...randomBytes(bytes));
+  return btoa(bin).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+/** Public identifiers (client_id): lowercase hex. */
+export function randomHex(bytes = 16): string {
+  return Array.from(randomBytes(bytes))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function requireEnv(value: string | undefined, name: string): string {
+  if (!value) throw new Error(`Missing required env var ${name}.`);
+  return value;
+}
+
+async function signingKey(privateKeyPem?: string) {
+  const pem = privateKeyPem ?? requireEnv(process.env.MCP_JWT_PRIVATE_KEY, "MCP_JWT_PRIVATE_KEY");
+  // Env UIs often store the PEM with literal "\n" — normalize.
+  return await importPKCS8(pem.replaceAll("\\n", "\n"), "RS256");
+}
+
+async function mint(
+  subject: string,
+  claims: Record<string, string>,
+  ttlSeconds: number,
+  privateKeyPem?: string,
+  issuer?: string,
+): Promise<string> {
+  return await new SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256", kid: MCP_JWT_KID })
+    .setSubject(subject)
+    .setIssuer(issuer ?? requireEnv(process.env.NEXT_PUBLIC_APP_URL, "NEXT_PUBLIC_APP_URL"))
+    .setAudience(MCP_JWT_AUDIENCE)
+    .setIssuedAt()
+    .setExpirationTime(`${ttlSeconds}s`)
+    .sign(await signingKey(privateKeyPem));
+}
+
+/** OAuth access token: `sub = userId|mcp:grantId`, 15 min. Doubles as the Convex credential. */
+export async function mintAccessToken(opts: {
+  userId: string;
+  grantId: string;
+  clientId: string;
+  scope: string;
+  ttlSeconds?: number;
+  privateKeyPem?: string;
+  issuer?: string;
+}): Promise<string> {
+  return await mint(
+    `${opts.userId}|mcp:${opts.grantId}`,
+    { client_id: opts.clientId, scope: opts.scope },
+    opts.ttlSeconds ?? ACCESS_TOKEN_TTL_SECONDS,
+    opts.privateKeyPem,
+    opts.issuer,
+  );
+}
+
+/** Short-lived Convex credential minted after a PAT passes hash lookup. */
+export async function mintPatBridgeToken(opts: {
+  userId: string;
+  tokenId: string;
+  privateKeyPem?: string;
+  issuer?: string;
+}): Promise<string> {
+  return await mint(
+    `${opts.userId}|pat:${opts.tokenId}`,
+    { client_id: "personal-access-token", scope: "read write" },
+    PAT_BRIDGE_TTL_SECONDS,
+    opts.privateKeyPem,
+    opts.issuer,
+  );
+}
+
+/**
+ * Public JWKS derived from the private key (private fields stripped), plus any
+ * extra public keys from MCP_EXTRA_PUBLIC_JWKS (JSON array) — used to publish a
+ * dev keypair's public half alongside prod (see verification sub-plan).
+ */
+export async function getPublicJwks(privateKeyPem?: string): Promise<{ keys: object[] }> {
+  const jwk = (await exportJWK(await signingKey(privateKeyPem))) as Record<string, unknown>;
+  for (const f of ["d", "p", "q", "dp", "dq", "qi"]) delete jwk[f];
+  const keys: object[] = [{ ...jwk, kid: MCP_JWT_KID, alg: "RS256", use: "sig" }];
+  const extra = process.env.MCP_EXTRA_PUBLIC_JWKS;
+  if (extra) keys.push(...(JSON.parse(extra) as object[]));
+  return { keys };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test:run src/lib/mcp/tokens.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/mcp/tokens.ts src/lib/mcp/tokens.test.ts
+git commit -m "feat: add MCP token crypto and JWT helpers"
+```
+
+---
+
+### Task 4: `src/lib/mcp/oauth-validation.ts` — redirect URIs, PKCE, safe paths
+
+**Files:**
+- Create: `my-app/src/lib/mcp/oauth-validation.ts`
+- Create: `my-app/src/lib/mcp/oauth-validation.test.ts`
+
+**Interfaces:**
+- Produces (consumed by DCR route, token route, Convex `oauth.ts` defense-in-depth checks, sub-plan 4's authorize page and signin redirect):
+  - `isValidRedirectUri(uri: string): boolean` — absolute `https:` URL, or `http:` only for hostname `localhost`/`127.0.0.1` (any port); no URL fragment
+  - `matchesRegisteredRedirect(uri: string, registered: string[]): boolean` — **exact string comparison** (RFC 8252 §8.4 style; no prefix or wildcard matching)
+  - `computeS256Challenge(codeVerifier: string): Promise<string>` — base64url(SHA-256(ascii(verifier))), no padding (RFC 7636 §4.2)
+  - `isSafeInternalPath(path: string): boolean` — begins `/`, not `//`, no `\` (open-redirect guard for `?redirect=`)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/mcp/oauth-validation.test.ts
+import { describe, expect, test } from "vitest";
+import {
+  isValidRedirectUri,
+  matchesRegisteredRedirect,
+  computeS256Challenge,
+  isSafeInternalPath,
+} from "./oauth-validation";
+
+describe("isValidRedirectUri", () => {
+  test.each([
+    ["https://claude.ai/api/mcp/auth_callback", true],
+    ["https://example.com/cb?flavor=a", true],
+    ["http://localhost:33418/callback", true],
+    ["http://127.0.0.1:8976/oauth/cb", true],
+    ["http://evil.com/cb", false], // http on non-loopback
+    ["https://example.com/cb#frag", false], // fragments forbidden (RFC 6749 §3.1.2)
+    ["ftp://example.com/cb", false],
+    ["not a url", false],
+    ["", false],
+  ])("%s → %s", (uri, ok) => {
+    expect(isValidRedirectUri(uri)).toBe(ok);
+  });
+});
+
+describe("matchesRegisteredRedirect", () => {
+  const registered = ["https://a.example/cb", "http://localhost:1234/cb"];
+  test("exact match passes", () => {
+    expect(matchesRegisteredRedirect("https://a.example/cb", registered)).toBe(true);
+  });
+  test.each([
+    "https://a.example/cb/extra", // prefix is not enough
+    "https://a.example/CB", // case-sensitive
+    "https://a.example/cb?x=1", // query must match exactly
+    "http://localhost:9999/cb", // different port
+  ])("non-exact %s fails", (uri) => {
+    expect(matchesRegisteredRedirect(uri, registered)).toBe(false);
+  });
+});
+
+describe("computeS256Challenge", () => {
+  test("matches the RFC 7636 appendix B vector", async () => {
+    expect(await computeS256Challenge("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")).toBe(
+      "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+    );
+  });
+});
+
+describe("isSafeInternalPath", () => {
+  test.each([
+    ["/", true],
+    ["/oauth/authorize?client_id=x&state=y", true],
+    ["//evil.com", false],
+    ["https://evil.com", false],
+    ["/a\\b", false],
+    ["", false],
+  ])("%s → %s", (path, ok) => {
+    expect(isSafeInternalPath(path)).toBe(ok);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:run src/lib/mcp/oauth-validation.test.ts`
+Expected: FAIL — cannot resolve `./oauth-validation`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/mcp/oauth-validation.ts
+// Pure validation helpers for the OAuth server. No env access, no I/O —
+// importable from Next routes, server actions, and Convex functions alike.
+
+/** Registered redirect URIs must be https, or http on loopback only. Fragments are forbidden. */
+export function isValidRedirectUri(uri: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    return false;
+  }
+  if (url.hash !== "") return false;
+  if (url.protocol === "https:") return true;
+  return url.protocol === "http:" && (url.hostname === "localhost" || url.hostname === "127.0.0.1");
+}
+
+/** OAuth redirect_uri matching is exact string comparison — no prefixes, no wildcards. */
+export function matchesRegisteredRedirect(uri: string, registered: string[]): boolean {
+  return registered.includes(uri);
+}
+
+/** PKCE S256: base64url(SHA-256(ascii(code_verifier))), unpadded (RFC 7636 §4.2). */
+export async function computeS256Challenge(codeVerifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(codeVerifier));
+  const bin = String.fromCharCode(...new Uint8Array(digest));
+  return btoa(bin).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+/** Guard for `?redirect=` params: same-origin path only, no scheme-relative or backslash tricks. */
+export function isSafeInternalPath(path: string): boolean {
+  return path.startsWith("/") && !path.startsWith("//") && !path.includes("\\");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test:run src/lib/mcp/oauth-validation.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/mcp/oauth-validation.ts src/lib/mcp/oauth-validation.test.ts
+git commit -m "feat: add OAuth redirect/PKCE/path validation helpers"
+```
+
+---
+
+### Task 5: Rate limits for OAuth endpoints
+
+**Files:**
+- Modify: `my-app/convex/rateLimits.ts`
+
+**Interfaces:**
+- Produces: limit names `oauthRegister` (IP-keyed, 5/hour), `oauthTokenExchange` (IP-keyed, 30/min burst 10), `createApiToken` (user-keyed, 10/hour burst 3) — consumed by Tasks 6–7 via `rateLimiter.limit(ctx, name, { key, throws: true })`.
+
+- [ ] **Step 1: Add the definitions**
+
+In `convex/rateLimits.ts`, change the import to include `HOUR` and append inside the `RateLimiter` config object after the wear-log block:
+
+```ts
+import { RateLimiter, MINUTE, HOUR } from "@convex-dev/rate-limiter";
+```
+
+```ts
+  // ── MCP OAuth endpoints (keys are client IPs passed in from Next routes,
+  // except createApiToken which is per-user) ────────────────────────────
+  oauthRegister: { kind: "token bucket", rate: 5, period: HOUR, capacity: 5 },
+  oauthTokenExchange: { kind: "token bucket", rate: 30, period: MINUTE, capacity: 10 },
+  createApiToken: { kind: "token bucket", rate: 10, period: HOUR, capacity: 3 },
+```
+
+Also extend the doc-comment table at the top of the file with the three new rows, matching its formatting.
+
+- [ ] **Step 2: Verify**
+
+```bash
+bun run typecheck && bun run test:run convex/
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add convex/rateLimits.ts
+git commit -m "feat: add OAuth endpoint rate limits"
+```
+
+---
+
+### Task 6: `convex/oauth.ts` — clients, codes, grants, refresh rotation (test-first)
+
+**Files:**
+- Create: `my-app/convex/oauth.ts`
+- Create: `my-app/convex/oauth.test.ts`
+
+**Interfaces:**
+- Consumes: schema tables (Task 2), rate limits (Task 5), `isValidRedirectUri`/`matchesRegisteredRedirect` from `../src/lib/mcp/oauth-validation` (Task 4 — same cross-import pattern as `wearLogs.ts` importing `../src/lib/constants`).
+- Produces (consumed by the DCR/token routes in Tasks 9–10 and sub-plan 4's consent action / settings UI):
+  - `registerClient` (public mutation): `{ clientId, clientName, redirectUris, ip }` → `null`; throws `ConvexError({ code: "invalid_redirect_uri" })` on bad URIs
+  - `getClientPublic` (public query): `{ clientId }` → `{ clientId, clientName, redirectUris } | null`
+  - `createAuthCode` (authed mutation): `{ clientId, redirectUri, codeHash, codeChallenge, scope, resource? }` → `null`
+  - `exchangeAuthCode` (public mutation): `{ codeHash, clientId, redirectUri, codeChallenge, refreshTokenHash, ip }` → `{ userId, grantId, scope }`; throws `ConvexError({ code: "invalid_grant", message })`
+  - `rotateRefreshToken` (public mutation): `{ tokenHash, newTokenHash, clientId, ip }` → `{ userId, grantId, scope }`; same error shape
+  - `listGrants` (authed query): `{}` → `Array<{ _id, clientName, scope, createdAt, lastUsedAt? }>` (active only)
+  - `revokeGrant` (authed mutation): `{ grantId }` → `null`
+- Error contract: all OAuth-protocol failures throw `ConvexError` whose `.data.code` is an RFC 6749 error code; the token route maps it to the HTTP body. **Public mutations are deliberately callable without auth** (Next calls them server-side unauthenticated); they handle only hashes, throw uniform `invalid_grant`, and are rate-limited — note this in a file-top comment.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// convex/oauth.test.ts
+import { ConvexError } from "convex/values";
+import { beforeEach, describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import { createTestUser, setupTest } from "./test.setup";
+
+const IP = "203.0.113.7";
+const CLIENT = {
+  clientId: "abc123abc123abc123abc123abc123ab",
+  clientName: "Claude",
+  redirectUris: ["https://claude.ai/api/mcp/auth_callback"],
+  ip: IP,
+};
+const REDIRECT = CLIENT.redirectUris[0];
+const CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+type T = ReturnType<typeof setupTest>;
+
+async function mintCode(t: T, as: Awaited<ReturnType<typeof createTestUser>>["as"], codeHash: string) {
+  await as.mutation(api.oauth.createAuthCode, {
+    clientId: CLIENT.clientId,
+    redirectUri: REDIRECT,
+    codeHash,
+    codeChallenge: CHALLENGE,
+    scope: "read write",
+  });
+}
+
+function exchangeArgs(codeHash: string, overrides: Partial<Record<string, string>> = {}) {
+  return {
+    codeHash,
+    clientId: CLIENT.clientId,
+    redirectUri: REDIRECT,
+    codeChallenge: CHALLENGE,
+    refreshTokenHash: "rt-hash-1",
+    ip: IP,
+    ...overrides,
+  };
+}
+
+describe("oauth", () => {
+  let t: T;
+  beforeEach(async () => {
+    t = setupTest();
+    await t.mutation(api.oauth.registerClient, CLIENT);
+  });
+
+  test("registerClient rejects invalid redirect URIs", async () => {
+    await expect(
+      t.mutation(api.oauth.registerClient, {
+        ...CLIENT,
+        clientId: "otherotherotherotherotherotherot",
+        redirectUris: ["http://evil.com/cb"],
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  test("getClientPublic returns registered metadata, null for unknown", async () => {
+    const client = await t.query(api.oauth.getClientPublic, { clientId: CLIENT.clientId });
+    expect(client).toMatchObject({ clientName: "Claude", redirectUris: [REDIRECT] });
+    expect(await t.query(api.oauth.getClientPublic, { clientId: "nope" })).toBeNull();
+  });
+
+  test("createAuthCode requires auth", async () => {
+    await expect(
+      t.mutation(api.oauth.createAuthCode, {
+        clientId: CLIENT.clientId,
+        redirectUri: REDIRECT,
+        codeHash: "h",
+        codeChallenge: CHALLENGE,
+        scope: "read write",
+      }),
+    ).rejects.toThrow("Unauthenticated");
+  });
+
+  test("exchangeAuthCode happy path creates a grant and returns it", async () => {
+    const { userId, as } = await createTestUser(t);
+    await mintCode(t, as, "code-hash-1");
+    const result = await t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-1"));
+    expect(result.userId).toBe(userId);
+    expect(result.scope).toBe("read write");
+    const grants = await as.query(api.oauth.listGrants, {});
+    expect(grants).toHaveLength(1);
+    expect(grants[0].clientName).toBe("Claude");
+  });
+
+  test("exchangeAuthCode rejects a wrong PKCE challenge", async () => {
+    const { as } = await createTestUser(t);
+    await mintCode(t, as, "code-hash-2");
+    await expect(
+      t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-2", { codeChallenge: "WRONG" })),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  test("exchangeAuthCode rejects mismatched redirectUri and clientId", async () => {
+    const { as } = await createTestUser(t);
+    await mintCode(t, as, "code-hash-3");
+    await expect(
+      t.mutation(
+        api.oauth.exchangeAuthCode,
+        exchangeArgs("code-hash-3", { redirectUri: "https://claude.ai/other" }),
+      ),
+    ).rejects.toThrow(ConvexError);
+    await expect(
+      t.mutation(
+        api.oauth.exchangeAuthCode,
+        exchangeArgs("code-hash-3", { clientId: "wrongwrongwrongwrongwrongwrongwr" }),
+      ),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  test("a code is single-use; reuse revokes the grant", async () => {
+    const { as } = await createTestUser(t);
+    await mintCode(t, as, "code-hash-4");
+    await t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-4"));
+    await expect(
+      t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-4")),
+    ).rejects.toThrow(ConvexError);
+    expect(await as.query(api.oauth.listGrants, {})).toHaveLength(0);
+  });
+
+  test("expired codes are rejected", async () => {
+    const { as } = await createTestUser(t);
+    await mintCode(t, as, "code-hash-5");
+    await t.run(async (ctx) => {
+      const code = await ctx.db
+        .query("oauthAuthCodes")
+        .withIndex("by_code_hash", (q) => q.eq("codeHash", "code-hash-5"))
+        .unique();
+      await ctx.db.patch(code!._id, { expiresAt: Date.now() - 1 });
+    });
+    await expect(
+      t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-5")),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  test("refresh rotation works and reuse of a rotated token revokes the whole grant", async () => {
+    const { as } = await createTestUser(t);
+    await mintCode(t, as, "code-hash-6");
+    await t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-6"));
+
+    // Rotate rt-hash-1 → rt-hash-2: OK.
+    const rotated = await t.mutation(api.oauth.rotateRefreshToken, {
+      tokenHash: "rt-hash-1",
+      newTokenHash: "rt-hash-2",
+      clientId: CLIENT.clientId,
+      ip: IP,
+    });
+    expect(rotated.scope).toBe("read write");
+
+    // Reusing the rotated rt-hash-1 is theft evidence → whole grant dies.
+    await expect(
+      t.mutation(api.oauth.rotateRefreshToken, {
+        tokenHash: "rt-hash-1",
+        newTokenHash: "rt-hash-3",
+        clientId: CLIENT.clientId,
+        ip: IP,
+      }),
+    ).rejects.toThrow(ConvexError);
+    expect(await as.query(api.oauth.listGrants, {})).toHaveLength(0);
+
+    // The descendant token is dead too.
+    await expect(
+      t.mutation(api.oauth.rotateRefreshToken, {
+        tokenHash: "rt-hash-2",
+        newTokenHash: "rt-hash-4",
+        clientId: CLIENT.clientId,
+        ip: IP,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  test("revokeGrant hides the grant and kills its refresh tokens", async () => {
+    const { as } = await createTestUser(t);
+    await mintCode(t, as, "code-hash-7");
+    await t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-7"));
+    const [grant] = await as.query(api.oauth.listGrants, {});
+    await as.mutation(api.oauth.revokeGrant, { grantId: grant._id });
+    expect(await as.query(api.oauth.listGrants, {})).toHaveLength(0);
+    await expect(
+      t.mutation(api.oauth.rotateRefreshToken, {
+        tokenHash: "rt-hash-1",
+        newTokenHash: "rt-hash-9",
+        clientId: CLIENT.clientId,
+        ip: IP,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  test("revokeGrant rejects a grant owned by another user", async () => {
+    const { as } = await createTestUser(t);
+    const { as: asOther } = await createTestUser(t);
+    await mintCode(t, as, "code-hash-8");
+    await t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-8"));
+    const [grant] = await as.query(api.oauth.listGrants, {});
+    await expect(asOther.mutation(api.oauth.revokeGrant, { grantId: grant._id })).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun run test:run convex/oauth.test.ts`
+Expected: FAIL — `api.oauth` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// convex/oauth.ts
+// OAuth 2.1 storage layer. SECURITY MODEL: the *Next.js* routes generate every
+// raw secret and hash it; these functions only store/compare hashes and opaque
+// strings — no crypto here (Convex's default runtime lacks async crypto.subtle).
+// registerClient / exchangeAuthCode / rotateRefreshToken are public mutations
+// called server-side without user auth; they are IP-rate-limited, operate only
+// on hashes, and fail uniformly with `invalid_grant` so nothing is enumerable.
+import { ConvexError, v } from "convex/values";
+import { mutation, query, MutationCtx } from "./_generated/server";
+import { Doc, Id } from "./_generated/dataModel";
+import { getUserId } from "./helpers";
+import { rateLimiter } from "./rateLimits";
+import { isValidRedirectUri, matchesRegisteredRedirect } from "../src/lib/mcp/oauth-validation";
+
+const AUTH_CODE_TTL_MS = 10 * 60 * 1000; // RFC 6749 §4.1.2: codes MUST be short-lived
+const REFRESH_TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+function invalidGrant(message: string): ConvexError<{ code: string; message: string }> {
+  return new ConvexError({ code: "invalid_grant", message });
+}
+
+async function revokeGrantById(ctx: MutationCtx, grantId: Id<"oauthGrants">): Promise<void> {
+  const now = Date.now();
+  const grant = await ctx.db.get(grantId);
+  if (grant && grant.revokedAt === undefined) {
+    await ctx.db.patch(grantId, { revokedAt: now });
+  }
+  const tokens = await ctx.db
+    .query("oauthRefreshTokens")
+    .withIndex("by_grant", (q) => q.eq("grantId", grantId))
+    .collect();
+  await Promise.all(
+    tokens
+      .filter((t) => t.revokedAt === undefined)
+      .map((t) => ctx.db.patch(t._id, { revokedAt: now })),
+  );
+}
+
+async function findGrantForUserClient(
+  ctx: MutationCtx,
+  userId: Id<"users">,
+  clientId: string,
+): Promise<Doc<"oauthGrants"> | null> {
+  const grants = await ctx.db
+    .query("oauthGrants")
+    .withIndex("by_user_client", (q) => q.eq("userId", userId).eq("clientId", clientId))
+    .collect();
+  return grants.find((g) => g.revokedAt === undefined) ?? null;
+}
+
+// ── Dynamic client registration (RFC 7591) ───────────────────────────────────
+
+export const registerClient = mutation({
+  args: {
+    clientId: v.string(),
+    clientName: v.string(),
+    redirectUris: v.array(v.string()),
+    ip: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await rateLimiter.limit(ctx, "oauthRegister", { key: args.ip, throws: true });
+    // Defense in depth: the Next route already validated; never trust one layer.
+    if (args.redirectUris.length === 0 || !args.redirectUris.every(isValidRedirectUri)) {
+      throw new ConvexError({
+        code: "invalid_redirect_uri",
+        message: "redirect_uris must be https, or http on localhost only, without fragments.",
+      });
+    }
+    await ctx.db.insert("oauthClients", {
+      clientId: args.clientId,
+      clientName: args.clientName,
+      redirectUris: args.redirectUris,
+      tokenEndpointAuthMethod: "none",
+      createdAt: Date.now(),
+    });
+    return null;
+  },
+});
+
+export const getClientPublic = query({
+  args: { clientId: v.string() },
+  handler: async (ctx, args) => {
+    const client = await ctx.db
+      .query("oauthClients")
+      .withIndex("by_client_id", (q) => q.eq("clientId", args.clientId))
+      .unique();
+    if (!client) return null;
+    return {
+      clientId: client.clientId,
+      clientName: client.clientName,
+      redirectUris: client.redirectUris,
+    };
+  },
+});
+
+// ── Authorization codes ───────────────────────────────────────────────────────
+
+/** Called (authed) by the consent-page server action after the user approves. */
+export const createAuthCode = mutation({
+  args: {
+    clientId: v.string(),
+    redirectUri: v.string(),
+    codeHash: v.string(),
+    codeChallenge: v.string(),
+    scope: v.string(),
+    resource: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getUserId(ctx);
+    const client = await ctx.db
+      .query("oauthClients")
+      .withIndex("by_client_id", (q) => q.eq("clientId", args.clientId))
+      .unique();
+    if (!client || !matchesRegisteredRedirect(args.redirectUri, client.redirectUris)) {
+      throw new ConvexError({ code: "invalid_request", message: "Unknown client or redirect URI." });
+    }
+    await ctx.db.insert("oauthAuthCodes", {
+      codeHash: args.codeHash,
+      clientId: args.clientId,
+      userId,
+      redirectUri: args.redirectUri,
+      codeChallenge: args.codeChallenge,
+      scope: args.scope,
+      resource: args.resource,
+      expiresAt: Date.now() + AUTH_CODE_TTL_MS,
+    });
+    return null;
+  },
+});
+
+/**
+ * Token-endpoint authorization_code grant. Atomically enforces single-use,
+ * expiry, client/redirect binding, and PKCE, then upserts the grant and stores
+ * the first refresh-token hash. Reuse of a consumed code revokes the grant
+ * (RFC 6749 §4.1.2 SHOULD).
+ */
+export const exchangeAuthCode = mutation({
+  args: {
+    codeHash: v.string(),
+    clientId: v.string(),
+    redirectUri: v.string(),
+    codeChallenge: v.string(),
+    refreshTokenHash: v.string(),
+    ip: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await rateLimiter.limit(ctx, "oauthTokenExchange", { key: args.ip, throws: true });
+    const now = Date.now();
+    const code = await ctx.db
+      .query("oauthAuthCodes")
+      .withIndex("by_code_hash", (q) => q.eq("codeHash", args.codeHash))
+      .unique();
+    if (!code) throw invalidGrant("Unknown authorization code.");
+    if (code.usedAt !== undefined) {
+      const grant = await findGrantForUserClient(ctx, code.userId, code.clientId);
+      if (grant) await revokeGrantById(ctx, grant._id);
+      throw invalidGrant("Authorization code already used.");
+    }
+    if (code.expiresAt < now) throw invalidGrant("Authorization code expired.");
+    if (code.clientId !== args.clientId) throw invalidGrant("Client mismatch.");
+    if (code.redirectUri !== args.redirectUri) throw invalidGrant("redirect_uri mismatch.");
+    if (code.codeChallenge !== args.codeChallenge) throw invalidGrant("PKCE verification failed.");
+
+    await ctx.db.patch(code._id, { usedAt: now });
+
+    let grant = await findGrantForUserClient(ctx, code.userId, code.clientId);
+    if (grant) {
+      await ctx.db.patch(grant._id, { lastUsedAt: now, scope: code.scope });
+    } else {
+      const client = await ctx.db
+        .query("oauthClients")
+        .withIndex("by_client_id", (q) => q.eq("clientId", code.clientId))
+        .unique();
+      const grantId = await ctx.db.insert("oauthGrants", {
+        userId: code.userId,
+        clientId: code.clientId,
+        clientName: client?.clientName ?? code.clientId,
+        scope: code.scope,
+        createdAt: now,
+      });
+      grant = (await ctx.db.get(grantId))!;
+    }
+
+    await ctx.db.insert("oauthRefreshTokens", {
+      tokenHash: args.refreshTokenHash,
+      grantId: grant._id,
+      userId: code.userId,
+      clientId: code.clientId,
+      expiresAt: now + REFRESH_TOKEN_TTL_MS,
+    });
+
+    return { userId: code.userId, grantId: grant._id, scope: code.scope };
+  },
+});
+
+// ── Refresh-token rotation ────────────────────────────────────────────────────
+
+/**
+ * Token-endpoint refresh_token grant. Every use rotates the token; presenting
+ * a token that was already rotated or revoked is treated as theft and revokes
+ * the entire grant including all descendant tokens.
+ */
+export const rotateRefreshToken = mutation({
+  args: {
+    tokenHash: v.string(),
+    newTokenHash: v.string(),
+    clientId: v.string(),
+    ip: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await rateLimiter.limit(ctx, "oauthTokenExchange", { key: args.ip, throws: true });
+    const now = Date.now();
+    const token = await ctx.db
+      .query("oauthRefreshTokens")
+      .withIndex("by_token_hash", (q) => q.eq("tokenHash", args.tokenHash))
+      .unique();
+    if (!token) throw invalidGrant("Unknown refresh token.");
+    if (token.revokedAt !== undefined || token.replacedBy !== undefined) {
+      await revokeGrantById(ctx, token.grantId); // reuse detected
+      throw invalidGrant("Refresh token reuse detected; grant revoked.");
+    }
+    if (token.expiresAt < now) throw invalidGrant("Refresh token expired.");
+    if (token.clientId !== args.clientId) throw invalidGrant("Client mismatch.");
+    const grant = await ctx.db.get(token.grantId);
+    if (!grant || grant.revokedAt !== undefined) throw invalidGrant("Grant revoked.");
+
+    const newId = await ctx.db.insert("oauthRefreshTokens", {
+      tokenHash: args.newTokenHash,
+      grantId: token.grantId,
+      userId: token.userId,
+      clientId: token.clientId,
+      expiresAt: now + REFRESH_TOKEN_TTL_MS,
+    });
+    await ctx.db.patch(token._id, { replacedBy: newId });
+    await ctx.db.patch(grant._id, { lastUsedAt: now });
+
+    return { userId: token.userId, grantId: token.grantId, scope: grant.scope };
+  },
+});
+
+// ── Settings UI ───────────────────────────────────────────────────────────────
+
+export const listGrants = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getUserId(ctx);
+    const grants = await ctx.db
+      .query("oauthGrants")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+    return grants
+      .filter((g) => g.revokedAt === undefined)
+      .map((g) => ({
+        _id: g._id,
+        clientName: g.clientName,
+        scope: g.scope,
+        createdAt: g.createdAt,
+        lastUsedAt: g.lastUsedAt,
+      }));
+  },
+});
+
+export const revokeGrant = mutation({
+  args: { grantId: v.id("oauthGrants") },
+  handler: async (ctx, args) => {
+    const userId = await getUserId(ctx);
+    const grant = await ctx.db.get(args.grantId);
+    if (!grant || grant.userId !== userId) {
+      throw new Error("Grant not found or access denied.");
+    }
+    await revokeGrantById(ctx, args.grantId);
+    return null;
+  },
+});
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run test:run convex/oauth.test.ts`
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add convex/oauth.ts convex/oauth.test.ts
+git commit -m "feat: add OAuth client/code/grant/refresh Convex layer with rotation reuse detection"
+```
+
+---
+
+### Task 7: `convex/apiTokens.ts` — PATs (test-first)
+
+**Files:**
+- Create: `my-app/convex/apiTokens.ts`
+- Create: `my-app/convex/apiTokens.test.ts`
+
+**Interfaces:**
+- Produces (consumed by sub-plan 3's verifier and sub-plan 4's settings UI):
+  - `create` (authed mutation): `{ tokenHash, name, expiresAt? }` → `Id<"personalAccessTokens">`; rate-limited `createApiToken` per user; scopes fixed to `["read", "write"]`
+  - `validate` (public mutation — mutation, not query, so it can bump `lastUsedAt`): `{ tokenHash }` → `{ userId, tokenId, scopes } | null` (null for unknown/revoked/expired); `lastUsedAt` updated at most every 5 minutes to avoid write amplification
+  - `list` (authed query): `{}` → non-revoked `Array<{ _id, name, createdAt, lastUsedAt?, expiresAt? }>`
+  - `revoke` (authed mutation): `{ tokenId }` → `null`; ownership-checked
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// convex/apiTokens.test.ts
+import { beforeEach, describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import { createTestUser, setupTest } from "./test.setup";
+
+type T = ReturnType<typeof setupTest>;
+
+describe("apiTokens", () => {
+  let t: T;
+  beforeEach(() => {
+    t = setupTest();
+  });
+
+  test("create + validate round-trip", async () => {
+    const { userId, as } = await createTestUser(t);
+    const tokenId = await as.mutation(api.apiTokens.create, { tokenHash: "hash-1", name: "CLI" });
+    const result = await t.mutation(api.apiTokens.validate, { tokenHash: "hash-1" });
+    expect(result).toEqual({ userId, tokenId, scopes: ["read", "write"] });
+  });
+
+  test("validate returns null for unknown hashes", async () => {
+    expect(await t.mutation(api.apiTokens.validate, { tokenHash: "nope" })).toBeNull();
+  });
+
+  test("revoked tokens stop validating and drop out of list", async () => {
+    const { as } = await createTestUser(t);
+    const tokenId = await as.mutation(api.apiTokens.create, { tokenHash: "hash-2", name: "CLI" });
+    await as.mutation(api.apiTokens.revoke, { tokenId });
+    expect(await t.mutation(api.apiTokens.validate, { tokenHash: "hash-2" })).toBeNull();
+    expect(await as.query(api.apiTokens.list, {})).toHaveLength(0);
+  });
+
+  test("expired tokens stop validating", async () => {
+    const { as } = await createTestUser(t);
+    await as.mutation(api.apiTokens.create, {
+      tokenHash: "hash-3",
+      name: "short",
+      expiresAt: Date.now() - 1,
+    });
+    expect(await t.mutation(api.apiTokens.validate, { tokenHash: "hash-3" })).toBeNull();
+  });
+
+  test("revoke rejects tokens owned by another user", async () => {
+    const { as } = await createTestUser(t);
+    const { as: asOther } = await createTestUser(t);
+    const tokenId = await as.mutation(api.apiTokens.create, { tokenHash: "hash-4", name: "CLI" });
+    await expect(asOther.mutation(api.apiTokens.revoke, { tokenId })).rejects.toThrow();
+  });
+
+  test("list shows only the caller's active tokens", async () => {
+    const { as } = await createTestUser(t);
+    const { as: asOther } = await createTestUser(t);
+    await as.mutation(api.apiTokens.create, { tokenHash: "hash-5", name: "mine" });
+    await asOther.mutation(api.apiTokens.create, { tokenHash: "hash-6", name: "theirs" });
+    const mine = await as.query(api.apiTokens.list, {});
+    expect(mine).toHaveLength(1);
+    expect(mine[0].name).toBe("mine");
+  });
+
+  test("create is rate limited per user", async () => {
+    const { as } = await createTestUser(t);
+    // createApiToken: burst capacity 3.
+    for (let i = 0; i < 3; i++) {
+      await as.mutation(api.apiTokens.create, { tokenHash: `burst-${i}`, name: `t${i}` });
+    }
+    await expect(
+      as.mutation(api.apiTokens.create, { tokenHash: "burst-overflow", name: "overflow" }),
+    ).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun run test:run convex/apiTokens.test.ts`
+Expected: FAIL — `api.apiTokens` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// convex/apiTokens.ts
+// Personal access tokens for header-auth MCP clients (Claude Code, curl).
+// Raw token ("fgt_..." format) is generated client/Next-side and shown once;
+// only its SHA-256 hex hash reaches Convex.
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { getUserId } from "./helpers";
+import { rateLimiter } from "./rateLimits";
+
+const LAST_USED_UPDATE_INTERVAL_MS = 5 * 60 * 1000;
+
+export const create = mutation({
+  args: {
+    tokenHash: v.string(),
+    name: v.string(),
+    expiresAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getUserId(ctx);
+    await rateLimiter.limit(ctx, "createApiToken", { key: userId, throws: true });
+    if (args.name.length === 0 || args.name.length > 100) {
+      throw new Error("Token name must be 1-100 characters.");
+    }
+    return await ctx.db.insert("personalAccessTokens", {
+      userId,
+      tokenHash: args.tokenHash,
+      name: args.name,
+      scopes: ["read", "write"],
+      createdAt: Date.now(),
+      expiresAt: args.expiresAt,
+    });
+  },
+});
+
+/**
+ * Called (unauthenticated, server-side) by the MCP bearer verifier. A mutation
+ * rather than a query so it can bump lastUsedAt — throttled to one write per
+ * 5 minutes per token so hot agents don't burn mutation quota.
+ */
+export const validate = mutation({
+  args: { tokenHash: v.string() },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const token = await ctx.db
+      .query("personalAccessTokens")
+      .withIndex("by_token_hash", (q) => q.eq("tokenHash", args.tokenHash))
+      .unique();
+    if (!token) return null;
+    if (token.revokedAt !== undefined) return null;
+    if (token.expiresAt !== undefined && token.expiresAt < now) return null;
+    if (token.lastUsedAt === undefined || now - token.lastUsedAt > LAST_USED_UPDATE_INTERVAL_MS) {
+      await ctx.db.patch(token._id, { lastUsedAt: now });
+    }
+    return { userId: token.userId, tokenId: token._id, scopes: token.scopes };
+  },
+});
+
+export const list = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getUserId(ctx);
+    const tokens = await ctx.db
+      .query("personalAccessTokens")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+    return tokens
+      .filter((t) => t.revokedAt === undefined)
+      .map((t) => ({
+        _id: t._id,
+        name: t.name,
+        createdAt: t.createdAt,
+        lastUsedAt: t.lastUsedAt,
+        expiresAt: t.expiresAt,
+      }));
+  },
+});
+
+export const revoke = mutation({
+  args: { tokenId: v.id("personalAccessTokens") },
+  handler: async (ctx, args) => {
+    const userId = await getUserId(ctx);
+    const token = await ctx.db.get(args.tokenId);
+    if (!token || token.userId !== userId) {
+      throw new Error("Token not found or access denied.");
+    }
+    await ctx.db.patch(args.tokenId, { revokedAt: Date.now() });
+    return null;
+  },
+});
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run test:run convex/apiTokens.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add convex/apiTokens.ts convex/apiTokens.test.ts
+git commit -m "feat: add personal access token Convex layer"
+```
+
+---
+
+### Task 8: Register the `customJwt` provider in Convex auth config
+
+**Files:**
+- Modify: `my-app/convex/auth.config.ts`
+
+**Interfaces:**
+- Produces: Convex accepts our RS256 JWTs via `ctx.auth.getUserIdentity()`; `getAuthUserId()` then resolves `sub.split("|")[0]` — the entire existing data layer works unchanged for MCP callers (epic §3.1).
+
+- [ ] **Step 1: Replace the file**
+
+```ts
+// convex/auth.config.ts
+const authConfig = {
+  providers: [
+    {
+      domain: process.env.CONVEX_SITE_URL,
+      applicationID: "convex",
+    },
+    // MCP access tokens: RS256 JWTs minted by the Next.js OAuth server under a
+    // dedicated keypair. `sub` is "userId|mcp:grantId" or "userId|pat:tokenId",
+    // which getAuthUserId() resolves via sub.split("|")[0] — same shape Convex
+    // Auth itself uses ("userId|sessionId").
+    {
+      type: "customJwt",
+      applicationID: "fragrances-mcp",
+      issuer: process.env.MCP_JWT_ISSUER,
+      jwks: process.env.MCP_JWKS_URL,
+      algorithm: "RS256",
+    },
+  ],
+};
+
+export default authConfig;
+```
+
+- [ ] **Step 2: Verify the dev deployment accepts the config**
+
+With `MCP_JWT_ISSUER` and `MCP_JWKS_URL` set in the Convex dev dashboard (Task 1):
+
+```bash
+bunx convex dev --once
+```
+
+Expected: deploys without config errors. Then `bun run typecheck && bun run test:run convex/` — PASS (convex-test ignores auth.config).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add convex/auth.config.ts
+git commit -m "feat: register MCP customJwt auth provider"
+```
+
+---
+
+### Task 9: Metadata + JWKS routes (RFC 8414, RFC 9728) with CORS
+
+**Files:**
+- Create: `my-app/src/lib/mcp/cors.ts`
+- Create: `my-app/src/app/api/oauth/jwks/route.ts`
+- Create: `my-app/src/app/.well-known/oauth-authorization-server/route.ts`
+- Create: `my-app/src/app/.well-known/oauth-protected-resource/[[...path]]/route.ts`
+
+**Interfaces:**
+- Produces: discovery endpoints agents hit anonymously from browser contexts. CORS contract (all three routes): `Access-Control-Allow-Origin: *`, `Access-Control-Allow-Methods: GET, POST, OPTIONS`, `Access-Control-Allow-Headers: Content-Type, Authorization, mcp-protocol-version`; `OPTIONS` returns 204 with those headers. `src/proxy.ts` needs no change: its matcher `"/((?!.*\\..*|_next).*)"` already skips dotted paths (`.well-known`) and `/api/*` is passed through without redirects.
+
+- [ ] **Step 1: Write the CORS helper**
+
+```ts
+// src/lib/mcp/cors.ts
+// Agents (claude.ai, ChatGPT) fetch OAuth metadata from browser contexts on
+// other origins, so every metadata/token endpoint must answer CORS preflights.
+export const OAUTH_CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, mcp-protocol-version",
+  "Access-Control-Max-Age": "86400",
+};
+
+export function corsJson(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...OAUTH_CORS_HEADERS,
+      ...init.headers,
+    },
+  });
+}
+
+export function corsPreflight(): Response {
+  return new Response(null, { status: 204, headers: OAUTH_CORS_HEADERS });
+}
+
+export function appOrigin(): string {
+  const origin = process.env.NEXT_PUBLIC_APP_URL;
+  if (!origin) throw new Error("Missing required env var NEXT_PUBLIC_APP_URL.");
+  return origin.replace(/\/$/, "");
+}
+```
+
+- [ ] **Step 2: JWKS route**
+
+```ts
+// src/app/api/oauth/jwks/route.ts
+import { getPublicJwks } from "@/lib/mcp/tokens";
+import { corsJson, corsPreflight } from "@/lib/mcp/cors";
+
+export async function GET() {
+  return corsJson(await getPublicJwks(), {
+    headers: { "Cache-Control": "public, max-age=3600" },
+  });
+}
+
+export function OPTIONS() {
+  return corsPreflight();
+}
+```
+
+- [ ] **Step 3: Authorization-server metadata (RFC 8414)**
+
+```ts
+// src/app/.well-known/oauth-authorization-server/route.ts
+import { appOrigin, corsJson, corsPreflight } from "@/lib/mcp/cors";
+
+export function GET() {
+  const origin = appOrigin();
+  return corsJson({
+    issuer: origin,
+    authorization_endpoint: `${origin}/oauth/authorize`,
+    token_endpoint: `${origin}/api/oauth/token`,
+    registration_endpoint: `${origin}/api/oauth/register`,
+    jwks_uri: `${origin}/api/oauth/jwks`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["none"],
+    scopes_supported: ["read", "write"],
+  });
+}
+
+export function OPTIONS() {
+  return corsPreflight();
+}
+```
+
+- [ ] **Step 4: Protected-resource metadata (RFC 9728), catch-all**
+
+Catch-all because some connectors request `/.well-known/oauth-protected-resource/api/mcp` (path-suffixed variant) — both must answer (epic risk #4).
+
+```ts
+// src/app/.well-known/oauth-protected-resource/[[...path]]/route.ts
+import { appOrigin, corsJson, corsPreflight } from "@/lib/mcp/cors";
+
+export function GET() {
+  const origin = appOrigin();
+  return corsJson({
+    resource: `${origin}/api/mcp`,
+    authorization_servers: [origin],
+    bearer_methods_supported: ["header"],
+    scopes_supported: ["read", "write"],
+  });
+}
+
+export function OPTIONS() {
+  return corsPreflight();
+}
+```
+
+- [ ] **Step 5: Verify with curl (dev server running)**
+
+```bash
+curl -si http://localhost:3000/.well-known/oauth-authorization-server | head -20
+curl -si http://localhost:3000/.well-known/oauth-protected-resource/api/mcp | head -20
+curl -si http://localhost:3000/api/oauth/jwks | head -20
+curl -si -X OPTIONS http://localhost:3000/.well-known/oauth-authorization-server
+```
+
+Expected: three 200s with `access-control-allow-origin: *` and the JSON bodies above (JWKS `keys[0]` has `kid: "mcp-1"`, no `d` field); OPTIONS → 204. Also confirm no redirect to `/signin` occurred (middleware bypass works).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/mcp/cors.ts src/app/api/oauth/jwks src/app/.well-known
+git commit -m "feat: add JWKS and OAuth discovery metadata endpoints"
+```
+
+---
+
+### Task 10: Dynamic client registration route (RFC 7591)
+
+**Files:**
+- Create: `my-app/src/app/api/oauth/register/route.ts`
+
+**Interfaces:**
+- Consumes: `randomHex` (Task 3), `isValidRedirectUri` (Task 4), `api.oauth.registerClient` (Task 6), CORS helper (Task 9).
+- Produces: `POST /api/oauth/register` for public clients. Success: **201** `{ client_id, client_name, redirect_uris, token_endpoint_auth_method: "none", grant_types: [...], response_types: ["code"] }`. Errors: **400** `{ error: "invalid_client_metadata" | "invalid_redirect_uri", error_description }`; **429** `{ error: "rate_limited" }` when the IP limit trips.
+
+- [ ] **Step 1: Write the route**
+
+```ts
+// src/app/api/oauth/register/route.ts
+import { ConvexHttpClient } from "convex/browser";
+import { ConvexError } from "convex/values";
+import { api } from "../../../../../convex/_generated/api";
+import { corsJson, corsPreflight } from "@/lib/mcp/cors";
+import { randomHex } from "@/lib/mcp/tokens";
+import { isValidRedirectUri } from "@/lib/mcp/oauth-validation";
+
+const MAX_REDIRECT_URIS = 10;
+const MAX_URI_LENGTH = 2000;
+
+function clientIp(req: Request): string {
+  return req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+}
+
+function registrationError(error: string, description: string): Response {
+  return corsJson({ error, error_description: description }, { status: 400 });
+}
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return registrationError("invalid_client_metadata", "Request body must be JSON.");
+  }
+  const meta = body as { client_name?: unknown; redirect_uris?: unknown };
+
+  const clientName =
+    typeof meta.client_name === "string" && meta.client_name.trim().length > 0
+      ? meta.client_name.trim().slice(0, 200)
+      : null;
+  if (!clientName) {
+    return registrationError("invalid_client_metadata", "client_name is required.");
+  }
+
+  const uris = meta.redirect_uris;
+  if (
+    !Array.isArray(uris) ||
+    uris.length === 0 ||
+    uris.length > MAX_REDIRECT_URIS ||
+    !uris.every((u) => typeof u === "string" && u.length <= MAX_URI_LENGTH)
+  ) {
+    return registrationError(
+      "invalid_redirect_uri",
+      `redirect_uris must be 1-${MAX_REDIRECT_URIS} strings.`,
+    );
+  }
+  const bad = (uris as string[]).find((u) => !isValidRedirectUri(u));
+  if (bad) {
+    return registrationError(
+      "invalid_redirect_uri",
+      `Invalid redirect URI (must be https, or http://localhost, no fragment): ${bad}`,
+    );
+  }
+
+  const clientId = randomHex(16);
+  const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+  try {
+    await convex.mutation(api.oauth.registerClient, {
+      clientId,
+      clientName,
+      redirectUris: uris as string[],
+      ip: clientIp(req),
+    });
+  } catch (error) {
+    if (error instanceof ConvexError) {
+      const data = error.data as { code?: string; message?: string };
+      if (data.code === "invalid_redirect_uri") {
+        return registrationError("invalid_redirect_uri", data.message ?? "Invalid redirect URI.");
+      }
+      // Rate limiter throws ConvexError with retryAfter.
+      return corsJson({ error: "rate_limited" }, { status: 429 });
+    }
+    throw error;
+  }
+
+  return corsJson(
+    {
+      client_id: clientId,
+      client_name: clientName,
+      redirect_uris: uris,
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+    },
+    { status: 201, headers: { "Cache-Control": "no-store" } },
+  );
+}
+
+export function OPTIONS() {
+  return corsPreflight();
+}
+```
+
+- [ ] **Step 2: Verify with curl (dev server + `bunx convex dev` running)**
+
+```bash
+curl -si -X POST http://localhost:3000/api/oauth/register \
+  -H "Content-Type: application/json" \
+  -d '{"client_name":"Test Client","redirect_uris":["http://localhost:6274/oauth/callback"]}'
+```
+
+Expected: 201 with a `client_id`. Error paths:
+
+```bash
+# bad URI → 400 invalid_redirect_uri
+curl -s -X POST http://localhost:3000/api/oauth/register \
+  -H "Content-Type: application/json" \
+  -d '{"client_name":"x","redirect_uris":["http://evil.com/cb"]}'
+# missing name → 400 invalid_client_metadata
+curl -s -X POST http://localhost:3000/api/oauth/register \
+  -H "Content-Type: application/json" -d '{"redirect_uris":["https://a.example/cb"]}'
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/oauth/register
+git commit -m "feat: add RFC 7591 dynamic client registration endpoint"
+```
+
+---
+
+### Task 11: Token endpoint — authorization_code + refresh_token grants
+
+**Files:**
+- Create: `my-app/src/app/api/oauth/token/route.ts`
+
+**Interfaces:**
+- Consumes: `sha256Hex`/`randomToken`/`mintAccessToken` (Task 3), `computeS256Challenge` (Task 4), `api.oauth.exchangeAuthCode`/`api.oauth.rotateRefreshToken` (Task 6), CORS helper (Task 9).
+- Produces: `POST /api/oauth/token` (form-encoded). Success (both grants): **200** `{ access_token, token_type: "Bearer", expires_in: 900, refresh_token, scope }` with `Cache-Control: no-store, Pragma: no-cache`. Error table (all JSON, CORS'd):
+
+| Condition | Status | `error` |
+|---|---|---|
+| Body not form-encoded / missing required param | 400 | `invalid_request` |
+| `grant_type` not `authorization_code`/`refresh_token` | 400 | `unsupported_grant_type` |
+| Convex threw `invalid_grant` (bad/expired/reused code, PKCE fail, redirect/client mismatch, reused/revoked/expired refresh token) | 400 | `invalid_grant` |
+| IP rate limit tripped | 429 | `rate_limited` |
+
+- [ ] **Step 1: Write the route**
+
+```ts
+// src/app/api/oauth/token/route.ts
+import { ConvexHttpClient } from "convex/browser";
+import { ConvexError } from "convex/values";
+import { api } from "../../../../../convex/_generated/api";
+import { corsJson, corsPreflight } from "@/lib/mcp/cors";
+import { ACCESS_TOKEN_TTL_SECONDS, mintAccessToken, randomToken, sha256Hex } from "@/lib/mcp/tokens";
+import { computeS256Challenge } from "@/lib/mcp/oauth-validation";
+
+function tokenError(error: string, description?: string, status = 400): Response {
+  return corsJson(
+    { error, ...(description ? { error_description: description } : {}) },
+    { status, headers: { "Cache-Control": "no-store", Pragma: "no-cache" } },
+  );
+}
+
+function clientIp(req: Request): string {
+  return req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+}
+
+function mapConvexError(error: unknown): Response {
+  if (error instanceof ConvexError) {
+    const data = error.data as { code?: string; message?: string; retryAfter?: number };
+    if (data.code === "invalid_grant") return tokenError("invalid_grant", data.message);
+    if (typeof data.retryAfter === "number") return tokenError("rate_limited", undefined, 429);
+  }
+  throw error;
+}
+
+async function successResponse(
+  grant: { userId: string; grantId: string; scope: string },
+  clientId: string,
+  refreshToken: string,
+): Promise<Response> {
+  const accessToken = await mintAccessToken({
+    userId: grant.userId,
+    grantId: grant.grantId,
+    clientId,
+    scope: grant.scope,
+  });
+  return corsJson(
+    {
+      access_token: accessToken,
+      token_type: "Bearer",
+      expires_in: ACCESS_TOKEN_TTL_SECONDS,
+      refresh_token: refreshToken,
+      scope: grant.scope,
+    },
+    { headers: { "Cache-Control": "no-store", Pragma: "no-cache" } },
+  );
+}
+
+export async function POST(req: Request) {
+  let form: URLSearchParams;
+  try {
+    form = new URLSearchParams(await req.text());
+  } catch {
+    return tokenError("invalid_request", "Body must be application/x-www-form-urlencoded.");
+  }
+  const grantType = form.get("grant_type");
+  const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+  const ip = clientIp(req);
+
+  if (grantType === "authorization_code") {
+    const code = form.get("code");
+    const codeVerifier = form.get("code_verifier");
+    const clientId = form.get("client_id");
+    const redirectUri = form.get("redirect_uri");
+    if (!code || !codeVerifier || !clientId || !redirectUri) {
+      return tokenError(
+        "invalid_request",
+        "code, code_verifier, client_id and redirect_uri are required.",
+      );
+    }
+    const refreshToken = randomToken();
+    try {
+      const grant = await convex.mutation(api.oauth.exchangeAuthCode, {
+        codeHash: await sha256Hex(code),
+        clientId,
+        redirectUri,
+        codeChallenge: await computeS256Challenge(codeVerifier),
+        refreshTokenHash: await sha256Hex(refreshToken),
+        ip,
+      });
+      return await successResponse(grant, clientId, refreshToken);
+    } catch (error) {
+      return mapConvexError(error);
+    }
+  }
+
+  if (grantType === "refresh_token") {
+    const refreshToken = form.get("refresh_token");
+    const clientId = form.get("client_id");
+    if (!refreshToken || !clientId) {
+      return tokenError("invalid_request", "refresh_token and client_id are required.");
+    }
+    const newRefreshToken = randomToken();
+    try {
+      const grant = await convex.mutation(api.oauth.rotateRefreshToken, {
+        tokenHash: await sha256Hex(refreshToken),
+        newTokenHash: await sha256Hex(newRefreshToken),
+        clientId,
+        ip,
+      });
+      return await successResponse(grant, clientId, newRefreshToken);
+    } catch (error) {
+      return mapConvexError(error);
+    }
+  }
+
+  return tokenError("unsupported_grant_type");
+}
+
+export function OPTIONS() {
+  return corsPreflight();
+}
+```
+
+- [ ] **Step 2: Verify error paths with curl (dev server + convex dev running)**
+
+```bash
+# unsupported grant type
+curl -s -X POST http://localhost:3000/api/oauth/token -d 'grant_type=password'
+# → {"error":"unsupported_grant_type"}
+
+# missing params
+curl -s -X POST http://localhost:3000/api/oauth/token -d 'grant_type=authorization_code&code=x'
+# → {"error":"invalid_request",...}
+
+# unknown code → invalid_grant
+curl -s -X POST http://localhost:3000/api/oauth/token \
+  -d 'grant_type=authorization_code&code=bogus&code_verifier=bogusverifierbogusverifierbogusverifier123&client_id=x&redirect_uri=https://a.example/cb'
+# → {"error":"invalid_grant",...}
+
+# unknown refresh token → invalid_grant
+curl -s -X POST http://localhost:3000/api/oauth/token \
+  -d 'grant_type=refresh_token&refresh_token=bogus&client_id=x'
+# → {"error":"invalid_grant",...}
+```
+
+The happy path needs a consent page to mint a code — that is sub-plan 4; end-to-end token verification happens in sub-plan 5.
+
+- [ ] **Step 3: Full gate + commit**
+
+```bash
+bun run typecheck && bun run lint && bun run test:run && bun run build
+git add src/app/api/oauth/token
+git commit -m "feat: add OAuth token endpoint with PKCE code and rotating refresh grants"
+```
+
+---
+
+### Task 12: PR
+
+- [ ] **Step 1: Push and open the PR**
+
+```bash
+git push -u origin feat/mcp-oauth-foundation
+gh pr create --title "feat: OAuth 2.1 + PAT token foundation for MCP server" --body "Sub-plan 2/5 of docs/mcp-server-plan.md (issue #65): tables, crypto/JWT helpers, Convex OAuth+PAT layer (test-first: single-use codes, PKCE mismatch, rotation reuse revocation, PAT revocation), customJwt provider, JWKS/metadata/DCR/token endpoints with exact RFC 6749 error semantics + CORS.
+
+Not yet wired: consent UI (sub-plan 4) and MCP tools (sub-plan 3) — token endpoint error paths curl-verified, happy path lands with sub-plan 4.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```

--- a/docs/superpowers/plans/2026-07-06-mcp-3-insights-mcp-tools.md
+++ b/docs/superpowers/plans/2026-07-06-mcp-3-insights-mcp-tools.md
@@ -1,0 +1,1012 @@
+# MCP Sub-plan 3/5: Insight Queries + MCP Tool Surface Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Epic:** `docs/mcp-server-plan.md` (issue #65). Sub-plan 3 of 5. Requires sub-plans 1 (spike findings) and 2 (OAuth foundation) merged. Sub-plan 4 adds the consent/settings UI; sub-plan 5 verifies end-to-end.
+
+> **⚠️ Spike corrections (from `2026-07-06-mcp-0-spike-findings.md` — apply while implementing):**
+> - **C2 (tool registration):** register tools with **`server.registerTool(name, { description, inputSchema }, cb)`** — NOT the deprecated `server.tool(...)`. `inputSchema` is a zod **raw shape** (`{ name: z.string() }`), not `z.object(...)`. A reference `ping` implementation already exists on this branch at `src/app/api/[transport]/route.ts` (rewrite it into the real 12-tool route).
+> - **C1 (zod):** use **`zod@^4`** (4.3.6), not `^3` — `^3` breaks the build (`TS2589`). Author schemas with the zod v4 API.
+> - **C5 (`authInfo.extra`):** the verifier's returned `extra` **survives** to the tool callback (`(args, { authInfo }) => (authInfo!.extra as McpExtra).convexToken`). The WeakMap fallback in sub-plan 1 Task 4 is **not needed**.
+> - **C7 (transport):** responses are SSE-framed (`content-type: text/event-stream`); test clients must send `Accept: application/json, text/event-stream`. No `initialize`/`mcp-session-id` prerequisite in stateless mode.
+
+**Goal:** Add the three insight queries (`convex/insights.ts`, test-first), the dual-mode bearer verifier, the zod tool schemas, and the `/api/mcp` endpoint registering all 13 tools against the existing Convex functions.
+
+**Architecture:** Tool handlers create a `ConvexHttpClient`, call `setAuth(authInfo.extra.convexToken)`, and invoke **existing public Convex functions unchanged** — `getUserId`, `getOwnedDoc`, validators, and per-user write rate limits all apply automatically (epic §3.1). OAuth JWTs *are* the Convex credential; PATs are hash-validated then bridged to a 5-minute JWT. Tool errors return `{ isError: true }` content so agents can self-correct.
+
+**Tech Stack:** mcp-handler@1.1.0 + @modelcontextprotocol/sdk@1.26.0 + **zod@^4** + jose (pinned by sub-plan 1), Convex 1.42, convex-test, Vitest edge-runtime.
+
+## Global Constraints
+
+- All commands run from `/home/code/fragrances-tracker/my-app`.
+- Branch: `feat/mcp-tools` cut from `main` after sub-plan 2's PR merges. Install no packages.
+- **Spike findings govern the mcp-handler API.** Code blocks below use `server.registerTool(name, { description, inputSchema }, cb)` with zod **raw shapes**; if `2026-07-06-mcp-0-spike-findings.md` recorded a different registration method, config keys, or `authInfo` shape, follow findings and keep everything else here intact.
+- Scope model (locked, epic §10): tokens carry `"read write"`; **no per-tool or Convex-side scope enforcement in v1**. The verifier still surfaces `scopes` on `AuthInfo` for future use.
+- Zod bounds must mirror the server bounds exactly (`convex/bottles.ts` / `convex/wearLogs.ts` constants); Convex validators remain authoritative — zod is early feedback only.
+- IDs travel as opaque strings; Convex `v.id()` rejects garbage. Tool descriptions must tell agents where IDs come from.
+- Full gate before PR: `bun run typecheck && bun run lint && bun run test:run && bun run build`.
+- Commit after every task (`feat:` / `test:` prefixes).
+
+---
+
+### Task 1: `convex/insights.ts` — three read queries (test-first)
+
+**Files:**
+- Create: `my-app/convex/insights.ts`
+- Create: `my-app/convex/insights.test.ts`
+
+**Interfaces:**
+- Consumes: `getOptionalUserId` (`convex/helpers.ts`), indexes `by_user`, `by_user_time`, `by_user_bottle_time` (existing schema).
+- Produces (consumed by Task 4's tools):
+  - `listWearLogsFiltered` (query): `{ bottleId?: Id<"bottles">, from?: number, to?: number, limit?: number }` → wear-log docs, `wornAt` **descending**, limit clamped to 1–500 (default 100). Foreign/unknown `bottleId` yields `[]` (index is user-scoped — never leaks).
+  - `collectionStats` (query): `{}` → `{ totals: { bottleCount, totalWears, totalSprays, favoriteCount, unwornBottleCount, mostWornBottleId, leastWornBottleId }, bottles: Array<{ bottleId, name, brand, isFavorite, wears, sprays, avgRating, lastWornAt }> }`. `avgRating`/`lastWornAt` are `null` when unrated/unworn. `mostWornBottleId`: highest `wears` (ties → earliest `createdAt`); `leastWornBottleId`: lowest `wears` **among worn bottles** (unworn ones are already called out via `unwornBottleCount` and `wears: 0` rows); both `null` when no bottle has wears. **This is a new aggregation — the existing `listBottleStats` does not compute `lastWornAt` and is left untouched.**
+  - `collectionSnapshot` (query): `{ recentLogsPerBottle?: number }` (clamped 0–20, default 5) → `{ generatedAt, bottles: Array<{ ...collectionStats bottle row, tags, comments, createdAt, recentLogs: Array<{ wornAt, sprays, context, rating, comment }> }> }` — compact one-shot export for agent-side analysis.
+- All three return empty/zero results for unauthenticated callers (same convention as existing queries).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// convex/insights.test.ts
+import { beforeEach, describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import { createTestUser, setupTest } from "./test.setup";
+import { Id } from "./_generated/dataModel";
+
+type T = ReturnType<typeof setupTest>;
+type As = Awaited<ReturnType<typeof createTestUser>>["as"];
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = Date.now();
+
+async function addBottle(as: As, name: string) {
+  return await as.mutation(api.bottles.addBottle, { name });
+}
+
+async function wear(as: As, bottleId: Id<"bottles">, wornAt: number, sprays = 2, rating?: number) {
+  return await as.mutation(api.wearLogs.addWearLog, { bottleId, wornAt, sprays, rating });
+}
+
+describe("insights", () => {
+  let t: T;
+  beforeEach(() => {
+    t = setupTest();
+  });
+
+  describe("listWearLogsFiltered", () => {
+    test("filters by time range and bottle, newest first", async () => {
+      const { as } = await createTestUser(t);
+      const a = await addBottle(as, "A");
+      const b = await addBottle(as, "B");
+      await wear(as, a, NOW - 3 * DAY);
+      await wear(as, a, NOW - 1 * DAY);
+      await wear(as, b, NOW - 2 * DAY);
+
+      const all = await as.query(api.insights.listWearLogsFiltered, {});
+      expect(all.map((l) => l.bottleId)).toEqual([a, b, a]); // desc by wornAt
+
+      const ranged = await as.query(api.insights.listWearLogsFiltered, {
+        from: NOW - 2.5 * DAY,
+        to: NOW - 1.5 * DAY,
+      });
+      expect(ranged).toHaveLength(1);
+      expect(ranged[0].bottleId).toBe(b);
+
+      const onlyA = await as.query(api.insights.listWearLogsFiltered, { bottleId: a });
+      expect(onlyA).toHaveLength(2);
+    });
+
+    test("clamps limit and never returns another user's logs", async () => {
+      const { as } = await createTestUser(t);
+      const { as: asOther } = await createTestUser(t);
+      const mine = await addBottle(as, "mine");
+      const theirs = await addBottle(asOther, "theirs");
+      await wear(as, mine, NOW - DAY);
+      await wear(as, mine, NOW - 2 * DAY);
+      await wear(asOther, theirs, NOW - DAY);
+
+      expect(await as.query(api.insights.listWearLogsFiltered, { limit: 1 })).toHaveLength(1);
+      expect(await as.query(api.insights.listWearLogsFiltered, { limit: 9999 })).toHaveLength(2);
+      // Foreign bottleId: user-scoped index yields nothing, no error, no leak.
+      expect(await as.query(api.insights.listWearLogsFiltered, { bottleId: theirs })).toEqual([]);
+    });
+  });
+
+  describe("collectionStats", () => {
+    test("aggregates per bottle with lastWornAt and totals, including unworn bottles", async () => {
+      const { as } = await createTestUser(t);
+      const a = await addBottle(as, "A");
+      const b = await addBottle(as, "B");
+      const c = await addBottle(as, "C"); // never worn
+      await as.mutation(api.bottles.toggleFavorite, { bottleId: c });
+      await wear(as, a, NOW - 3 * DAY, 2, 8);
+      await wear(as, a, NOW - 1 * DAY, 3, 6);
+      await wear(as, b, NOW - 2 * DAY, 4);
+
+      const stats = await as.query(api.insights.collectionStats, {});
+      expect(stats.totals).toEqual({
+        bottleCount: 3,
+        totalWears: 3,
+        totalSprays: 9,
+        favoriteCount: 1,
+        unwornBottleCount: 1,
+        mostWornBottleId: a,
+        leastWornBottleId: b,
+      });
+
+      const rowA = stats.bottles.find((x) => x.bottleId === a)!;
+      expect(rowA).toMatchObject({ name: "A", wears: 2, sprays: 5, avgRating: 7 });
+      expect(rowA.lastWornAt).toBe(NOW - 1 * DAY);
+
+      const rowC = stats.bottles.find((x) => x.bottleId === c)!;
+      expect(rowC).toMatchObject({ wears: 0, sprays: 0, avgRating: null, lastWornAt: null, isFavorite: true });
+    });
+
+    test("empty collection yields zero totals with null most/least worn", async () => {
+      const { as } = await createTestUser(t);
+      const stats = await as.query(api.insights.collectionStats, {});
+      expect(stats.bottles).toEqual([]);
+      expect(stats.totals.mostWornBottleId).toBeNull();
+      expect(stats.totals.leastWornBottleId).toBeNull();
+    });
+  });
+
+  describe("collectionSnapshot", () => {
+    test("returns bottles with stats and capped recent logs, newest first", async () => {
+      const { as } = await createTestUser(t);
+      const a = await addBottle(as, "A");
+      for (let i = 1; i <= 4; i++) await wear(as, a, NOW - i * DAY);
+
+      const snap = await as.query(api.insights.collectionSnapshot, { recentLogsPerBottle: 2 });
+      expect(snap.bottles).toHaveLength(1);
+      const row = snap.bottles[0];
+      expect(row.wears).toBe(4);
+      expect(row.recentLogs).toHaveLength(2);
+      expect(row.recentLogs[0].wornAt).toBe(NOW - 1 * DAY);
+      expect(row.recentLogs[1].wornAt).toBe(NOW - 2 * DAY);
+    });
+
+    test("does not include other users' data", async () => {
+      const { as } = await createTestUser(t);
+      const { as: asOther } = await createTestUser(t);
+      await addBottle(asOther, "theirs");
+      const snap = await as.query(api.insights.collectionSnapshot, {});
+      expect(snap.bottles).toEqual([]);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun run test:run convex/insights.test.ts`
+Expected: FAIL — `api.insights` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// convex/insights.ts
+// Read-only, insight-shaped queries for MCP agents. These exist so a connected
+// agent can answer "summarize my collection / what should I wear tonight" in
+// one or two tool calls instead of paging raw rows. Aggregation happens here,
+// interpretation happens in the agent — no server-side AI (epic §1).
+import { v } from "convex/values";
+import { query, QueryCtx } from "./_generated/server";
+import { Doc, Id } from "./_generated/dataModel";
+import { getOptionalUserId } from "./helpers";
+
+const DEFAULT_LOG_LIMIT = 100;
+const MAX_LOG_LIMIT = 500;
+const DEFAULT_RECENT_LOGS = 5;
+const MAX_RECENT_LOGS = 20;
+
+export const listWearLogsFiltered = query({
+  args: {
+    bottleId: v.optional(v.id("bottles")),
+    from: v.optional(v.number()),
+    to: v.optional(v.number()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getOptionalUserId(ctx);
+    if (userId === null) return [];
+    const limit = Math.min(Math.max(Math.trunc(args.limit ?? DEFAULT_LOG_LIMIT), 1), MAX_LOG_LIMIT);
+    const { from, to, bottleId } = args;
+
+    // Both index shapes end in wornAt, so the range bounds stay in the index.
+    // A bottleId the user doesn't own simply matches nothing — no leak.
+    if (bottleId !== undefined) {
+      return await ctx.db
+        .query("wearLogs")
+        .withIndex("by_user_bottle_time", (q) => {
+          let r = q.eq("userId", userId).eq("bottleId", bottleId);
+          if (from !== undefined) r = r.gte("wornAt", from);
+          if (to !== undefined) r = r.lte("wornAt", to);
+          return r;
+        })
+        .order("desc")
+        .take(limit);
+    }
+    return await ctx.db
+      .query("wearLogs")
+      .withIndex("by_user_time", (q) => {
+        let r = q.eq("userId", userId);
+        if (from !== undefined) r = r.gte("wornAt", from);
+        if (to !== undefined) r = r.lte("wornAt", to);
+        return r;
+      })
+      .order("desc")
+      .take(limit);
+  },
+});
+
+type BottleAgg = {
+  wears: number;
+  sprays: number;
+  ratingSum: number;
+  ratingCount: number;
+  lastWornAt: number | null;
+};
+
+function aggregate(bottles: Doc<"bottles">[], logs: Doc<"wearLogs">[]) {
+  const byBottle = new Map<string, BottleAgg>();
+  for (const bottle of bottles) {
+    byBottle.set(bottle._id, { wears: 0, sprays: 0, ratingSum: 0, ratingCount: 0, lastWornAt: null });
+  }
+  for (const log of logs) {
+    const agg = byBottle.get(log.bottleId);
+    if (!agg) continue; // log for a just-deleted bottle; skip
+    agg.wears += 1;
+    agg.sprays += log.sprays;
+    if (typeof log.rating === "number") {
+      agg.ratingSum += log.rating;
+      agg.ratingCount += 1;
+    }
+    if (agg.lastWornAt === null || log.wornAt > agg.lastWornAt) agg.lastWornAt = log.wornAt;
+  }
+  return byBottle;
+}
+
+function statsRow(bottle: Doc<"bottles">, agg: BottleAgg) {
+  return {
+    bottleId: bottle._id,
+    name: bottle.name,
+    brand: bottle.brand ?? null,
+    isFavorite: bottle.isFavorite ?? false,
+    wears: agg.wears,
+    sprays: agg.sprays,
+    avgRating: agg.ratingCount > 0 ? agg.ratingSum / agg.ratingCount : null,
+    lastWornAt: agg.lastWornAt,
+  };
+}
+
+async function loadUserData(ctx: QueryCtx, userId: Id<"users">) {
+  const bottles = await ctx.db
+    .query("bottles")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .collect();
+  const logs = await ctx.db
+    .query("wearLogs")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .collect();
+  return { bottles, logs };
+}
+
+export const collectionStats = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getOptionalUserId(ctx);
+    if (userId === null) {
+      return {
+        totals: {
+          bottleCount: 0, totalWears: 0, totalSprays: 0, favoriteCount: 0,
+          unwornBottleCount: 0, mostWornBottleId: null, leastWornBottleId: null,
+        },
+        bottles: [],
+      };
+    }
+    const { bottles, logs } = await loadUserData(ctx, userId);
+    const byBottle = aggregate(bottles, logs);
+    const rows = bottles.map((b) => statsRow(b, byBottle.get(b._id)!));
+
+    // Ties broken by earliest createdAt so results are deterministic.
+    const worn = bottles
+      .filter((b) => byBottle.get(b._id)!.wears > 0)
+      .sort((a, b) => a.createdAt - b.createdAt);
+    let mostWorn: Doc<"bottles"> | null = null;
+    let leastWorn: Doc<"bottles"> | null = null;
+    for (const b of worn) {
+      const wears = byBottle.get(b._id)!.wears;
+      if (mostWorn === null || wears > byBottle.get(mostWorn._id)!.wears) mostWorn = b;
+      if (leastWorn === null || wears < byBottle.get(leastWorn._id)!.wears) leastWorn = b;
+    }
+
+    return {
+      totals: {
+        bottleCount: bottles.length,
+        totalWears: logs.length,
+        totalSprays: logs.reduce((sum, l) => sum + l.sprays, 0),
+        favoriteCount: bottles.filter((b) => b.isFavorite === true).length,
+        unwornBottleCount: rows.filter((r) => r.wears === 0).length,
+        mostWornBottleId: mostWorn?._id ?? null,
+        leastWornBottleId: leastWorn?._id ?? null,
+      },
+      bottles: rows,
+    };
+  },
+});
+
+export const collectionSnapshot = query({
+  args: { recentLogsPerBottle: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const userId = await getOptionalUserId(ctx);
+    if (userId === null) return { generatedAt: Date.now(), bottles: [] };
+    const recentCount = Math.min(
+      Math.max(Math.trunc(args.recentLogsPerBottle ?? DEFAULT_RECENT_LOGS), 0),
+      MAX_RECENT_LOGS,
+    );
+    const { bottles, logs } = await loadUserData(ctx, userId);
+    const byBottle = aggregate(bottles, logs);
+
+    const rows = await Promise.all(
+      bottles.map(async (bottle) => {
+        const recent =
+          recentCount === 0
+            ? []
+            : await ctx.db
+                .query("wearLogs")
+                .withIndex("by_user_bottle_time", (q) =>
+                  q.eq("userId", userId).eq("bottleId", bottle._id),
+                )
+                .order("desc")
+                .take(recentCount);
+        return {
+          ...statsRow(bottle, byBottle.get(bottle._id)!),
+          tags: bottle.tags ?? [],
+          comments: bottle.comments ?? null,
+          createdAt: bottle.createdAt,
+          recentLogs: recent.map((l) => ({
+            wornAt: l.wornAt,
+            sprays: l.sprays,
+            context: l.context ?? null,
+            rating: l.rating ?? null,
+            comment: l.comment ?? null,
+          })),
+        };
+      }),
+    );
+    return { generatedAt: Date.now(), bottles: rows };
+  },
+});
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run test:run convex/insights.test.ts`
+Expected: PASS (6 tests). Also `bun run test:run convex/` — existing suites still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add convex/insights.ts convex/insights.test.ts
+git commit -m "feat: add insight queries (filtered logs, collection stats with lastWornAt, snapshot)"
+```
+
+---
+
+### Task 2: Dual-mode bearer verifier (test-first)
+
+**Files:**
+- Create: `my-app/src/lib/mcp/verify-token.ts`
+- Create: `my-app/src/lib/mcp/verify-token.test.ts`
+
+**Interfaces:**
+- Consumes: `getPublicJwks`, `mintPatBridgeToken`, `sha256Hex`, `PAT_PREFIX`, `MCP_JWT_AUDIENCE` (sub-plan 2 Task 3), `api.apiTokens.validate` (sub-plan 2 Task 7).
+- Produces (consumed by Task 4's `withMcpAuth`):
+  - `type McpExtra = { userId: string; convexToken: string }`
+  - `createMcpTokenVerifier(deps?)` → `(req: Request, bearer?: string) => Promise<McpAuthInfo | undefined>` — factory with injectable deps for tests
+  - `verifyMcpToken` — the default-deps instance used by the route
+  - Behavior: `fgt_*` bearer → sha256 → `apiTokens.validate` → mint 5-min bridge JWT; anything else → local `jwtVerify` against our own JWKS (no network, no DB); any failure → `undefined` (which `withMcpAuth` turns into 401).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/mcp/verify-token.test.ts
+import { describe, expect, test } from "vitest";
+import { exportPKCS8, generateKeyPair } from "jose";
+import { mintAccessToken, sha256Hex } from "./tokens";
+import { createMcpTokenVerifier, McpExtra } from "./verify-token";
+
+const ISSUER = "https://example.test";
+const REQ = new Request("https://example.test/api/mcp");
+
+async function makeVerifier(overrides: Partial<Parameters<typeof createMcpTokenVerifier>[0]> = {}) {
+  const { privateKey } = await generateKeyPair("RS256", { extractable: true });
+  const pem = await exportPKCS8(privateKey);
+  return {
+    pem,
+    verify: createMcpTokenVerifier({
+      privateKeyPem: pem,
+      issuer: ISSUER,
+      validatePat: async () => null,
+      ...overrides,
+    }),
+  };
+}
+
+describe("verifyMcpToken — OAuth JWT path", () => {
+  test("valid JWT yields authInfo whose convexToken is the JWT itself", async () => {
+    const { pem, verify } = await makeVerifier();
+    const jwt = await mintAccessToken({
+      userId: "user123", grantId: "grant456", clientId: "client789",
+      scope: "read write", privateKeyPem: pem, issuer: ISSUER,
+    });
+    const info = await verify(REQ, jwt);
+    expect(info?.clientId).toBe("client789");
+    expect(info?.scopes).toEqual(["read", "write"]);
+    expect(info?.extra as McpExtra).toEqual({ userId: "user123", convexToken: jwt });
+  });
+
+  test("JWT signed by a different key is rejected", async () => {
+    const { verify } = await makeVerifier();
+    const other = await generateKeyPair("RS256", { extractable: true });
+    const forged = await mintAccessToken({
+      userId: "user123", grantId: "g", clientId: "c", scope: "read write",
+      privateKeyPem: await exportPKCS8(other.privateKey), issuer: ISSUER,
+    });
+    expect(await verify(REQ, forged)).toBeUndefined();
+  });
+
+  test("missing bearer and garbage bearer are rejected", async () => {
+    const { verify } = await makeVerifier();
+    expect(await verify(REQ, undefined)).toBeUndefined();
+    expect(await verify(REQ, "not-a-jwt")).toBeUndefined();
+  });
+});
+
+describe("verifyMcpToken — PAT path", () => {
+  test("valid PAT is hash-looked-up and bridged to a convex JWT", async () => {
+    const pat = "fgt_test-token-value";
+    const expectedHash = await sha256Hex(pat);
+    let seenHash: string | null = null;
+    const { verify } = await makeVerifier({
+      validatePat: async (tokenHash: string) => {
+        seenHash = tokenHash;
+        return { userId: "user123", tokenId: "tok1", scopes: ["read", "write"] };
+      },
+    });
+    const info = await verify(REQ, pat);
+    expect(seenHash).toBe(expectedHash);
+    expect(info?.clientId).toBe("personal-access-token");
+    const extra = info?.extra as McpExtra;
+    expect(extra.userId).toBe("user123");
+    expect(extra.convexToken.split(".")).toHaveLength(3); // bridge JWT, not the PAT
+  });
+
+  test("revoked/unknown PAT is rejected", async () => {
+    const { verify } = await makeVerifier({ validatePat: async () => null });
+    expect(await verify(REQ, "fgt_revoked")).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:run src/lib/mcp/verify-token.test.ts`
+Expected: FAIL — cannot resolve `./verify-token`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/mcp/verify-token.ts
+// Dual-mode bearer verification for /api/mcp (epic §3.3):
+//   fgt_* → PAT: hash → Convex lookup → 5-min bridge JWT as the Convex credential.
+//   else  → OAuth access token: local RS256 verify (no DB, no network); the JWT
+//           itself is the Convex credential (customJwt provider trusts it).
+// Any failure returns undefined; withMcpAuth converts that into the 401 +
+// WWW-Authenticate discovery response.
+import { createLocalJWKSet, jwtVerify } from "jose";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../../../convex/_generated/api";
+import {
+  getPublicJwks,
+  mintPatBridgeToken,
+  sha256Hex,
+  MCP_JWT_AUDIENCE,
+  PAT_PREFIX,
+} from "./tokens";
+
+export type McpExtra = { userId: string; convexToken: string };
+
+export type McpAuthInfo = {
+  token: string;
+  clientId: string;
+  scopes: string[];
+  extra: McpExtra;
+};
+
+type PatRecord = { userId: string; tokenId: string; scopes: string[] };
+
+type VerifierDeps = {
+  privateKeyPem?: string;
+  issuer?: string;
+  validatePat?: (tokenHash: string) => Promise<PatRecord | null>;
+};
+
+function defaultValidatePat(tokenHash: string): Promise<PatRecord | null> {
+  const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+  return convex.mutation(api.apiTokens.validate, { tokenHash });
+}
+
+export function createMcpTokenVerifier(deps: VerifierDeps = {}) {
+  const validatePat = deps.validatePat ?? defaultValidatePat;
+
+  return async function verifyMcpToken(
+    _req: Request,
+    bearer?: string,
+  ): Promise<McpAuthInfo | undefined> {
+    if (!bearer) return undefined;
+
+    if (bearer.startsWith(PAT_PREFIX)) {
+      const pat = await validatePat(await sha256Hex(bearer));
+      if (!pat) return undefined;
+      const convexToken = await mintPatBridgeToken({
+        userId: pat.userId,
+        tokenId: pat.tokenId,
+        privateKeyPem: deps.privateKeyPem,
+        issuer: deps.issuer,
+      });
+      return {
+        token: bearer,
+        clientId: "personal-access-token",
+        scopes: pat.scopes,
+        extra: { userId: pat.userId, convexToken },
+      };
+    }
+
+    try {
+      const jwks = createLocalJWKSet(await getPublicJwks(deps.privateKeyPem));
+      const { payload } = await jwtVerify(bearer, jwks, {
+        issuer: deps.issuer ?? process.env.NEXT_PUBLIC_APP_URL,
+        audience: MCP_JWT_AUDIENCE,
+      });
+      const [userId] = (payload.sub as string).split("|");
+      return {
+        token: bearer,
+        clientId: (payload.client_id as string) ?? "unknown",
+        scopes: ((payload.scope as string) ?? "").split(" ").filter(Boolean),
+        extra: { userId, convexToken: bearer },
+      };
+    } catch {
+      return undefined;
+    }
+  };
+}
+
+/** Default instance used by the /api/mcp route. */
+export const verifyMcpToken = createMcpTokenVerifier();
+```
+
+If the spike findings recorded a different `AuthInfo` type for `withMcpAuth` (e.g. an SDK-exported interface with required `expiresAt`), align `McpAuthInfo` with it here.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test:run src/lib/mcp/verify-token.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/mcp/verify-token.ts src/lib/mcp/verify-token.test.ts
+git commit -m "feat: add dual-mode MCP bearer verifier (OAuth JWT + PAT bridge)"
+```
+
+---
+
+### Task 3: Tool input schemas
+
+**Files:**
+- Create: `my-app/src/lib/mcp/tool-schemas.ts`
+- Create: `my-app/src/lib/mcp/tool-schemas.test.ts`
+
+**Interfaces:**
+- Produces: one exported zod **raw shape** per tool (consumed by Task 4). Bounds mirror `convex/bottles.ts` (name ≤200, brand ≤200, comments ≤2000, tags ≤20×≤50, sizeMl >0 ≤10000) and `convex/wearLogs.ts` (sprays int 1–100 via `MAX_SPRAYS` in `src/lib/constants.ts`, rating 1–10, context ≤200, comment ≤2000). Update shapes use `.nullable()` on clearable fields — `null` clears, matching `buildPatch`.
+
+- [ ] **Step 1: Write the failing test** (spot-checks the tricky semantics only: null-clears, int bounds, defaults)
+
+```ts
+// src/lib/mcp/tool-schemas.test.ts
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import {
+  updateBottleShape,
+  addWearLogShape,
+  listWearLogsShape,
+  getCollectionSnapshotShape,
+} from "./tool-schemas";
+
+describe("tool schemas", () => {
+  test("update_bottle accepts null to clear optional fields but not for name", () => {
+    const schema = z.object(updateBottleShape);
+    expect(schema.safeParse({ bottleId: "x", brand: null, sizeMl: null }).success).toBe(true);
+    expect(schema.safeParse({ bottleId: "x", name: null }).success).toBe(false);
+  });
+
+  test("add_wear_log enforces integer spray bounds and rating range", () => {
+    const schema = z.object(addWearLogShape);
+    const base = { bottleId: "x", wornAt: 1700000000000 };
+    expect(schema.safeParse({ ...base, sprays: 3 }).success).toBe(true);
+    expect(schema.safeParse({ ...base, sprays: 2.5 }).success).toBe(false);
+    expect(schema.safeParse({ ...base, sprays: 0 }).success).toBe(false);
+    expect(schema.safeParse({ ...base, sprays: 101 }).success).toBe(false);
+    expect(schema.safeParse({ ...base, sprays: 3, rating: 11 }).success).toBe(false);
+  });
+
+  test("list_wear_logs bounds limit and snapshot bounds recentLogsPerBottle", () => {
+    expect(z.object(listWearLogsShape).safeParse({ limit: 501 }).success).toBe(false);
+    expect(z.object(listWearLogsShape).safeParse({}).success).toBe(true);
+    expect(z.object(getCollectionSnapshotShape).safeParse({ recentLogsPerBottle: 21 }).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:run src/lib/mcp/tool-schemas.test.ts`
+Expected: FAIL — cannot resolve `./tool-schemas`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/mcp/tool-schemas.ts
+// Zod raw shapes for MCP tool inputs. These mirror the server-side bounds in
+// convex/bottles.ts and convex/wearLogs.ts to give agents early, descriptive
+// validation errors — the Convex validators remain authoritative.
+import { z } from "zod";
+import { MAX_SPRAYS } from "@/lib/constants";
+
+const bottleId = z.string().describe("Bottle ID from list_bottles / get_collection_stats.");
+const wearLogId = z.string().describe("Wear log ID from list_wear_logs.");
+
+const name = z.string().min(1).max(200);
+const brand = z.string().max(200);
+const sizeMl = z.number().positive().max(10_000).describe("Bottle size in millilitres.");
+const tags = z.array(z.string().min(1).max(50)).max(20);
+const comments = z.string().max(2000);
+
+const wornAt = z
+  .number()
+  .int()
+  .positive()
+  .describe("Wear time as Unix epoch milliseconds (convert ISO dates: Date.parse). Must not be in the future.");
+const sprays = z.number().int().min(1).max(MAX_SPRAYS);
+const context = z.string().max(200).describe('Occasion, e.g. "office", "date night".');
+const rating = z.number().min(1).max(10);
+const wearComment = z.string().max(2000);
+
+export const listBottlesShape = {};
+export const getBottleShape = { bottleId };
+
+export const addBottleShape = {
+  name,
+  brand: brand.optional(),
+  sizeMl: sizeMl.optional(),
+  tags: tags.optional(),
+  comments: comments.optional(),
+};
+
+// null clears a field (buildPatch semantics); name is required in the schema
+// so it can be overwritten but never cleared.
+export const updateBottleShape = {
+  bottleId,
+  name: name.optional(),
+  brand: brand.nullable().optional(),
+  sizeMl: sizeMl.nullable().optional(),
+  tags: tags.nullable().optional(),
+  comments: comments.nullable().optional(),
+};
+
+export const deleteBottleShape = { bottleId };
+export const toggleFavoriteShape = { bottleId };
+
+export const addWearLogShape = {
+  bottleId,
+  wornAt,
+  sprays,
+  context: context.optional(),
+  rating: rating.optional(),
+  comment: wearComment.optional(),
+};
+
+export const updateWearLogShape = {
+  wearLogId,
+  wornAt: wornAt.optional(),
+  sprays: sprays.optional(),
+  context: context.nullable().optional(),
+  rating: rating.nullable().optional(),
+  comment: wearComment.nullable().optional(),
+};
+
+export const deleteWearLogShape = { wearLogId };
+
+export const listWearLogsShape = {
+  bottleId: bottleId.optional(),
+  from: z.number().int().optional().describe("Inclusive lower bound, epoch ms."),
+  to: z.number().int().optional().describe("Inclusive upper bound, epoch ms."),
+  limit: z.number().int().min(1).max(500).optional().describe("Max logs to return (default 100)."),
+};
+
+export const getCollectionStatsShape = {};
+
+export const getCollectionSnapshotShape = {
+  recentLogsPerBottle: z.number().int().min(0).max(20).optional()
+    .describe("Recent wear logs to include per bottle (default 5)."),
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test:run src/lib/mcp/tool-schemas.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/mcp/tool-schemas.ts src/lib/mcp/tool-schemas.test.ts
+git commit -m "feat: add zod input schemas for the 13 MCP tools"
+```
+
+---
+
+### Task 4: `/api/mcp` route — 13 tools + auth wiring
+
+**Files:**
+- Create (replace any spike leftover): `my-app/src/app/api/[transport]/route.ts`
+
+**Interfaces:**
+- Consumes: `verifyMcpToken` + `McpExtra` (Task 2), all shapes (Task 3), existing `api.bottles.*` / `api.wearLogs.*` and new `api.insights.*` (Task 1).
+- Produces: `/api/mcp` (streamable HTTP, stateless). Tool result convention: success → `{ content: [{ type: "text", text: JSON.stringify(data) }] }`; failure → same plus `isError: true` with the human-readable Convex error message so agents can self-correct (bad ID, validation bound, `retryAfter` rate limit).
+
+- [ ] **Step 1: Write the route**
+
+Adjust registration-call shape to spike findings; everything else stands.
+
+```ts
+// src/app/api/[transport]/route.ts
+import { createMcpHandler, withMcpAuth } from "mcp-handler";
+import { ConvexHttpClient } from "convex/browser";
+import { ConvexError } from "convex/values";
+import { api } from "../../../../convex/_generated/api";
+import { verifyMcpToken, McpExtra } from "@/lib/mcp/verify-token";
+import * as shapes from "@/lib/mcp/tool-schemas";
+
+function convexFor(extra: McpExtra): ConvexHttpClient {
+  const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+  convex.setAuth(extra.convexToken);
+  return convex;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof ConvexError) {
+    const data = error.data as unknown;
+    if (typeof data === "string") return data;
+    if (data && typeof data === "object") {
+      const d = data as { message?: string; kind?: string; retryAfter?: number };
+      if (d.kind === "RateLimited" && typeof d.retryAfter === "number") {
+        return `Rate limited. Retry after ${Math.ceil(d.retryAfter / 1000)}s.`;
+      }
+      if (d.message) return d.message;
+    }
+    return "Request rejected.";
+  }
+  if (error instanceof Error) {
+    // Convex wraps thrown Error messages with call metadata; keep the useful tail.
+    const match = error.message.match(/Uncaught Error: (.*?)(\n|$)/);
+    return match ? match[1] : error.message;
+  }
+  return "Unknown error.";
+}
+
+type ToolResult = { content: Array<{ type: "text"; text: string }>; isError?: boolean };
+
+async function run(fn: () => Promise<unknown>): Promise<ToolResult> {
+  try {
+    const data = await fn();
+    return { content: [{ type: "text", text: JSON.stringify(data ?? { ok: true }) }] };
+  } catch (error) {
+    return { isError: true, content: [{ type: "text", text: errorMessage(error) }] };
+  }
+}
+
+const handler = createMcpHandler(
+  (server) => {
+    const extraOf = (authInfo: unknown) =>
+      (authInfo as { extra: McpExtra }).extra;
+
+    // ── Bottles ───────────────────────────────────────────────────────────
+    server.registerTool(
+      "list_bottles",
+      { description: "List every fragrance bottle in the user's collection, newest first. Start here to get bottle IDs.", inputSchema: shapes.listBottlesShape },
+      async (_args, { authInfo }) =>
+        run(() => convexFor(extraOf(authInfo)).query(api.bottles.listBottles, {})),
+    );
+    server.registerTool(
+      "get_bottle",
+      { description: "Get one bottle by ID. Returns null if it doesn't exist or isn't the user's.", inputSchema: shapes.getBottleShape },
+      async (args, { authInfo }) =>
+        run(() => convexFor(extraOf(authInfo)).query(api.bottles.getBottle, args)),
+    );
+    server.registerTool(
+      "add_bottle",
+      { description: "Add a fragrance bottle to the user's collection. Returns the new bottle ID.", inputSchema: shapes.addBottleShape },
+      async (args, { authInfo }) =>
+        run(async () => ({
+          bottleId: await convexFor(extraOf(authInfo)).mutation(api.bottles.addBottle, args),
+        })),
+    );
+    server.registerTool(
+      "update_bottle",
+      { description: "Update a bottle. Omit a field to leave it unchanged; pass null to clear it (name cannot be cleared).", inputSchema: shapes.updateBottleShape },
+      async (args, { authInfo }) =>
+        run(() => convexFor(extraOf(authInfo)).mutation(api.bottles.updateBottle, args)),
+    );
+    server.registerTool(
+      "delete_bottle",
+      { description: "Delete a bottle AND all of its wear logs (cascade). Irreversible — confirm with the user first.", inputSchema: shapes.deleteBottleShape },
+      async (args, { authInfo }) =>
+        run(() => convexFor(extraOf(authInfo)).mutation(api.bottles.deleteBottle, args)),
+    );
+    server.registerTool(
+      "toggle_favorite",
+      { description: "Toggle a bottle's favorite flag.", inputSchema: shapes.toggleFavoriteShape },
+      async (args, { authInfo }) =>
+        run(() => convexFor(extraOf(authInfo)).mutation(api.bottles.toggleFavorite, args)),
+    );
+
+    // ── Wear logs ─────────────────────────────────────────────────────────
+    server.registerTool(
+      "add_wear_log",
+      { description: "Log a wear of a bottle. wornAt is epoch milliseconds and must not be in the future.", inputSchema: shapes.addWearLogShape },
+      async (args, { authInfo }) =>
+        run(async () => ({
+          wearLogId: await convexFor(extraOf(authInfo)).mutation(api.wearLogs.addWearLog, args),
+        })),
+    );
+    server.registerTool(
+      "update_wear_log",
+      { description: "Update a wear log. Omit a field to keep it; pass null to clear context/rating/comment.", inputSchema: shapes.updateWearLogShape },
+      async (args, { authInfo }) =>
+        run(() => convexFor(extraOf(authInfo)).mutation(api.wearLogs.updateWearLog, args)),
+    );
+    server.registerTool(
+      "delete_wear_log",
+      { description: "Delete a single wear log.", inputSchema: shapes.deleteWearLogShape },
+      async (args, { authInfo }) =>
+        run(() => convexFor(extraOf(authInfo)).mutation(api.wearLogs.deleteWearLog, args)),
+    );
+
+    // ── Insights ──────────────────────────────────────────────────────────
+    server.registerTool(
+      "list_wear_logs",
+      { description: "List wear logs newest-first, optionally filtered by bottle and/or time range (epoch ms). Default limit 100, max 500.", inputSchema: shapes.listWearLogsShape },
+      async (args, { authInfo }) =>
+        run(() => convexFor(extraOf(authInfo)).query(api.insights.listWearLogsFiltered, args)),
+    );
+    server.registerTool(
+      "get_collection_stats",
+      { description: "Per-bottle stats (wears, sprays, avgRating, lastWornAt) plus collection totals (most/least worn, favorites, unworn count). Ideal first call for analysis.", inputSchema: shapes.getCollectionStatsShape },
+      async (_args, { authInfo }) =>
+        run(() => convexFor(extraOf(authInfo)).query(api.insights.collectionStats, {})),
+    );
+    server.registerTool(
+      "get_collection_snapshot",
+      { description: "Compact full export: every bottle with stats, tags, notes, and N recent wear logs each. Built for one-shot analysis (rotation gaps, seasonal patterns, recommendations).", inputSchema: shapes.getCollectionSnapshotShape },
+      async (args, { authInfo }) =>
+        run(() => convexFor(extraOf(authInfo)).query(api.insights.collectionSnapshot, args)),
+    );
+  },
+  {},
+  { basePath: "/api", maxDuration: 60 },
+);
+
+const authed = withMcpAuth(handler, verifyMcpToken, {
+  required: true,
+  resourceMetadataPath: "/.well-known/oauth-protected-resource",
+});
+
+export { authed as GET, authed as POST };
+```
+
+(That is 12 registrations covering the epic's 13 tool names — the epic counts `list_wear_logs` in both reuse and insight tables; 12 distinct tools is correct. Note this in the PR description.)
+
+- [ ] **Step 2: Typecheck and verify the 401 discovery path (dev server running)**
+
+```bash
+bun run typecheck
+curl -si -X POST http://localhost:3000/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | head -10
+```
+
+Expected: 401 with `WWW-Authenticate` pointing at `/.well-known/oauth-protected-resource`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/\[transport\]
+git commit -m "feat: add /api/mcp endpoint with 12 CRUD + insight tools"
+```
+
+---
+
+### Task 5: PAT smoke test via dev seed
+
+**Files:**
+- Create: `my-app/convex/devSeed.ts`
+
+**Interfaces:**
+- Produces: `internalMutation` `devSeed.seedPat` — CLI-only helper (internal functions are not callable from clients) to plant a PAT hash for a user, enabling authed end-to-end smoke before the settings UI (sub-plan 4) exists.
+
+- [ ] **Step 1: Write the seed helper**
+
+```ts
+// convex/devSeed.ts
+// Dev-only helpers, callable exclusively via `bunx convex run` (internal
+// functions are unreachable from clients). Used to smoke-test the MCP endpoint
+// before the settings UI exists.
+import { v } from "convex/values";
+import { internalMutation } from "./_generated/server";
+
+export const seedPat = internalMutation({
+  args: { userId: v.id("users"), tokenHash: v.string(), name: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("personalAccessTokens", {
+      userId: args.userId,
+      tokenHash: args.tokenHash,
+      name: args.name,
+      scopes: ["read", "write"],
+      createdAt: Date.now(),
+    });
+  },
+});
+```
+
+- [ ] **Step 2: Seed and smoke (dev server + `bunx convex dev` running; sign in once via the web app so your user exists)**
+
+```bash
+# Find your user id (users table) in the Convex dashboard, then:
+PAT="fgt_local-smoke-token"
+HASH=$(python3 -c "import hashlib;print(hashlib.sha256('fgt_local-smoke-token'.encode()).hexdigest())")
+bunx convex run devSeed:seedPat "{\"userId\":\"<your-user-id>\",\"tokenHash\":\"$HASH\",\"name\":\"smoke\"}"
+
+curl -s -X POST http://localhost:3000/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $PAT" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_collection_stats","arguments":{}}}'
+```
+
+Expected: a result containing your real `totals`. This exercises PAT hash lookup → bridge JWT → Convex `customJwt` verification → `getUserId` → insights, i.e. the entire epic §3.1 unlock. (Requires the Convex dev deployment to reach the JWKS — apply sub-plan 5 Task 1's local strategy if verification fails with an auth error.)
+
+Also verify a tool error surfaces as `isError` content:
+
+```bash
+curl -s -X POST http://localhost:3000/api/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $PAT" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_bottle","arguments":{"bottleId":"garbage"}}}'
+```
+
+Expected: `isError: true` with a validator message, not a protocol failure.
+
+- [ ] **Step 3: Full gate + commit + PR**
+
+```bash
+bun run typecheck && bun run lint && bun run test:run && bun run build
+git add convex/devSeed.ts
+git commit -m "feat: add dev-only PAT seed helper for MCP smoke tests"
+git push -u origin feat/mcp-tools
+gh pr create --title "feat: MCP endpoint with insight queries and 12 tools" --body "Sub-plan 3/5 of docs/mcp-server-plan.md (issue #65): convex/insights.ts (new aggregation incl. lastWornAt — listBottleStats untouched), dual-mode bearer verifier, zod tool schemas, /api/mcp with 12 tools (epic said 13; list_wear_logs was double-counted). Scopes carried but not enforced per v1 decision (epic §10). PAT path smoke-tested end-to-end via dev seed.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```

--- a/docs/superpowers/plans/2026-07-06-mcp-4-consent-settings-ui.md
+++ b/docs/superpowers/plans/2026-07-06-mcp-4-consent-settings-ui.md
@@ -1,0 +1,894 @@
+# MCP Sub-plan 4/5: Consent, Sign-in Redirect + Settings UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Epic:** `docs/mcp-server-plan.md` (issue #65). Sub-plan 4 of 5. Requires sub-plan 2 (OAuth foundation) merged; independent of sub-plan 3 (can run in parallel with it). Completes the OAuth happy path: after this, code → token exchange works end to end.
+
+> **⚠️ Spike corrections (from `2026-07-06-mcp-0-spike-findings.md`):** mostly backend-facing, but note: browser-side PAT generation reuses the isomorphic `tokens.ts` from sub-plan 2 — PAT raw values are random bytes (`randomToken`), unaffected by the jose C6 fix (that applies only to the RS256 keypair export). Any zod schema you add uses **zod@^4** (C1).
+
+**Goal:** Build the human-facing surfaces: sign-in `?redirect=` passthrough (today sign-in always lands on `/`), the `/oauth/authorize` consent page with exact error/redirect semantics, and `/settings/connections` (connected apps + PATs) — the repo's first settings route, linked from the home header.
+
+**Architecture:** The consent page is a server component: it validates the authorization request, then renders a card whose approve/deny buttons are plain `<form action={serverAction}>` — no client JS. The approve action generates the raw code in Next (crypto placement rule), stores only its hash via an authed Convex mutation (`convexAuthNextjsToken()`), and 302s to the client's `redirect_uri`. Settings sections are client components on the existing Convex React providers, reusing `ConfirmDeleteButton`, `Dialog`, and `formatWearDate`. PAT raw values are generated **in the browser** (`tokens.ts` is isomorphic) and shown exactly once.
+
+**Tech Stack:** Next.js 16 App Router (server components + server actions), `@convex-dev/auth` middleware/nextjs helpers, Convex React hooks, Tailwind 4, Vitest + Testing Library (jsdom for `.tsx` tests).
+
+## Global Constraints
+
+- All commands run from `/home/code/fragrances-tracker/my-app`.
+- Branch: `feat/mcp-consent-settings` cut from `main` after sub-plan 2 merges. Install no packages.
+- Error semantics for `/oauth/authorize` (RFC 6749 §4.1.2.1, locked):
+  - Unknown `client_id`, missing/unregistered `redirect_uri` → **render an error card, never redirect** (protects users from open-redirect).
+  - Any other invalid parameter (`response_type` ≠ `code`, missing `code_challenge`, `code_challenge_method` ≠ `S256`) → **302 to `redirect_uri`** with `error` (+ `error_description`) and `state` passed through verbatim.
+  - Approval → 302 `redirect_uri?code=...` + `state` verbatim. Denial → 302 with `error=access_denied` + `state`.
+- `redirect_uri` matching is **exact string equality** against the registered list (`matchesRegisteredRedirect`).
+- Scope: consent always grants the fixed `"read write"` (v1 decision, epic §10) regardless of the requested `scope` param.
+- UI conventions: kebab-case filenames, named exports, `"use client"` only where interactive, `cn()` from `@/lib/utils`, styling consistent with `sign-in-screen.tsx` / `home-page.tsx` (surface cards, `font-display` headings, `text-text-secondary` metadata).
+- `.tsx` tests run in jsdom; mock Convex hooks with `vi.mock("convex/react")` like the existing component suites (see `src/components/bottle-detail.test.tsx` for the pattern).
+- Full gate before PR: `bun run typecheck && bun run lint && bun run test:run && bun run build`.
+- Commit after every task (`feat:` / `test:` prefixes).
+
+---
+
+### Task 1: Sign-in `?redirect=` passthrough + middleware protection
+
+**Files:**
+- Modify: `my-app/src/proxy.ts`
+- Modify: `my-app/src/app/signin/page.tsx`
+- Modify: `my-app/src/components/sign-in-screen.tsx`
+
+**Interfaces:**
+- Consumes: `isSafeInternalPath` from `@/lib/mcp/oauth-validation` (sub-plan 2 Task 4 — pure, edge-safe, fine to import in middleware).
+- Produces: visiting a protected non-`/` route unauthenticated → `/signin?redirect=<encoded path+query>`; after Google sign-in the user lands back on that path; an already-authenticated user hitting `/signin?redirect=...` is forwarded to the target. Protected routes now: `/`, `/oauth/authorize`, `/settings(.*)`. Unsafe redirect values silently fall back to `/`.
+
+- [ ] **Step 1: Update the middleware**
+
+Replace the body of `src/proxy.ts` lines 7–21 with:
+
+```ts
+import { isSafeInternalPath } from "@/lib/mcp/oauth-validation";
+
+const isSignInPage = createRouteMatcher(["/signin"]);
+const isProtectedRoute = createRouteMatcher(["/", "/oauth/authorize", "/settings(.*)"]);
+
+export default convexAuthNextjsMiddleware(
+  async (request, { convexAuth }) => {
+    const isAuthenticated = await convexAuth.isAuthenticated();
+
+    if (isSignInPage(request) && isAuthenticated) {
+      const target = request.nextUrl.searchParams.get("redirect");
+      return nextjsMiddlewareRedirect(
+        request,
+        target && isSafeInternalPath(target) ? target : "/",
+      );
+    }
+
+    if (isProtectedRoute(request) && !isAuthenticated) {
+      const { pathname, search } = request.nextUrl;
+      // Preserve where the user was headed (e.g. an OAuth authorize URL with
+      // its full query) so sign-in can bounce them back.
+      const suffix =
+        pathname === "/" ? "" : `?redirect=${encodeURIComponent(`${pathname}${search}`)}`;
+      return nextjsMiddlewareRedirect(request, `/signin${suffix}`);
+    }
+  },
+  {
+    cookieConfig: {
+      maxAge: 60 * 60 * 24 * 30,
+    },
+  },
+);
+```
+
+(Keep the existing `config.matcher` untouched — it already lets `/.well-known/*` and static assets through.)
+
+- [ ] **Step 2: Thread the redirect through the sign-in page**
+
+Replace `src/app/signin/page.tsx`:
+
+```tsx
+import { isAuthenticatedNextjs } from "@convex-dev/auth/nextjs/server";
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { SignInScreen } from "@/components/sign-in-screen";
+import { isSafeInternalPath } from "@/lib/mcp/oauth-validation";
+
+export const metadata: Metadata = {
+  title: "Sign In",
+};
+
+export default async function SignInPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ redirect?: string }>;
+}) {
+  const { redirect: redirectParam } = await searchParams;
+  const target =
+    redirectParam && isSafeInternalPath(redirectParam) ? redirectParam : "/";
+
+  if (await isAuthenticatedNextjs()) {
+    redirect(target);
+  }
+
+  return <SignInScreen redirectTo={target} />;
+}
+```
+
+- [ ] **Step 3: Accept the target in `SignInScreen`**
+
+In `src/components/sign-in-screen.tsx`, change the signature and the `signIn` call:
+
+```tsx
+export function SignInScreen({ redirectTo = "/" }: { redirectTo?: string }) {
+```
+
+and inside `handleGoogleSignIn`:
+
+```tsx
+await signIn("google", { redirectTo });
+```
+
+- [ ] **Step 4: Verify manually (dev server + convex dev running)**
+
+- Signed out, visit `http://localhost:3000/settings/connections` → lands on `/signin?redirect=%2Fsettings%2Fconnections`; complete Google sign-in → lands on `/settings/connections` (404 for now — route arrives in Task 3; the URL is what's being verified).
+- Signed in, visit `http://localhost:3000/signin?redirect=%2F%2Fevil.com` → lands on `/` (unsafe value discarded).
+
+- [ ] **Step 5: Gate + commit**
+
+```bash
+bun run typecheck && bun run lint && bun run test:run
+git add src/proxy.ts src/app/signin/page.tsx src/components/sign-in-screen.tsx
+git commit -m "feat: honor safe ?redirect= through sign-in and protect oauth/settings routes"
+```
+
+---
+
+### Task 2: `/oauth/authorize` consent page + server actions
+
+**Files:**
+- Create: `my-app/src/app/oauth/authorize/page.tsx`
+- Create: `my-app/src/app/oauth/authorize/actions.ts`
+
+**Interfaces:**
+- Consumes: `api.oauth.getClientPublic` + `api.oauth.createAuthCode` (sub-plan 2 Task 6), `api.users.currentUser` (existing), `randomToken`/`sha256Hex` (sub-plan 2 Task 3), `matchesRegisteredRedirect` (sub-plan 2 Task 4), `fetchQuery`/`fetchMutation` from `convex/nextjs`, `convexAuthNextjsToken` from `@convex-dev/auth/nextjs/server`.
+- Produces: the authorization endpoint advertised by the RFC 8414 metadata (`/oauth/authorize`). Query params consumed: `client_id`, `redirect_uri`, `response_type`, `code_challenge`, `code_challenge_method`, `scope` (ignored — fixed grant), `state`, `resource` (optional, stored for future RFC 8707 use).
+
+- [ ] **Step 1: Write the server actions**
+
+```ts
+// src/app/oauth/authorize/actions.ts
+"use server";
+
+import { fetchMutation, fetchQuery } from "convex/nextjs";
+import { convexAuthNextjsToken } from "@convex-dev/auth/nextjs/server";
+import { redirect } from "next/navigation";
+import { api } from "../../../../convex/_generated/api";
+import { randomToken, sha256Hex } from "@/lib/mcp/tokens";
+import { matchesRegisteredRedirect } from "@/lib/mcp/oauth-validation";
+
+/** Builds redirect_uri?k=v... preserving existing query params on the URI. */
+export async function buildCallbackUrl(
+  redirectUri: string,
+  params: Record<string, string>,
+): Promise<string> {
+  const url = new URL(redirectUri);
+  for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value);
+  return url.toString();
+}
+
+type AuthorizeFields = {
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  state: string | null;
+  resource: string | null;
+};
+
+function readFields(formData: FormData): AuthorizeFields {
+  const get = (k: string) => {
+    const v = formData.get(k);
+    return typeof v === "string" && v.length > 0 ? v : null;
+  };
+  return {
+    clientId: get("client_id") ?? "",
+    redirectUri: get("redirect_uri") ?? "",
+    codeChallenge: get("code_challenge") ?? "",
+    state: get("state"),
+    resource: get("resource"),
+  };
+}
+
+export async function approveAuthorization(formData: FormData): Promise<void> {
+  const f = readFields(formData);
+  // Re-validate everything server-side; hidden form fields are attacker input.
+  const client = await fetchQuery(api.oauth.getClientPublic, { clientId: f.clientId });
+  if (!client || !matchesRegisteredRedirect(f.redirectUri, client.redirectUris) || !f.codeChallenge) {
+    throw new Error("Invalid authorization request.");
+  }
+
+  const code = randomToken();
+  await fetchMutation(
+    api.oauth.createAuthCode,
+    {
+      clientId: f.clientId,
+      redirectUri: f.redirectUri,
+      codeHash: await sha256Hex(code),
+      codeChallenge: f.codeChallenge,
+      scope: "read write",
+      ...(f.resource ? { resource: f.resource } : {}),
+    },
+    { token: await convexAuthNextjsToken() },
+  );
+
+  redirect(
+    await buildCallbackUrl(f.redirectUri, {
+      code,
+      ...(f.state !== null ? { state: f.state } : {}),
+    }),
+  );
+}
+
+export async function denyAuthorization(formData: FormData): Promise<void> {
+  const f = readFields(formData);
+  const client = await fetchQuery(api.oauth.getClientPublic, { clientId: f.clientId });
+  if (!client || !matchesRegisteredRedirect(f.redirectUri, client.redirectUris)) {
+    throw new Error("Invalid authorization request.");
+  }
+  redirect(
+    await buildCallbackUrl(f.redirectUri, {
+      error: "access_denied",
+      ...(f.state !== null ? { state: f.state } : {}),
+    }),
+  );
+}
+```
+
+- [ ] **Step 2: Write the page**
+
+```tsx
+// src/app/oauth/authorize/page.tsx
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { fetchQuery } from "convex/nextjs";
+import { convexAuthNextjsToken } from "@convex-dev/auth/nextjs/server";
+import { api } from "../../../../convex/_generated/api";
+import { matchesRegisteredRedirect } from "@/lib/mcp/oauth-validation";
+import { approveAuthorization, denyAuthorization } from "./actions";
+import { Button } from "@/components/ui/button";
+
+export const metadata: Metadata = {
+  title: "Authorize access",
+};
+
+function ErrorCard({ message }: { message: string }) {
+  return (
+    <main className="flex min-h-dvh items-center justify-center bg-bg px-5">
+      <div className="w-full max-w-[400px] rounded-2xl border border-border/40 bg-surface/80 p-8 text-center">
+        <p className="font-display text-xl text-text">Authorization error</p>
+        <p className="mt-3 text-sm leading-relaxed text-text-secondary">{message}</p>
+      </div>
+    </main>
+  );
+}
+
+export default async function AuthorizePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  const str = (key: string): string | null => {
+    const value = params[key];
+    return typeof value === "string" && value.length > 0 ? value : null;
+  };
+
+  // Rule 1: bad client or redirect_uri → render, NEVER redirect.
+  const clientId = str("client_id");
+  const redirectUri = str("redirect_uri");
+  const client = clientId
+    ? await fetchQuery(api.oauth.getClientPublic, { clientId })
+    : null;
+  if (!client) {
+    return <ErrorCard message="Unknown or missing client_id. The connecting app may need to re-register." />;
+  }
+  if (!redirectUri || !matchesRegisteredRedirect(redirectUri, client.redirectUris)) {
+    return <ErrorCard message="The redirect URI does not match this app's registration." />;
+  }
+
+  // Rule 2: other protocol errors → bounce back to the client with `state`.
+  const bounce = (error: string, description: string): never => {
+    const url = new URL(redirectUri);
+    url.searchParams.set("error", error);
+    url.searchParams.set("error_description", description);
+    const state = str("state");
+    if (state !== null) url.searchParams.set("state", state);
+    redirect(url.toString());
+  };
+  if (str("response_type") !== "code") {
+    bounce("unsupported_response_type", "Only response_type=code is supported.");
+  }
+  const codeChallenge = str("code_challenge");
+  if (!codeChallenge || str("code_challenge_method") !== "S256") {
+    bounce("invalid_request", "PKCE with code_challenge_method=S256 is required.");
+  }
+
+  // Middleware guarantees an authenticated session here.
+  const user = await fetchQuery(api.users.currentUser, {}, { token: await convexAuthNextjsToken() });
+
+  const hidden = (
+    <>
+      <input type="hidden" name="client_id" value={clientId!} />
+      <input type="hidden" name="redirect_uri" value={redirectUri} />
+      <input type="hidden" name="code_challenge" value={codeChallenge!} />
+      {str("state") !== null && <input type="hidden" name="state" value={str("state")!} />}
+      {str("resource") !== null && <input type="hidden" name="resource" value={str("resource")!} />}
+    </>
+  );
+
+  return (
+    <main className="flex min-h-dvh items-center justify-center bg-bg px-5">
+      <div className="w-full max-w-[400px] rounded-2xl border border-border/40 bg-surface/80 p-8">
+        <p className="font-display text-xl tracking-tight text-text">
+          Connect {client.clientName}
+        </p>
+        <p className="mt-2 text-sm leading-relaxed text-text-secondary">
+          <span className="font-medium text-text">{client.clientName}</span> wants to read and
+          update the fragrance collection and wear history of{" "}
+          <span className="font-medium text-text">{user?.email ?? "your account"}</span>.
+        </p>
+        <ul className="mt-4 list-disc pl-5 text-sm text-text-secondary">
+          <li>View bottles, wear logs, and collection stats</li>
+          <li>Add, edit, and delete bottles and wear logs</li>
+        </ul>
+        <div className="mt-6 flex gap-3">
+          <form action={denyAuthorization} className="flex-1">
+            {hidden}
+            <Button type="submit" variant="outline" className="w-full">
+              Deny
+            </Button>
+          </form>
+          <form action={approveAuthorization} className="flex-1">
+            {hidden}
+            <Button type="submit" className="w-full">
+              Approve
+            </Button>
+          </form>
+        </div>
+        <p className="mt-4 text-xs text-text-secondary/70">
+          You can revoke access anytime in Settings → Connections.
+        </p>
+      </div>
+    </main>
+  );
+}
+```
+
+Note: `redirect()` inside a server component/action throws `NEXT_REDIRECT` — never wrap the `bounce`/action calls in try/catch.
+
+- [ ] **Step 3: Verify the full code→token happy path with curl + browser**
+
+With dev server + convex dev running and a registered client (sub-plan 2 Task 10 curl):
+
+```bash
+# 1. Register a client with a loopback redirect
+curl -s -X POST http://localhost:3000/api/oauth/register -H "Content-Type: application/json" \
+  -d '{"client_name":"Manual Test","redirect_uris":["http://localhost:9999/cb"]}'
+# note the client_id → CID
+
+# 2. PKCE pair (verifier + challenge)
+VERIFIER="dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+CHALLENGE="E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+# 3. In a signed-in browser, open:
+#   http://localhost:3000/oauth/authorize?client_id=CID&redirect_uri=http%3A%2F%2Flocalhost%3A9999%2Fcb&response_type=code&code_challenge=$CHALLENGE&code_challenge_method=S256&state=xyz
+#   Click Approve → browser lands on http://localhost:9999/cb?code=...&state=xyz (connection refused is fine — copy the code from the URL bar).
+
+# 4. Exchange it
+curl -s -X POST http://localhost:3000/api/oauth/token \
+  -d "grant_type=authorization_code&code=<CODE>&code_verifier=$VERIFIER&client_id=<CID>&redirect_uri=http://localhost:9999/cb"
+# → { access_token, refresh_token, expires_in: 900, scope: "read write" }
+```
+
+Also verify: Deny lands on `...?error=access_denied&state=xyz`; a bad `client_id` renders the error card without redirecting; `response_type=token` bounces with `error=unsupported_response_type&state=xyz`; signed-out visit round-trips through `/signin?redirect=...` back to the consent card.
+
+- [ ] **Step 4: Gate + commit**
+
+```bash
+bun run typecheck && bun run lint && bun run test:run
+git add src/app/oauth
+git commit -m "feat: add OAuth consent page with exact error/redirect semantics"
+```
+
+---
+
+### Task 3: Connected-apps section (test-first)
+
+**Files:**
+- Create: `my-app/src/components/connected-apps.tsx`
+- Create: `my-app/src/components/connected-apps.test.tsx`
+
+**Interfaces:**
+- Consumes: `api.oauth.listGrants` / `api.oauth.revokeGrant` (sub-plan 2 Task 6), `ConfirmDeleteButton` (existing two-click pattern: parent owns `confirming` state), `formatWearDate` from `@/lib/format`.
+- Produces: `<ConnectedApps />` — self-contained client section used by Task 5's page.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/components/connected-apps.test.tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { ConnectedApps } from "./connected-apps";
+
+const mockUseQuery = vi.fn();
+const mockRevoke = vi.fn();
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useMutation: () => mockRevoke,
+}));
+
+const GRANT = {
+  _id: "grant1",
+  clientName: "Claude",
+  scope: "read write",
+  createdAt: Date.UTC(2026, 0, 5, 12),
+  lastUsedAt: undefined,
+};
+
+describe("ConnectedApps", () => {
+  beforeEach(() => {
+    mockUseQuery.mockReset();
+    mockRevoke.mockReset().mockResolvedValue(null);
+  });
+
+  test("shows an empty state when there are no grants", () => {
+    mockUseQuery.mockReturnValue([]);
+    render(<ConnectedApps />);
+    expect(screen.getByText(/no connected apps/i)).toBeInTheDocument();
+  });
+
+  test("lists grants and revokes on double-click confirm", async () => {
+    mockUseQuery.mockReturnValue([GRANT]);
+    const user = userEvent.setup();
+    render(<ConnectedApps />);
+    expect(screen.getByText("Claude")).toBeInTheDocument();
+
+    const button = screen.getByRole("button", { name: /revoke claude/i });
+    await user.click(button); // arm
+    expect(mockRevoke).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: /confirm revoke/i })); // confirm
+    expect(mockRevoke).toHaveBeenCalledWith({ grantId: "grant1" });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:run src/components/connected-apps.test.tsx`
+Expected: FAIL — cannot resolve `./connected-apps`.
+
+- [ ] **Step 3: Write the component**
+
+```tsx
+// src/components/connected-apps.tsx
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { toast } from "sonner";
+import { api } from "../../convex/_generated/api";
+import { Id } from "../../convex/_generated/dataModel";
+import { ConfirmDeleteButton } from "@/components/confirm-delete-button";
+import { formatWearDate } from "@/lib/format";
+
+export function ConnectedApps() {
+  const grants = useQuery(api.oauth.listGrants);
+  const revokeGrant = useMutation(api.oauth.revokeGrant);
+  const [confirmingId, setConfirmingId] = useState<Id<"oauthGrants"> | null>(null);
+
+  const handleRevoke = async (grantId: Id<"oauthGrants">, clientName: string) => {
+    if (confirmingId !== grantId) {
+      setConfirmingId(grantId);
+      return;
+    }
+    setConfirmingId(null);
+    try {
+      await revokeGrant({ grantId });
+      toast.success(`Disconnected ${clientName}.`);
+    } catch {
+      toast.error("Could not revoke access. Please try again.");
+    }
+  };
+
+  return (
+    <section>
+      <h2 className="font-display text-lg text-text">Connected apps</h2>
+      <p className="mt-1 text-sm text-text-secondary">
+        AI agents you have granted access to via OAuth. Revoking stops new requests within 15
+        minutes (until their current token expires).
+      </p>
+      {grants === undefined ? (
+        <p className="mt-4 text-sm text-text-secondary">Loading…</p>
+      ) : grants.length === 0 ? (
+        <p className="mt-4 rounded-lg border border-border/40 bg-surface/60 px-4 py-3 text-sm text-text-secondary">
+          No connected apps yet.
+        </p>
+      ) : (
+        <ul className="mt-4 divide-y divide-border/40 rounded-lg border border-border/40 bg-surface/60">
+          {grants.map((grant) => (
+            <li key={grant._id} className="flex items-center justify-between gap-3 px-4 py-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-text">{grant.clientName}</p>
+                <p className="text-xs text-text-secondary">
+                  Connected {formatWearDate(grant.createdAt)}
+                  {grant.lastUsedAt ? ` · Last used ${formatWearDate(grant.lastUsedAt)}` : ""}
+                </p>
+              </div>
+              <ConfirmDeleteButton
+                confirming={confirmingId === grant._id}
+                onClick={() => void handleRevoke(grant._id, grant.clientName)}
+                onMouseLeave={() => setConfirmingId(null)}
+                idleLabel={`Revoke ${grant.clientName}`}
+                confirmLabel="Confirm revoke"
+                size="compact"
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test:run src/components/connected-apps.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/connected-apps.tsx src/components/connected-apps.test.tsx
+git commit -m "feat: add connected apps section with grant revocation"
+```
+
+---
+
+### Task 4: PAT manager section (test-first)
+
+**Files:**
+- Create: `my-app/src/components/pat-manager.tsx`
+- Create: `my-app/src/components/pat-manager.test.tsx`
+
+**Interfaces:**
+- Consumes: `api.apiTokens.list/create/revoke` (sub-plan 2 Task 7), `randomToken`/`sha256Hex`/`PAT_PREFIX` from `@/lib/mcp/tokens` (isomorphic — runs in the browser), `Dialog` from `@/components/ui/dialog`, `Input`, `Button`, `ConfirmDeleteButton`, `formatWearDate`.
+- Produces: `<PatManager />` — list + create-with-copy-once dialog + revoke. **The raw token exists only in browser memory; only its hash is sent to Convex; it is rendered exactly once.**
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/components/pat-manager.test.tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { PatManager } from "./pat-manager";
+import { PAT_PREFIX, sha256Hex } from "@/lib/mcp/tokens";
+
+const mockUseQuery = vi.fn();
+const mockCreate = vi.fn();
+const mockRevoke = vi.fn();
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useMutation: (ref: { _name?: string }) =>
+    String(ref).includes("revoke") ? mockRevoke : mockCreate,
+}));
+
+describe("PatManager", () => {
+  beforeEach(() => {
+    mockUseQuery.mockReset().mockReturnValue([]);
+    mockCreate.mockReset().mockResolvedValue("tok1");
+    mockRevoke.mockReset().mockResolvedValue(null);
+  });
+
+  test("creating a token sends only the hash and shows the raw value once", async () => {
+    const user = userEvent.setup();
+    render(<PatManager />);
+
+    await user.click(screen.getByRole("button", { name: /create token/i }));
+    await user.type(screen.getByLabelText(/token name/i), "Claude Code");
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    // Raw token displayed once, fgt_-prefixed.
+    const rawEl = await screen.findByTestId("raw-token");
+    const raw = rawEl.textContent!;
+    expect(raw.startsWith(PAT_PREFIX)).toBe(true);
+
+    // The mutation received the SHA-256 of exactly that raw value — never the raw.
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const args = mockCreate.mock.calls[0][0] as { tokenHash: string; name: string };
+    expect(args.name).toBe("Claude Code");
+    expect(args.tokenHash).toBe(await sha256Hex(raw));
+  });
+});
+```
+
+If the `useMutation` ref-discrimination trick proves brittle, split the mock per test with `vi.mocked` — the assertion that matters is hash-not-raw.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test:run src/components/pat-manager.test.tsx`
+Expected: FAIL — cannot resolve `./pat-manager`.
+
+- [ ] **Step 3: Write the component**
+
+```tsx
+// src/components/pat-manager.tsx
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { Copy, Plus } from "lucide-react";
+import { toast } from "sonner";
+import { api } from "../../convex/_generated/api";
+import { Id } from "../../convex/_generated/dataModel";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { ConfirmDeleteButton } from "@/components/confirm-delete-button";
+import { formatWearDate } from "@/lib/format";
+import { PAT_PREFIX, randomToken, sha256Hex } from "@/lib/mcp/tokens";
+
+export function PatManager() {
+  const tokens = useQuery(api.apiTokens.list);
+  const createToken = useMutation(api.apiTokens.create);
+  const revokeToken = useMutation(api.apiTokens.revoke);
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [rawToken, setRawToken] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [confirmingId, setConfirmingId] = useState<Id<"personalAccessTokens"> | null>(null);
+
+  const handleCreate = async () => {
+    if (name.trim().length === 0) return;
+    setIsCreating(true);
+    try {
+      // Raw token never leaves the browser; Convex stores only the hash.
+      const raw = PAT_PREFIX + randomToken();
+      await createToken({ tokenHash: await sha256Hex(raw), name: name.trim() });
+      setRawToken(raw);
+    } catch {
+      toast.error("Could not create the token. Please try again.");
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const closeDialog = (open: boolean) => {
+    setDialogOpen(open);
+    if (!open) {
+      setName("");
+      setRawToken(null);
+    }
+  };
+
+  const handleRevoke = async (tokenId: Id<"personalAccessTokens">) => {
+    if (confirmingId !== tokenId) {
+      setConfirmingId(tokenId);
+      return;
+    }
+    setConfirmingId(null);
+    try {
+      await revokeToken({ tokenId });
+      toast.success("Token revoked.");
+    } catch {
+      toast.error("Could not revoke the token. Please try again.");
+    }
+  };
+
+  return (
+    <section>
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="font-display text-lg text-text">API tokens</h2>
+          <p className="mt-1 text-sm text-text-secondary">
+            Personal access tokens for CLI clients (Claude Code, curl). Sent as{" "}
+            <code className="text-xs">Authorization: Bearer fgt_…</code>
+          </p>
+        </div>
+        <Dialog open={dialogOpen} onOpenChange={closeDialog}>
+          <DialogTrigger asChild>
+            <Button size="sm" className="gap-2 shrink-0">
+              <Plus className="h-4 w-4" /> Create token
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            {rawToken === null ? (
+              <>
+                <DialogHeader>
+                  <DialogTitle>Create API token</DialogTitle>
+                  <DialogDescription>
+                    Name it after the client that will use it.
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-2">
+                  <Label htmlFor="pat-name">Token name</Label>
+                  <Input
+                    id="pat-name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    maxLength={100}
+                    placeholder="e.g. Claude Code on laptop"
+                  />
+                </div>
+                <Button onClick={() => void handleCreate()} disabled={isCreating || name.trim() === ""}>
+                  Create
+                </Button>
+              </>
+            ) : (
+              <>
+                <DialogHeader>
+                  <DialogTitle>Copy your token now</DialogTitle>
+                  <DialogDescription>
+                    This is the only time it will be shown. Store it like a password.
+                  </DialogDescription>
+                </DialogHeader>
+                <code
+                  data-testid="raw-token"
+                  className="block break-all rounded-lg border border-border/40 bg-surface-alt px-3 py-2 text-xs"
+                >
+                  {rawToken}
+                </code>
+                <Button
+                  variant="outline"
+                  className="gap-2"
+                  onClick={() => {
+                    void navigator.clipboard.writeText(rawToken);
+                    toast.success("Copied to clipboard.");
+                  }}
+                >
+                  <Copy className="h-4 w-4" /> Copy
+                </Button>
+              </>
+            )}
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {tokens === undefined ? (
+        <p className="mt-4 text-sm text-text-secondary">Loading…</p>
+      ) : tokens.length === 0 ? (
+        <p className="mt-4 rounded-lg border border-border/40 bg-surface/60 px-4 py-3 text-sm text-text-secondary">
+          No API tokens yet.
+        </p>
+      ) : (
+        <ul className="mt-4 divide-y divide-border/40 rounded-lg border border-border/40 bg-surface/60">
+          {tokens.map((token) => (
+            <li key={token._id} className="flex items-center justify-between gap-3 px-4 py-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-text">{token.name}</p>
+                <p className="text-xs text-text-secondary">
+                  Created {formatWearDate(token.createdAt)}
+                  {token.lastUsedAt ? ` · Last used ${formatWearDate(token.lastUsedAt)}` : " · Never used"}
+                </p>
+              </div>
+              <ConfirmDeleteButton
+                confirming={confirmingId === token._id}
+                onClick={() => void handleRevoke(token._id)}
+                onMouseLeave={() => setConfirmingId(null)}
+                idleLabel={`Revoke ${token.name}`}
+                confirmLabel="Confirm revoke"
+                size="compact"
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+```
+
+Check `src/components/ui/dialog.tsx` for the exact exported names before importing (the add-bottle dialog is the reference consumer); adjust imports to match.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test:run src/components/pat-manager.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/pat-manager.tsx src/components/pat-manager.test.tsx
+git commit -m "feat: add PAT manager with hash-only creation and copy-once display"
+```
+
+---
+
+### Task 5: `/settings/connections` page + header nav link
+
+**Files:**
+- Create: `my-app/src/app/settings/connections/page.tsx`
+- Modify: `my-app/src/components/home-page.tsx` (header actions, around line 116)
+
+**Interfaces:**
+- Consumes: `<ConnectedApps />` (Task 3), `<PatManager />` (Task 4). Route already protected by Task 1's middleware.
+- Produces: the app's first settings route; header gains a gear icon linking to it.
+
+- [ ] **Step 1: Write the page**
+
+```tsx
+// src/app/settings/connections/page.tsx
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { ConnectedApps } from "@/components/connected-apps";
+import { PatManager } from "@/components/pat-manager";
+import { Button } from "@/components/ui/button";
+
+export const metadata: Metadata = {
+  title: "Connections",
+};
+
+export default function ConnectionsPage() {
+  return (
+    <main className="min-h-dvh bg-bg">
+      <div className="mx-auto w-full max-w-2xl px-5 py-8">
+        <div className="flex items-center gap-3">
+          <Button asChild variant="ghost" size="sm" aria-label="Back to collection">
+            <Link href="/">
+              <ArrowLeft className="h-4 w-4" />
+            </Link>
+          </Button>
+          <h1 className="font-display text-2xl tracking-tight text-text">Connections</h1>
+        </div>
+        <p className="mt-2 text-sm text-text-secondary">
+          Manage AI agents and API tokens that can access your collection via MCP.
+        </p>
+        <div className="mt-8 space-y-10">
+          <ConnectedApps />
+          <PatManager />
+        </div>
+      </div>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Add the header link in `home-page.tsx`**
+
+In the header actions `div` (currently `<ThemeToggle />` + sign-out button, line ~116), insert before `<ThemeToggle />`:
+
+```tsx
+<Button asChild variant="ghost" size="sm" aria-label="Connections settings">
+  <Link href="/settings/connections">
+    <Settings className="h-4 w-4" />
+  </Link>
+</Button>
+```
+
+Add imports: `Settings` to the existing `lucide-react` import; `import Link from "next/link";`.
+
+- [ ] **Step 3: Verify in the browser**
+
+`bun dev`: gear icon appears in the header; clicking it opens `/settings/connections`; create a PAT, copy it, revoke it; connect via the Task 2 curl flow and see the grant appear under Connected apps; revoke it and confirm a subsequent refresh-token grant fails with `invalid_grant`.
+
+- [ ] **Step 4: Full gate + commit + PR**
+
+```bash
+bun run typecheck && bun run lint && bun run test:run && bun run build
+git add src/app/settings src/components/home-page.tsx
+git commit -m "feat: add /settings/connections page and header nav link"
+git push -u origin feat/mcp-consent-settings
+gh pr create --title "feat: OAuth consent page, sign-in redirect passthrough, connections settings" --body "Sub-plan 4/5 of docs/mcp-server-plan.md (issue #65): safe ?redirect= through sign-in (middleware + page + screen), /oauth/authorize with locked RFC 6749 error semantics (render vs bounce, state passthrough), /settings/connections with grant revocation and copy-once PATs. Completes the OAuth code→token happy path.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```

--- a/docs/superpowers/plans/2026-07-06-mcp-5-verification-docs.md
+++ b/docs/superpowers/plans/2026-07-06-mcp-5-verification-docs.md
@@ -1,0 +1,250 @@
+# MCP Sub-plan 5/5: Verification + Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Epic:** `docs/mcp-server-plan.md` (issue #65). Sub-plan 5 of 5. Requires sub-plans 2–4 merged and deployed to the Vercel production app + Convex prod deployment.
+
+**Goal:** Prove the whole system end to end — local JWKS strategy, scripted endpoint tests, MCP inspector flow, Claude Code in both auth modes, production claude.ai/ChatGPT connectors — and write the operator/user documentation.
+
+**Architecture:** Verification-only plus docs; the single code artifact is a curl smoke script. The local-dev JWKS problem (Convex Cloud cannot fetch `localhost`) is solved by a **dedicated dev keypair whose public half is published in the production JWKS** via the `MCP_EXTRA_PUBLIC_JWKS` env hook built in sub-plan 2 — an explicit, documented tradeoff: only public key material is shared, the dev private key never leaves the developer machine, and prod rejects dev-signed tokens because the issuer claim differs.
+
+**Tech Stack:** bash + curl + python3 (assertions), `@modelcontextprotocol/inspector`, Claude Code CLI, claude.ai / ChatGPT connector UIs.
+
+## Global Constraints
+
+- All commands run from `/home/code/fragrances-tracker/my-app` unless stated otherwise.
+- Branch: `feat/mcp-verification-docs` cut from `main` after sub-plan 4 merges.
+- Never paste raw tokens (PATs, refresh tokens, access tokens) into files, commits, or issue comments. Keys generated for prod stay in Vercel/Convex env UIs only.
+- CI parity gate before the PR: `bun run typecheck && bun run lint && bun run test:run && bun run build`.
+- Record every manual verification's outcome (pass/fail + date) in the PR description checklist, not in the repo.
+
+---
+
+### Task 1: Local-dev JWKS strategy — dev keypair published via prod JWKS
+
+**Files:**
+- Modify: env vars only (Vercel prod, Convex dev deployment, `.env.local`) — the `MCP_EXTRA_PUBLIC_JWKS` mechanism already exists in `src/lib/mcp/tokens.ts#getPublicJwks` (sub-plan 2 Task 3).
+
+**Interfaces:**
+- Produces: a working local loop — locally-minted JWTs verify in the Convex **dev** deployment — plus the documented tradeoff for Task 6's README section.
+
+- [ ] **Step 1: Generate a dedicated dev keypair**
+
+```bash
+bun scripts/generate-mcp-keypair.mjs mcp-dev-1
+```
+
+- Private PEM → `.env.local` `MCP_JWT_PRIVATE_KEY` (dev only; never in Vercel).
+- Public JWK (it already carries `kid: "mcp-dev-1"`) → copy for the next step.
+
+- [ ] **Step 2: Publish the dev public key in the prod JWKS**
+
+In Vercel env for the production app, set:
+
+```
+MCP_EXTRA_PUBLIC_JWKS=[{"kty":"RSA","n":"...","e":"AQAB","kid":"mcp-dev-1","alg":"RS256","use":"sig"}]
+```
+
+Redeploy, then confirm both keys are served:
+
+```bash
+curl -s https://<prod-app>/api/oauth/jwks | python3 -c "import json,sys; print([k['kid'] for k in json.load(sys.stdin)['keys']])"
+# expected: ['mcp-1', 'mcp-dev-1']
+```
+
+- [ ] **Step 3: Point the Convex dev deployment at it**
+
+Convex **dev** dashboard env: `MCP_JWT_ISSUER=http://localhost:3000`, `MCP_JWKS_URL=https://<prod-app>/api/oauth/jwks`.
+
+Why this is safe (goes verbatim into the README in Task 6): the JWKS contains only public keys; the dev private key never leaves the developer's machine; a dev-signed token presented to **prod** Convex fails because prod's `customJwt` provider requires `iss = https://<prod-app>` while dev tokens carry `iss = http://localhost:3000`. Alternative if publishing the dev key is unacceptable: run `cloudflared tunnel --url http://localhost:3000` and use the tunnel URL as both issuer and JWKS host (re-set env each run — quick tunnels get random hostnames).
+
+- [ ] **Step 4: Verify the local loop**
+
+Re-run sub-plan 3 Task 5's PAT smoke curl against `localhost` — `get_collection_stats` must return real data, proving dev-minted bridge JWTs verify in Convex dev.
+
+---
+
+### Task 2: Scripted endpoint smoke tests
+
+**Files:**
+- Create: `my-app/scripts/oauth-smoke.sh`
+
+**Interfaces:**
+- Produces: one command asserting the OAuth surface of any deployment. Usage: `./scripts/oauth-smoke.sh <base-url> [revoked-pat]`.
+
+- [ ] **Step 1: Write the script**
+
+```bash
+#!/usr/bin/env bash
+# Smoke-tests the MCP OAuth surface. Usage:
+#   ./scripts/oauth-smoke.sh http://localhost:3000 [revoked-pat]
+# Pass a *revoked* PAT as $2 to also assert the 401 path for dead tokens.
+set -euo pipefail
+BASE="${1:?usage: oauth-smoke.sh <base-url> [revoked-pat]}"
+REVOKED_PAT="${2:-}"
+PASS=0; FAIL=0
+
+check() { # check <name> <expected> <actual>
+  if [ "$2" = "$3" ]; then PASS=$((PASS+1)); echo "ok   $1"; else FAIL=$((FAIL+1)); echo "FAIL $1 (expected $2, got $3)"; fi
+}
+json_field() { python3 -c "import json,sys; print(json.load(sys.stdin).get('$1',''))"; }
+status_of() { curl -s -o /dev/null -w "%{http_code}" "$@"; }
+
+# ── Discovery metadata ──
+check "AS metadata 200" 200 "$(status_of "$BASE/.well-known/oauth-authorization-server")"
+check "PRM root 200" 200 "$(status_of "$BASE/.well-known/oauth-protected-resource")"
+check "PRM path-suffixed 200" 200 "$(status_of "$BASE/.well-known/oauth-protected-resource/api/mcp")"
+check "JWKS 200" 200 "$(status_of "$BASE/api/oauth/jwks")"
+check "metadata CORS" "*" "$(curl -s -D - -o /dev/null "$BASE/.well-known/oauth-authorization-server" | tr -d '\r' | awk -F': ' 'tolower($1)=="access-control-allow-origin"{print $2}')"
+check "metadata OPTIONS 204" 204 "$(status_of -X OPTIONS "$BASE/.well-known/oauth-authorization-server")"
+check "JWKS has no private fields" "" "$(curl -s "$BASE/api/oauth/jwks" | python3 -c "import json,sys; print(''.join(f for k in json.load(sys.stdin)['keys'] for f in ('d','p','q') if f in k))")"
+
+# ── DCR ──
+REG=$(curl -s -X POST "$BASE/api/oauth/register" -H "Content-Type: application/json" \
+  -d '{"client_name":"smoke-test","redirect_uris":["http://localhost:9999/cb"]}')
+CID=$(echo "$REG" | json_field client_id)
+check "DCR returns client_id" "yes" "$([ -n "$CID" ] && echo yes || echo no)"
+check "DCR bad URI rejected" "invalid_redirect_uri" "$(curl -s -X POST "$BASE/api/oauth/register" \
+  -H "Content-Type: application/json" -d '{"client_name":"x","redirect_uris":["http://evil.com/cb"]}' | json_field error)"
+
+# ── Token endpoint error semantics ──
+check "unsupported grant type" "unsupported_grant_type" \
+  "$(curl -s -X POST "$BASE/api/oauth/token" -d 'grant_type=password' | json_field error)"
+check "missing params invalid_request" "invalid_request" \
+  "$(curl -s -X POST "$BASE/api/oauth/token" -d 'grant_type=authorization_code&code=x' | json_field error)"
+check "bogus code invalid_grant" "invalid_grant" \
+  "$(curl -s -X POST "$BASE/api/oauth/token" \
+    -d "grant_type=authorization_code&code=bogus&code_verifier=bogusverifierbogusverifierbogusverifier1234&client_id=$CID&redirect_uri=http://localhost:9999/cb" | json_field error)"
+check "bogus refresh invalid_grant" "invalid_grant" \
+  "$(curl -s -X POST "$BASE/api/oauth/token" -d "grant_type=refresh_token&refresh_token=bogus&client_id=$CID" | json_field error)"
+check "token no-store" "no-store" \
+  "$(curl -s -D - -o /dev/null -X POST "$BASE/api/oauth/token" -d 'grant_type=password' | tr -d '\r' | awk -F': ' 'tolower($1)=="cache-control"{print $2}')"
+
+# ── MCP endpoint auth ──
+MCP_ARGS=(-X POST "$BASE/api/mcp" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}')
+check "MCP unauthenticated 401" 401 "$(status_of "${MCP_ARGS[@]}")"
+check "401 advertises resource metadata" "yes" \
+  "$(curl -s -D - -o /dev/null "${MCP_ARGS[@]}" | grep -qi 'www-authenticate.*resource_metadata' && echo yes || echo no)"
+if [ -n "$REVOKED_PAT" ]; then
+  check "revoked PAT 401" 401 "$(status_of "${MCP_ARGS[@]}" -H "Authorization: Bearer $REVOKED_PAT")"
+fi
+
+echo; echo "passed=$PASS failed=$FAIL"
+[ "$FAIL" -eq 0 ]
+```
+
+- [ ] **Step 2: Run it locally and fix anything red**
+
+```bash
+chmod +x scripts/oauth-smoke.sh
+./scripts/oauth-smoke.sh http://localhost:3000
+```
+
+Expected: `failed=0`. Then create a PAT in `/settings/connections`, revoke it, and re-run with it as `$2` to cover the revoked-PAT 401.
+
+- [ ] **Step 3: Manual single-use-code check (not scriptable — needs browser consent)**
+
+Run sub-plan 4 Task 2 Step 3's browser flow to get a fresh `code`, exchange it once (200), exchange the same body again → `invalid_grant`, then confirm in `/settings/connections` that the grant was revoked (reuse defense). Reconnect afterwards.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/oauth-smoke.sh
+git commit -m "test: add OAuth endpoint smoke script"
+```
+
+---
+
+### Task 3: MCP inspector end-to-end (local)
+
+No files — checklist. Dev server + `bunx convex dev` running, Task 1 strategy applied.
+
+- [ ] `npx @modelcontextprotocol/inspector`, transport Streamable HTTP, URL `http://localhost:3000/api/mcp`, click Connect with auth enabled.
+- [ ] Observe the full flow: 401 → metadata discovery → DCR → browser opens `/oauth/authorize` (sign in if needed — verifies the `?redirect=` passthrough) → consent card shows "Inspector" client name + your email → Approve → inspector shows connected.
+- [ ] Tools tab lists all 12 tools with descriptions.
+- [ ] Call `get_collection_stats` → real totals. Call `add_bottle` (`{"name":"Inspector Test"}`) → returns `bottleId`; verify it appears in the web app; `delete_bottle` it.
+- [ ] Call `get_bottle` with `{"bottleId":"garbage"}` → `isError` result with a readable message, not a protocol error.
+- [ ] `/settings/connections` shows the inspector grant; revoke it; inspector's next call after token expiry (≤15 min) fails; note observed behavior.
+
+---
+
+### Task 4: Claude Code — both auth modes (local or prod)
+
+No files — checklist.
+
+- [ ] OAuth mode:
+
+```bash
+claude mcp add --transport http fragrances https://<app-domain>/api/mcp
+```
+
+In a Claude Code session run `/mcp`, complete the browser OAuth flow, then prompt: *"Using the fragrances tools, summarize my collection."* Confirm `get_collection_stats` / `get_collection_snapshot` fire and the summary is grounded in real data.
+
+- [ ] PAT mode: create a PAT in `/settings/connections`, then:
+
+```bash
+claude mcp remove fragrances
+claude mcp add --transport http fragrances https://<app-domain>/api/mcp \
+  --header "Authorization: Bearer fgt_<token>"
+```
+
+Prompt: *"Log that I wore <bottle name> today, 3 sprays."* Confirm the wear log appears in the web app (this exercises `list_bottles` → `add_wear_log` and the per-user write rate limits).
+
+- [ ] Revoke that PAT in settings; the next tool call returns 401 within one request (PAT lookup is per-request, but a live 5-min bridge JWT may let one in-flight call through — note actual behavior).
+
+---
+
+### Task 5: Production connectors — claude.ai + ChatGPT
+
+No files — checklist. Prod Vercel + Convex prod env vars set (`MCP_JWT_PRIVATE_KEY`, `NEXT_PUBLIC_APP_URL` / `MCP_JWT_ISSUER`, `MCP_JWKS_URL`); `./scripts/oauth-smoke.sh https://<app-domain>` green first.
+
+- [ ] claude.ai → Settings → Connectors → Add custom connector → `https://<app-domain>/api/mcp`. Complete OAuth. Prompt: *"What should I wear tonight? Consider what I've worn recently."* — confirm insight tools fire and the consent grant shows in `/settings/connections`.
+- [ ] ChatGPT → Settings → Connectors (developer mode) → add `https://<app-domain>/api/mcp`. Complete OAuth. Same prompt. Record any connector quirks hit (path-suffixed PRM, CORS, redirect URIs — epic risk #4) and, if code changes were needed, file them as issues rather than hot-fixing unreviewed.
+- [ ] Revoke both grants from settings and confirm both connectors lose access after access-token expiry (≤15 min).
+
+---
+
+### Task 6: README + epic close-out
+
+**Files:**
+- Modify: `README.md` (repo root — add an "MCP server: connect your AI agent" section)
+- Modify: `docs/mcp-server-plan.md` (mark sub-plans complete)
+
+- [ ] **Step 1: Write the README section**
+
+Content requirements (write it, don't stub it):
+
+1. **What it is** — remote MCP server at `https://<app-domain>/api/mcp`, streamable HTTP, OAuth 2.1 + PATs, 12 tools (CRUD + insights).
+2. **Connect from claude.ai / ChatGPT** — the two connector UIs, paste the URL, approve consent.
+3. **Connect from Claude Code** — both `claude mcp add` commands from Task 4 verbatim.
+4. **PATs** — created in Settings → Connections, `fgt_` prefix, shown once, revocable; sent as a Bearer header.
+5. **Operator setup** — env var table:
+
+| Var | Where | Value |
+|---|---|---|
+| `MCP_JWT_PRIVATE_KEY` | Vercel + `.env.local` | PKCS8 PEM from `bun scripts/generate-mcp-keypair.mjs` |
+| `NEXT_PUBLIC_APP_URL` | Vercel + `.env.local` | App origin; doubles as JWT issuer |
+| `MCP_EXTRA_PUBLIC_JWKS` | Vercel (optional) | JSON array of extra public JWKs (dev-key strategy) |
+| `MCP_JWT_ISSUER` | Convex dashboard | = app origin of that environment |
+| `MCP_JWKS_URL` | Convex dashboard | JWKS URL reachable from Convex Cloud |
+
+6. **Local development** — Task 1's dev-keypair strategy, verbatim including the why-this-is-safe paragraph and the cloudflared alternative.
+7. **Key rotation** — generate a new keypair with a new `kid`, serve **both** public keys via `MCP_EXTRA_PUBLIC_JWKS` while tokens signed by the old key can still exist (access ≤15 min, PAT bridge ≤5 min), switch `MCP_JWT_PRIVATE_KEY`, drop the old public key after 24 h.
+
+- [ ] **Step 2: Update the epic**
+
+In `docs/mcp-server-plan.md`, mark the sub-plan checklist (added when the plans were forked) complete and note any deviations discovered during verification.
+
+- [ ] **Step 3: Gate, commit, PR, close the issue**
+
+```bash
+bun run typecheck && bun run lint && bun run test:run && bun run build
+git add README.md ../docs/mcp-server-plan.md scripts/oauth-smoke.sh
+git commit -m "docs: MCP connection guide, env/rotation docs, verification close-out"
+git push -u origin feat/mcp-verification-docs
+gh pr create --title "docs: MCP server verification + connection docs" --body "Sub-plan 5/5 of docs/mcp-server-plan.md (issue #65). Includes smoke script; PR checklist records inspector/Claude Code/claude.ai/ChatGPT verification results. Closes #65.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+Fill the PR body with the Task 3–5 checklists and their observed results before requesting review.

--- a/my-app/bun.lock
+++ b/my-app/bun.lock
@@ -34,7 +34,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.1",
-        "zod": "^3",
+        "zod": "^4",
       },
       "devDependencies": {
         "@edge-runtime/vm": "^5.0.0",
@@ -1610,7 +1610,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
@@ -1653,8 +1653,6 @@
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
-    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -1699,8 +1697,6 @@
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.6", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA=="],
-
-    "eslint-plugin-react-hooks/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/my-app/bun.lock
+++ b/my-app/bun.lock
@@ -8,6 +8,7 @@
         "@auth/core": "0.37.0",
         "@convex-dev/auth": "^0.0.91",
         "@convex-dev/rate-limiter": "^0.3.2",
+        "@modelcontextprotocol/sdk": "1.26.0",
         "@radix-ui/react-dialog": "^1.1.17",
         "@radix-ui/react-dropdown-menu": "^2.1.18",
         "@radix-ui/react-label": "^2.1.10",
@@ -20,7 +21,9 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "convex": "^1.42.0",
+        "jose": "^6.2.3",
         "lucide-react": "^0.577.0",
+        "mcp-handler": "^1.1.0",
         "next": "16.2.6",
         "next-themes": "^0.4.6",
         "postcss": "^8.5.16",
@@ -31,6 +34,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.1",
+        "zod": "^3",
       },
       "devDependencies": {
         "@edge-runtime/vm": "^5.0.0",
@@ -222,6 +226,8 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -289,6 +295,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.26.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
@@ -401,6 +409,18 @@
     "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.6", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.6" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.2", "", {}, "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA=="],
+
+    "@redis/bloom": ["@redis/bloom@1.2.0", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg=="],
+
+    "@redis/client": ["@redis/client@1.6.1", "", { "dependencies": { "cluster-key-slot": "1.1.2", "generic-pool": "3.9.0", "yallist": "4.0.0" } }, "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw=="],
+
+    "@redis/graph": ["@redis/graph@1.1.1", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw=="],
+
+    "@redis/json": ["@redis/json@1.0.7", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ=="],
+
+    "@redis/search": ["@redis/search@1.2.0", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw=="],
+
+    "@redis/time-series": ["@redis/time-series@1.1.0", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.3", "", { "os": "android", "cpu": "arm64" }, "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g=="],
 
@@ -586,11 +606,15 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -638,11 +662,15 @@
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
     "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
@@ -674,13 +702,21 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
+    "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -689,6 +725,10 @@
     "convex-test": ["convex-test@0.0.47", "", { "peerDependencies": { "convex": "^1.32.0" } }, "sha512-EBJQ2Ys2sHWFCZYYO1bAqudrrMW3y+SP7BF2+E5rYIGVntU4v+EoWxx1h/X+2ISMKvecf4RJLV6ojBvWNUFDcw=="],
 
     "cookie": ["cookie@0.7.1", "", {}, "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -720,6 +760,8 @@
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -734,9 +776,13 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.307", "", {}, "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
 
@@ -763,6 +809,8 @@
     "esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -802,7 +850,17 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -814,6 +872,8 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
+
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -822,6 +882,8 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
@@ -829,6 +891,10 @@
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -839,6 +905,8 @@
     "functions-have-names": ["functions-have-names@1.2.3", "", {}, "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="],
 
     "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
+
+    "generic-pool": ["generic-pool@3.9.0", "", {}, "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
@@ -884,9 +952,15 @@
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
+    "hono": ["hono@4.12.28", "", {}, "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA=="],
+
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -896,9 +970,15 @@
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -948,6 +1028,8 @@
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
     "is-set": ["is-set@2.0.3", "", {}, "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="],
@@ -974,7 +1056,7 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
-    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -987,6 +1069,8 @@
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
@@ -1050,6 +1134,8 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "mcp-handler": ["mcp-handler@1.1.0", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^11.1.0", "redis": "^4.6.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "1.26.0", "next": ">=13.0.0" }, "optionalPeers": ["next"], "bin": { "mcp-adapter": "dist/cli/index.js", "mcp-handler": "dist/cli/index.js", "create-mcp-route": "dist/cli/index.js" } }, "sha512-MVCES7g18gcoZy+R/3v5nadkUMzMAWdos8jRl6DyljOKvd2/ZKDmwlCjL6zp4vo+7FeCXOYL1uWinHWlkKAAUg=="],
+
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
@@ -1081,6 +1167,10 @@
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -1142,6 +1232,10 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
@@ -1155,6 +1249,8 @@
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "next": ["next@16.2.6", "", { "dependencies": { "@next/env": "16.2.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.6", "@next/swc-darwin-x64": "16.2.6", "@next/swc-linux-arm64-gnu": "16.2.6", "@next/swc-linux-arm64-musl": "16.2.6", "@next/swc-linux-x64-gnu": "16.2.6", "@next/swc-linux-x64-musl": "16.2.6", "@next/swc-win32-arm64-msvc": "16.2.6", "@next/swc-win32-x64-msvc": "16.2.6", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw=="],
 
@@ -1184,6 +1280,10 @@
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
@@ -1198,6 +1298,8 @@
 
     "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -1211,6 +1313,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1230,9 +1334,17 @@
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
 
@@ -1249,6 +1361,8 @@
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "redis": ["redis@4.7.1", "", { "dependencies": { "@redis/bloom": "1.2.0", "@redis/client": "1.6.1", "@redis/graph": "1.1.1", "@redis/json": "1.0.7", "@redis/search": "1.2.0", "@redis/time-series": "1.1.0" } }, "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -1274,6 +1388,8 @@
 
     "rolldown": ["rolldown@1.1.3", "", { "dependencies": { "@oxc-project/types": "=0.137.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.3", "@rolldown/binding-darwin-arm64": "1.1.3", "@rolldown/binding-darwin-x64": "1.1.3", "@rolldown/binding-freebsd-x64": "1.1.3", "@rolldown/binding-linux-arm-gnueabihf": "1.1.3", "@rolldown/binding-linux-arm64-gnu": "1.1.3", "@rolldown/binding-linux-arm64-musl": "1.1.3", "@rolldown/binding-linux-ppc64-gnu": "1.1.3", "@rolldown/binding-linux-s390x-gnu": "1.1.3", "@rolldown/binding-linux-x64-gnu": "1.1.3", "@rolldown/binding-linux-x64-musl": "1.1.3", "@rolldown/binding-openharmony-arm64": "1.1.3", "@rolldown/binding-wasm32-wasi": "1.1.3", "@rolldown/binding-win32-arm64-msvc": "1.1.3", "@rolldown/binding-win32-x64-msvc": "1.1.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
@@ -1282,11 +1398,17 @@
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
 
@@ -1295,6 +1417,8 @@
     "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
@@ -1321,6 +1445,8 @@
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
@@ -1378,6 +1504,8 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
@@ -1393,6 +1521,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
@@ -1424,6 +1554,8 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
@@ -1433,6 +1565,8 @@
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
@@ -1464,21 +1598,27 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
-    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@auth/core/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
     "@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -1506,9 +1646,15 @@
 
     "@convex-dev/auth/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
+    "@convex-dev/auth/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -1542,6 +1688,10 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
+    "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
@@ -1550,9 +1700,13 @@
 
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.6", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA=="],
 
+    "eslint-plugin-react-hooks/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "is-bun-module/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "mcp-handler/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
@@ -1564,11 +1718,19 @@
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "qs/side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
     "sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
@@ -1576,10 +1738,16 @@
 
     "@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
+    "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
     "@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
 
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "qs/side-channel/side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
   }
 }

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -20,6 +20,7 @@
     "@auth/core": "0.37.0",
     "@convex-dev/auth": "^0.0.91",
     "@convex-dev/rate-limiter": "^0.3.2",
+    "@modelcontextprotocol/sdk": "1.26.0",
     "@radix-ui/react-dialog": "^1.1.17",
     "@radix-ui/react-dropdown-menu": "^2.1.18",
     "@radix-ui/react-label": "^2.1.10",
@@ -32,7 +33,9 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "convex": "^1.42.0",
+    "jose": "^6.2.3",
     "lucide-react": "^0.577.0",
+    "mcp-handler": "^1.1.0",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "postcss": "^8.5.16",
@@ -42,7 +45,8 @@
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
-    "tailwindcss": "^4.3.1"
+    "tailwindcss": "^4.3.1",
+    "zod": "^3"
   },
   "devDependencies": {
     "@edge-runtime/vm": "^5.0.0",

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -46,7 +46,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.1",
-    "zod": "^3"
+    "zod": "^4"
   },
   "devDependencies": {
     "@edge-runtime/vm": "^5.0.0",

--- a/my-app/scripts/spike-jose.mjs
+++ b/my-app/scripts/spike-jose.mjs
@@ -1,0 +1,19 @@
+import { generateKeyPair, exportPKCS8, exportJWK, SignJWT, jwtVerify, createLocalJWKSet, importPKCS8 } from 'jose';
+
+const { privateKey } = await generateKeyPair('RS256', { extractable: true });
+const pkcs8 = await exportPKCS8(privateKey);
+const signingKey = await importPKCS8(pkcs8, 'RS256', { extractable: true });
+const jwk = await exportJWK(signingKey);
+delete jwk.d; delete jwk.p; delete jwk.q; delete jwk.dp; delete jwk.dq; delete jwk.qi;
+const publicJwk = { ...jwk, kid: 'mcp-1', alg: 'RS256', use: 'sig' };
+const token = await new SignJWT({ client_id: 'spike', scope: 'read write' })
+  .setProtectedHeader({ alg: 'RS256', kid: 'mcp-1' })
+  .setSubject('user123|mcp:grant456')
+  .setIssuer('http://localhost:3000')
+  .setAudience('fragrances-mcp')
+  .setIssuedAt()
+  .setExpirationTime('15m')
+  .sign(signingKey);
+const jwks = createLocalJWKSet({ keys: [publicJwk] });
+const { payload } = await jwtVerify(token, jwks, { issuer: 'http://localhost:3000', audience: 'fragrances-mcp' });
+console.log('VERIFIED', payload.sub, payload.client_id, payload.scope);

--- a/my-app/src/app/api/[transport]/route.ts
+++ b/my-app/src/app/api/[transport]/route.ts
@@ -1,0 +1,21 @@
+import { createMcpHandler } from 'mcp-handler';
+import { z } from 'zod';
+
+const handler = createMcpHandler(
+  (server) => {
+    server.registerTool(
+      'ping',
+      {
+        description: 'Health check. Echoes the message back.',
+        inputSchema: { message: z.string() },
+      },
+      async ({ message }) => ({
+        content: [{ type: 'text', text: `pong: ${message}` }],
+      }),
+    );
+  },
+  {},
+  { basePath: '/api', maxDuration: 60, verboseLogs: true },
+);
+
+export { handler as GET, handler as POST };

--- a/my-app/src/app/api/[transport]/route.ts
+++ b/my-app/src/app/api/[transport]/route.ts
@@ -1,5 +1,16 @@
-import { createMcpHandler } from 'mcp-handler';
+import { createMcpHandler, withMcpAuth } from 'mcp-handler';
 import { z } from 'zod';
+
+const verifyStub = async (_req: Request, bearer?: string) => {
+  if (bearer !== 'test-token') return undefined;
+
+  return {
+    token: bearer,
+    clientId: 'spike-client',
+    scopes: ['read', 'write'],
+    extra: { userId: 'spike-user', convexToken: 'spike-jwt' },
+  };
+};
 
 const handler = createMcpHandler(
   (server) => {
@@ -9,8 +20,16 @@ const handler = createMcpHandler(
         description: 'Health check. Echoes the message back.',
         inputSchema: { message: z.string() },
       },
-      async ({ message }) => ({
-        content: [{ type: 'text', text: `pong: ${message}` }],
+      async ({ message }, { authInfo }) => ({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              pong: message,
+              extra: authInfo?.extra ?? null,
+            }),
+          },
+        ],
       }),
     );
   },
@@ -18,4 +37,9 @@ const handler = createMcpHandler(
   { basePath: '/api', maxDuration: 60, verboseLogs: true },
 );
 
-export { handler as GET, handler as POST };
+const authed = withMcpAuth(handler, verifyStub, {
+  required: true,
+  resourceMetadataPath: '/.well-known/oauth-protected-resource',
+});
+
+export { authed as GET, authed as POST };


### PR DESCRIPTION
Sub-plan 1/5 of `docs/mcp-server-plan.md` (issue #65). Compatibility spike — pins the MCP dependency stack, verifies every `mcp-handler`/SDK/jose assumption against installed `node_modules` types (not web docs), and records the verified facts in a findings doc that sub-plans 2–4 reconcile against.

## Verified pins
`mcp-handler@1.1.0` · `@modelcontextprotocol/sdk@1.26.0` (exact peer) · `zod@^4` · `jose@6.2.3`

## Findings (`docs/superpowers/plans/2026-07-06-mcp-0-spike-findings.md`)
2 hard blockers caught before sub-plans 2–3:
- **C1 zod:** `zod@^3` (3.25.76) raises `TS2589` with sdk 1.26 `registerTool` → re-pinned `zod@^4` (4.3.6, allowed by sdk peer).
- **C6 jose:** `importPKCS8` returns a non-extractable key → `exportJWK` throws; needs `{ extractable: true }`.

Plus: **C2** use `registerTool` not deprecated `tool()`; **C3** sdk pinned exact 1.26.0; **C4** metadata helpers ship (less hand-rolling); **C5** `authInfo.extra` survives passthrough (WeakMap fallback dropped); **C7** responses SSE-framed; **C8** 401 `WWW-Authenticate` carries `resource_metadata=`.

## Proven end-to-end (curl vs `bun dev`)
- `/api/mcp` `tools/list` + `ping` call (walking skeleton)
- `withMcpAuth`: 401 discovery header → authed call → `extra` passthrough
- jose RS256 sign → local-JWKS verify (`scripts/spike-jose.mjs`)

## Payload
Dep pins (`package.json`/`bun.lock`), findings doc, epic + sub-plan 2–4 reconciliations. Scaffold `src/app/api/[transport]/route.ts` + `scripts/spike-jose.mjs` stay as reference (stub-token gated; sub-plans 2–3 rewrite them).

## Checks
`bun run typecheck && lint && test:run (164) && build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)