### PR TITLE
feat: OAuth consent page, sign-in redirect passthrough, connections settings

### DIFF
--- a/my-app/src/app/oauth/authorize/actions.ts
+++ b/my-app/src/app/oauth/authorize/actions.ts
@@ -1,0 +1,85 @@
+// src/app/oauth/authorize/actions.ts
+"use server";
+
+import { fetchMutation, fetchQuery } from "convex/nextjs";
+import { convexAuthNextjsToken } from "@convex-dev/auth/nextjs/server";
+import { redirect } from "next/navigation";
+import { api } from "../../../../convex/_generated/api";
+import { randomToken, sha256Hex } from "@/lib/mcp/tokens";
+import { matchesRegisteredRedirect } from "@/lib/mcp/oauth-validation";
+
+/** Builds redirect_uri?k=v... preserving existing query params on the URI. */
+export async function buildCallbackUrl(
+  redirectUri: string,
+  params: Record<string, string>,
+): Promise<string> {
+  const url = new URL(redirectUri);
+  for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value);
+  return url.toString();
+}
+
+type AuthorizeFields = {
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  state: string | null;
+  resource: string | null;
+};
+
+function readFields(formData: FormData): AuthorizeFields {
+  const get = (k: string) => {
+    const v = formData.get(k);
+    return typeof v === "string" && v.length > 0 ? v : null;
+  };
+  return {
+    clientId: get("client_id") ?? "",
+    redirectUri: get("redirect_uri") ?? "",
+    codeChallenge: get("code_challenge") ?? "",
+    state: get("state"),
+    resource: get("resource"),
+  };
+}
+
+export async function approveAuthorization(formData: FormData): Promise<void> {
+  const f = readFields(formData);
+  // Re-validate everything server-side; hidden form fields are attacker input.
+  const client = await fetchQuery(api.oauth.getClientPublic, { clientId: f.clientId });
+  if (!client || !matchesRegisteredRedirect(f.redirectUri, client.redirectUris) || !f.codeChallenge) {
+    throw new Error("Invalid authorization request.");
+  }
+
+  const code = randomToken();
+  await fetchMutation(
+    api.oauth.createAuthCode,
+    {
+      clientId: f.clientId,
+      redirectUri: f.redirectUri,
+      codeHash: await sha256Hex(code),
+      codeChallenge: f.codeChallenge,
+      scope: "read write",
+      ...(f.resource ? { resource: f.resource } : {}),
+    },
+    { token: await convexAuthNextjsToken() },
+  );
+
+  redirect(
+    await buildCallbackUrl(f.redirectUri, {
+      code,
+      ...(f.state !== null ? { state: f.state } : {}),
+    }),
+  );
+}
+
+export async function denyAuthorization(formData: FormData): Promise<void> {
+  const f = readFields(formData);
+  const client = await fetchQuery(api.oauth.getClientPublic, { clientId: f.clientId });
+  if (!client || !matchesRegisteredRedirect(f.redirectUri, client.redirectUris)) {
+    throw new Error("Invalid authorization request.");
+  }
+  redirect(
+    await buildCallbackUrl(f.redirectUri, {
+      error: "access_denied",
+      ...(f.state !== null ? { state: f.state } : {}),
+    }),
+  );
+}

--- a/my-app/src/app/oauth/authorize/page.tsx
+++ b/my-app/src/app/oauth/authorize/page.tsx
@@ -1,0 +1,115 @@
+// src/app/oauth/authorize/page.tsx
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { fetchQuery } from "convex/nextjs";
+import { convexAuthNextjsToken } from "@convex-dev/auth/nextjs/server";
+import { api } from "../../../../convex/_generated/api";
+import { matchesRegisteredRedirect } from "@/lib/mcp/oauth-validation";
+import { approveAuthorization, denyAuthorization } from "./actions";
+import { Button } from "@/components/ui/button";
+
+export const metadata: Metadata = {
+  title: "Authorize access",
+};
+
+function ErrorCard({ message }: { message: string }) {
+  return (
+    <main className="flex min-h-dvh items-center justify-center bg-bg px-5">
+      <div className="w-full max-w-[400px] rounded-2xl border border-border/40 bg-surface/80 p-8 text-center">
+        <p className="font-display text-xl text-text">Authorization error</p>
+        <p className="mt-3 text-sm leading-relaxed text-text-secondary">{message}</p>
+      </div>
+    </main>
+  );
+}
+
+export default async function AuthorizePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  const str = (key: string): string | null => {
+    const value = params[key];
+    return typeof value === "string" && value.length > 0 ? value : null;
+  };
+
+  // Rule 1: bad client or redirect_uri → render, NEVER redirect.
+  const clientId = str("client_id");
+  const redirectUri = str("redirect_uri");
+  const client = clientId
+    ? await fetchQuery(api.oauth.getClientPublic, { clientId })
+    : null;
+  if (!client) {
+    return <ErrorCard message="Unknown or missing client_id. The connecting app may need to re-register." />;
+  }
+  if (!redirectUri || !matchesRegisteredRedirect(redirectUri, client.redirectUris)) {
+    return <ErrorCard message="The redirect URI does not match this app's registration." />;
+  }
+
+  // Rule 2: other protocol errors → bounce back to the client with `state`.
+  const bounce = (error: string, description: string): never => {
+    const url = new URL(redirectUri);
+    url.searchParams.set("error", error);
+    url.searchParams.set("error_description", description);
+    const state = str("state");
+    if (state !== null) url.searchParams.set("state", state);
+    redirect(url.toString());
+  };
+  if (str("response_type") !== "code") {
+    bounce("unsupported_response_type", "Only response_type=code is supported.");
+  }
+  const codeChallenge = str("code_challenge");
+  if (!codeChallenge || str("code_challenge_method") !== "S256") {
+    bounce("invalid_request", "PKCE with code_challenge_method=S256 is required.");
+  }
+
+  // Middleware guarantees an authenticated session here.
+  const user = await fetchQuery(api.users.currentUser, {}, { token: await convexAuthNextjsToken() });
+
+  const hidden = (
+    <>
+      <input type="hidden" name="client_id" value={clientId!} />
+      <input type="hidden" name="redirect_uri" value={redirectUri} />
+      <input type="hidden" name="code_challenge" value={codeChallenge!} />
+      {str("state") !== null && <input type="hidden" name="state" value={str("state")!} />}
+      {str("resource") !== null && <input type="hidden" name="resource" value={str("resource")!} />}
+    </>
+  );
+
+  return (
+    <main className="flex min-h-dvh items-center justify-center bg-bg px-5">
+      <div className="w-full max-w-[400px] rounded-2xl border border-border/40 bg-surface/80 p-8">
+        <p className="font-display text-xl tracking-tight text-text">
+          Connect {client.clientName}
+        </p>
+        <p className="mt-2 text-sm leading-relaxed text-text-secondary">
+          <span className="font-medium text-text">{client.clientName}</span> wants to read and
+          update the fragrance collection and wear history of{" "}
+          <span className="font-medium text-text">{user?.email ?? "your account"}</span>.
+        </p>
+        <ul className="mt-4 list-disc pl-5 text-sm text-text-secondary">
+          <li>View bottles, wear logs, and collection stats</li>
+          <li>Add, edit, and delete bottles and wear logs</li>
+        </ul>
+        <div className="mt-6 flex gap-3">
+          <form action={denyAuthorization} className="flex-1">
+            {hidden}
+            <Button type="submit" variant="outline" className="w-full">
+              Deny
+            </Button>
+          </form>
+          <form action={approveAuthorization} className="flex-1">
+            {hidden}
+            <Button type="submit" className="w-full">
+              Approve
+            </Button>
+          </form>
+        </div>
+        <p className="mt-4 text-xs text-text-secondary/70">
+          You can revoke access anytime in Settings → Connections.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/my-app/src/app/settings/connections/page.tsx
+++ b/my-app/src/app/settings/connections/page.tsx
@@ -1,0 +1,35 @@
+// src/app/settings/connections/page.tsx
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { ConnectedApps } from "@/components/connected-apps";
+import { PatManager } from "@/components/pat-manager";
+import { Button } from "@/components/ui/button";
+
+export const metadata: Metadata = {
+  title: "Connections",
+};
+
+export default function ConnectionsPage() {
+  return (
+    <main className="min-h-dvh bg-bg">
+      <div className="mx-auto w-full max-w-2xl px-5 py-8">
+        <div className="flex items-center gap-3">
+          <Button asChild variant="ghost" size="sm" aria-label="Back to collection">
+            <Link href="/">
+              <ArrowLeft className="h-4 w-4" />
+            </Link>
+          </Button>
+          <h1 className="font-display text-2xl tracking-tight text-text">Connections</h1>
+        </div>
+        <p className="mt-2 text-sm text-text-secondary">
+          Manage AI agents and API tokens that can access your collection via MCP.
+        </p>
+        <div className="mt-8 space-y-10">
+          <ConnectedApps />
+          <PatManager />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/my-app/src/app/signin/page.tsx
+++ b/my-app/src/app/signin/page.tsx
@@ -2,15 +2,24 @@ import { isAuthenticatedNextjs } from "@convex-dev/auth/nextjs/server";
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { SignInScreen } from "@/components/sign-in-screen";
+import { isSafeInternalPath } from "@/lib/mcp/oauth-validation";
 
 export const metadata: Metadata = {
   title: "Sign In",
 };
 
-export default async function SignInPage() {
+export default async function SignInPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ redirect?: string }>;
+}) {
+  const { redirect: redirectParam } = await searchParams;
+  const target =
+    redirectParam && isSafeInternalPath(redirectParam) ? redirectParam : "/";
+
   if (await isAuthenticatedNextjs()) {
-    redirect("/");
+    redirect(target);
   }
 
-  return <SignInScreen />;
+  return <SignInScreen redirectTo={target} />;
 }

--- a/my-app/src/components/connected-apps.test.tsx
+++ b/my-app/src/components/connected-apps.test.tsx
@@ -1,0 +1,46 @@
+// src/components/connected-apps.test.tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { ConnectedApps } from "./connected-apps";
+
+const mockUseQuery = vi.fn();
+const mockRevoke = vi.fn();
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useMutation: () => mockRevoke,
+}));
+
+const GRANT = {
+  _id: "grant1",
+  clientName: "Claude",
+  scope: "read write",
+  createdAt: Date.UTC(2026, 0, 5, 12),
+  lastUsedAt: undefined,
+};
+
+describe("ConnectedApps", () => {
+  beforeEach(() => {
+    mockUseQuery.mockReset();
+    mockRevoke.mockReset().mockResolvedValue(null);
+  });
+
+  test("shows an empty state when there are no grants", () => {
+    mockUseQuery.mockReturnValue([]);
+    render(<ConnectedApps />);
+    expect(screen.getByText(/no connected apps/i)).toBeInTheDocument();
+  });
+
+  test("lists grants and revokes on double-click confirm", async () => {
+    mockUseQuery.mockReturnValue([GRANT]);
+    const user = userEvent.setup();
+    render(<ConnectedApps />);
+    expect(screen.getByText("Claude")).toBeInTheDocument();
+
+    const button = screen.getByRole("button", { name: /revoke claude/i });
+    await user.click(button); // arm
+    expect(mockRevoke).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: /confirm revoke/i })); // confirm
+    expect(mockRevoke).toHaveBeenCalledWith({ grantId: "grant1" });
+  });
+});

--- a/my-app/src/components/connected-apps.tsx
+++ b/my-app/src/components/connected-apps.tsx
@@ -1,0 +1,69 @@
+// src/components/connected-apps.tsx
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { toast } from "sonner";
+import { api } from "../../convex/_generated/api";
+import { Id } from "../../convex/_generated/dataModel";
+import { ConfirmDeleteButton } from "@/components/confirm-delete-button";
+import { formatWearDate } from "@/lib/format";
+
+export function ConnectedApps() {
+  const grants = useQuery(api.oauth.listGrants);
+  const revokeGrant = useMutation(api.oauth.revokeGrant);
+  const [confirmingId, setConfirmingId] = useState<Id<"oauthGrants"> | null>(null);
+
+  const handleRevoke = async (grantId: Id<"oauthGrants">, clientName: string) => {
+    if (confirmingId !== grantId) {
+      setConfirmingId(grantId);
+      return;
+    }
+    setConfirmingId(null);
+    try {
+      await revokeGrant({ grantId });
+      toast.success(`Disconnected ${clientName}.`);
+    } catch {
+      toast.error("Could not revoke access. Please try again.");
+    }
+  };
+
+  return (
+    <section>
+      <h2 className="font-display text-lg text-text">Connected apps</h2>
+      <p className="mt-1 text-sm text-text-secondary">
+        AI agents you have granted access to via OAuth. Revoking stops new requests within 15
+        minutes (until their current token expires).
+      </p>
+      {grants === undefined ? (
+        <p className="mt-4 text-sm text-text-secondary">Loading…</p>
+      ) : grants.length === 0 ? (
+        <p className="mt-4 rounded-lg border border-border/40 bg-surface/60 px-4 py-3 text-sm text-text-secondary">
+          No connected apps yet.
+        </p>
+      ) : (
+        <ul className="mt-4 divide-y divide-border/40 rounded-lg border border-border/40 bg-surface/60">
+          {grants.map((grant) => (
+            <li key={grant._id} className="flex items-center justify-between gap-3 px-4 py-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-text">{grant.clientName}</p>
+                <p className="text-xs text-text-secondary">
+                  Connected {formatWearDate(grant.createdAt)}
+                  {grant.lastUsedAt ? ` · Last used ${formatWearDate(grant.lastUsedAt)}` : ""}
+                </p>
+              </div>
+              <ConfirmDeleteButton
+                confirming={confirmingId === grant._id}
+                onClick={() => void handleRevoke(grant._id, grant.clientName)}
+                onMouseLeave={() => setConfirmingId(null)}
+                idleLabel={`Revoke ${grant.clientName}`}
+                confirmLabel="Confirm revoke"
+                size="compact"
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/my-app/src/components/home-page.tsx
+++ b/my-app/src/components/home-page.tsx
@@ -3,6 +3,7 @@
 import { useAuthActions } from "@convex-dev/auth/react";
 import { useState, useCallback, useEffect } from "react";
 import { useQuery } from "convex/react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { api } from "../../convex/_generated/api";
 import { Id, Doc } from "../../convex/_generated/dataModel";
@@ -13,7 +14,7 @@ import { AddBottleDialog } from "@/components/add-bottle-dialog";
 import { AddWearLogDialog } from "@/components/add-wear-log-dialog";
 import { Button } from "@/components/ui/button";
 import { useOnboarding, ONBOARDING_SETTLE_MS } from "@/lib/use-onboarding";
-import { LoaderCircle, LogOut, Wine } from "lucide-react";
+import { LoaderCircle, LogOut, Settings, Wine } from "lucide-react";
 
 export function HomePage() {
   const router = useRouter();
@@ -114,6 +115,11 @@ export function HomePage() {
         </div>
 
         <div className="flex items-center gap-2">
+          <Button asChild variant="ghost" size="sm" aria-label="Connections settings">
+            <Link href="/settings/connections">
+              <Settings className="h-4 w-4" />
+            </Link>
+          </Button>
           <ThemeToggle />
           <Button
             variant="outline"

--- a/my-app/src/components/pat-manager.test.tsx
+++ b/my-app/src/components/pat-manager.test.tsx
@@ -1,0 +1,43 @@
+// src/components/pat-manager.test.tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { getFunctionName } from "convex/server";
+import { PatManager } from "./pat-manager";
+import { PAT_PREFIX, sha256Hex } from "@/lib/mcp/tokens";
+
+const mockUseQuery = vi.fn();
+const mockCreate = vi.fn();
+const mockRevoke = vi.fn();
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useMutation: (ref: never) => (getFunctionName(ref) === "apiTokens:revoke" ? mockRevoke : mockCreate),
+}));
+
+describe("PatManager", () => {
+  beforeEach(() => {
+    mockUseQuery.mockReset().mockReturnValue([]);
+    mockCreate.mockReset().mockResolvedValue("tok1");
+    mockRevoke.mockReset().mockResolvedValue(null);
+  });
+
+  test("creating a token sends only the hash and shows the raw value once", async () => {
+    const user = userEvent.setup();
+    render(<PatManager />);
+
+    await user.click(screen.getByRole("button", { name: /create token/i }));
+    await user.type(screen.getByLabelText(/token name/i), "Claude Code");
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    // Raw token displayed once, fgt_-prefixed.
+    const rawEl = await screen.findByTestId("raw-token");
+    const raw = rawEl.textContent!;
+    expect(raw.startsWith(PAT_PREFIX)).toBe(true);
+
+    // The mutation received the SHA-256 of exactly that raw value — never the raw.
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const args = mockCreate.mock.calls[0][0] as { tokenHash: string; name: string };
+    expect(args.name).toBe("Claude Code");
+    expect(args.tokenHash).toBe(await sha256Hex(raw));
+  });
+});

--- a/my-app/src/components/pat-manager.tsx
+++ b/my-app/src/components/pat-manager.tsx
@@ -1,0 +1,173 @@
+// src/components/pat-manager.tsx
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { Copy, Plus } from "lucide-react";
+import { toast } from "sonner";
+import { api } from "../../convex/_generated/api";
+import { Id } from "../../convex/_generated/dataModel";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { ConfirmDeleteButton } from "@/components/confirm-delete-button";
+import { formatWearDate } from "@/lib/format";
+import { PAT_PREFIX, randomToken, sha256Hex } from "@/lib/mcp/tokens";
+
+export function PatManager() {
+  const tokens = useQuery(api.apiTokens.list);
+  const createToken = useMutation(api.apiTokens.create);
+  const revokeToken = useMutation(api.apiTokens.revoke);
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [rawToken, setRawToken] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [confirmingId, setConfirmingId] = useState<Id<"personalAccessTokens"> | null>(null);
+
+  const handleCreate = async () => {
+    if (name.trim().length === 0) return;
+    setIsCreating(true);
+    try {
+      // Raw token never leaves the browser; Convex stores only the hash.
+      const raw = PAT_PREFIX + randomToken();
+      await createToken({ tokenHash: await sha256Hex(raw), name: name.trim() });
+      setRawToken(raw);
+    } catch {
+      toast.error("Could not create the token. Please try again.");
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const closeDialog = (open: boolean) => {
+    setDialogOpen(open);
+    if (!open) {
+      setName("");
+      setRawToken(null);
+    }
+  };
+
+  const handleRevoke = async (tokenId: Id<"personalAccessTokens">) => {
+    if (confirmingId !== tokenId) {
+      setConfirmingId(tokenId);
+      return;
+    }
+    setConfirmingId(null);
+    try {
+      await revokeToken({ tokenId });
+      toast.success("Token revoked.");
+    } catch {
+      toast.error("Could not revoke the token. Please try again.");
+    }
+  };
+
+  return (
+    <section>
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="font-display text-lg text-text">API tokens</h2>
+          <p className="mt-1 text-sm text-text-secondary">
+            Personal access tokens for CLI clients (Claude Code, curl). Sent as{" "}
+            <code className="text-xs">Authorization: Bearer fgt_…</code>
+          </p>
+        </div>
+        <Dialog open={dialogOpen} onOpenChange={closeDialog}>
+          <DialogTrigger asChild>
+            <Button size="sm" className="gap-2 shrink-0">
+              <Plus className="h-4 w-4" /> Create token
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            {rawToken === null ? (
+              <>
+                <DialogHeader>
+                  <DialogTitle>Create API token</DialogTitle>
+                  <DialogDescription>
+                    Name it after the client that will use it.
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-2">
+                  <Label htmlFor="pat-name">Token name</Label>
+                  <Input
+                    id="pat-name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    maxLength={100}
+                    placeholder="e.g. Claude Code on laptop"
+                  />
+                </div>
+                <Button onClick={() => void handleCreate()} disabled={isCreating || name.trim() === ""}>
+                  Create
+                </Button>
+              </>
+            ) : (
+              <>
+                <DialogHeader>
+                  <DialogTitle>Copy your token now</DialogTitle>
+                  <DialogDescription>
+                    This is the only time it will be shown. Store it like a password.
+                  </DialogDescription>
+                </DialogHeader>
+                <code
+                  data-testid="raw-token"
+                  className="block break-all rounded-lg border border-border/40 bg-surface-alt px-3 py-2 text-xs"
+                >
+                  {rawToken}
+                </code>
+                <Button
+                  variant="outline"
+                  className="gap-2"
+                  onClick={() => {
+                    void navigator.clipboard.writeText(rawToken);
+                    toast.success("Copied to clipboard.");
+                  }}
+                >
+                  <Copy className="h-4 w-4" /> Copy
+                </Button>
+              </>
+            )}
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {tokens === undefined ? (
+        <p className="mt-4 text-sm text-text-secondary">Loading…</p>
+      ) : tokens.length === 0 ? (
+        <p className="mt-4 rounded-lg border border-border/40 bg-surface/60 px-4 py-3 text-sm text-text-secondary">
+          No API tokens yet.
+        </p>
+      ) : (
+        <ul className="mt-4 divide-y divide-border/40 rounded-lg border border-border/40 bg-surface/60">
+          {tokens.map((token) => (
+            <li key={token._id} className="flex items-center justify-between gap-3 px-4 py-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-text">{token.name}</p>
+                <p className="text-xs text-text-secondary">
+                  Created {formatWearDate(token.createdAt)}
+                  {token.lastUsedAt ? ` · Last used ${formatWearDate(token.lastUsedAt)}` : " · Never used"}
+                </p>
+              </div>
+              <ConfirmDeleteButton
+                confirming={confirmingId === token._id}
+                onClick={() => void handleRevoke(token._id)}
+                onMouseLeave={() => setConfirmingId(null)}
+                idleLabel={`Revoke ${token.name}`}
+                confirmLabel="Confirm revoke"
+                size="compact"
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/my-app/src/components/sign-in-screen.tsx
+++ b/my-app/src/components/sign-in-screen.tsx
@@ -7,7 +7,7 @@ import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
 import { LoaderCircle } from "lucide-react";
 
-export function SignInScreen() {
+export function SignInScreen({ redirectTo = "/" }: { redirectTo?: string }) {
   const { signIn } = useAuthActions();
   const [isSigningIn, setIsSigningIn] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -17,7 +17,7 @@ export function SignInScreen() {
     setErrorMessage(null);
 
     try {
-      await signIn("google", { redirectTo: "/" });
+      await signIn("google", { redirectTo });
     } catch (error) {
       // Show a generic message instead of the raw error to avoid leaking
       // internal details (stack traces, library internals) to the user.

--- a/my-app/src/proxy.ts
+++ b/my-app/src/proxy.ts
@@ -3,20 +3,30 @@ import {
   createRouteMatcher,
   nextjsMiddlewareRedirect,
 } from "@convex-dev/auth/nextjs/server";
+import { isSafeInternalPath } from "@/lib/mcp/oauth-validation";
 
 const isSignInPage = createRouteMatcher(["/signin"]);
-const isProtectedRoute = createRouteMatcher(["/"]);
+const isProtectedRoute = createRouteMatcher(["/", "/oauth/authorize", "/settings(.*)"]);
 
 export default convexAuthNextjsMiddleware(
   async (request, { convexAuth }) => {
     const isAuthenticated = await convexAuth.isAuthenticated();
 
     if (isSignInPage(request) && isAuthenticated) {
-      return nextjsMiddlewareRedirect(request, "/");
+      const target = request.nextUrl.searchParams.get("redirect");
+      return nextjsMiddlewareRedirect(
+        request,
+        target && isSafeInternalPath(target) ? target : "/",
+      );
     }
 
     if (isProtectedRoute(request) && !isAuthenticated) {
-      return nextjsMiddlewareRedirect(request, "/signin");
+      const { pathname, search } = request.nextUrl;
+      // Preserve where the user was headed (e.g. an OAuth authorize URL with
+      // its full query) so sign-in can bounce them back.
+      const suffix =
+        pathname === "/" ? "" : `?redirect=${encodeURIComponent(`${pathname}${search}`)}`;
+      return nextjsMiddlewareRedirect(request, `/signin${suffix}`);
     }
   },
   {


### PR DESCRIPTION
Sub-plan 4/5 of `docs/mcp-server-plan.md` (issue #65). Targets `epic/mcp`. Completes the OAuth code→token happy path (human surfaces).

## What
- **Sign-in `?redirect=` passthrough:** middleware now protects `/`, `/oauth/authorize`, `/settings(.*)`; unauthenticated hits bounce to `/signin?redirect=<safe path+query>` and back after Google sign-in. Unsafe values fall back to `/` (`isSafeInternalPath`).
- **`/oauth/authorize` consent page** (server component, no client JS): locked RFC 6749 §4.1.2.1 semantics — unknown client / bad `redirect_uri` **render an error card (never redirect)**; other protocol errors **302 back to `redirect_uri`** with `error`+`state`. Approve mints the code in Next, stores only its hash via an authed mutation, 302s with `code`+`state`; deny → `error=access_denied`.
- **`/settings/connections`** (first settings route): `<ConnectedApps />` (grant list + two-click revoke) and `<PatManager />` (create-with-copy-once, **raw token never leaves the browser — only its SHA-256 hash is sent**). Header gains a gear link.

## Verified
- `typecheck + lint + test:run (227, +3 TDD) + build` all green.
- Live curl: unauthed `/settings/connections` → `/signin?redirect=%2Fsettings%2Fconnections`; unauthed `/oauth/authorize?...&state=xyz` → `/signin?redirect=<full path+query preserved>`; `/` → `/signin` (no param).
- PAT test asserts the mutation receives `sha256Hex(raw)`, never the raw token.

## Notes
- The interactive approve→code→token happy path needs a signed-in browser session — covered by sub-plan 5's end-to-end (and blocked locally only by the same JWKS-reachability caveat once the token is *used*, which sub-plan 5 fixes).
- Task 4's plan-provided `useMutation` mock (`String(ref)`) was brittle; used the plan-allowed adjustment (`getFunctionName(ref)`). Security assertion unchanged.
- Scope fixed to `read write` on consent (epic §10 v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)