### PR TITLE
chore: harden MCP OAuth (RS256 pin + cleanup cron)

### DIFF
--- a/my-app/convex/_generated/api.d.ts
+++ b/my-app/convex/_generated/api.d.ts
@@ -11,6 +11,8 @@
 import type * as apiTokens from "../apiTokens.js";
 import type * as auth from "../auth.js";
 import type * as bottles from "../bottles.js";
+import type * as cleanup from "../cleanup.js";
+import type * as crons from "../crons.js";
 import type * as devSeed from "../devSeed.js";
 import type * as helpers from "../helpers.js";
 import type * as http from "../http.js";
@@ -31,6 +33,8 @@ declare const fullApi: ApiFromModules<{
   apiTokens: typeof apiTokens;
   auth: typeof auth;
   bottles: typeof bottles;
+  cleanup: typeof cleanup;
+  crons: typeof crons;
   devSeed: typeof devSeed;
   helpers: typeof helpers;
   http: typeof http;

--- a/my-app/convex/cleanup.test.ts
+++ b/my-app/convex/cleanup.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { internal } from "./_generated/api";
+import { setupTest } from "./test.setup";
+
+type T = ReturnType<typeof setupTest>;
+
+const NOW = Date.now();
+const PAST = NOW - 60_000;
+const FUTURE = NOW + 60 * 60_000;
+
+describe("cleanup.purgeExpired", () => {
+  let t: T;
+  beforeEach(() => {
+    t = setupTest();
+  });
+
+  test("purges expired codes, expired refresh tokens, and expired/revoked PATs; keeps fresh rows and revoked-but-unexpired refresh tokens", async () => {
+    await t.run(async (ctx) => {
+      const userId = await ctx.db.insert("users", { name: "u" });
+      const grantId = await ctx.db.insert("oauthGrants", {
+        userId,
+        clientId: "c",
+        clientName: "C",
+        scope: "read write",
+        createdAt: NOW,
+      });
+      const code = (extra: { codeHash: string; expiresAt: number }) =>
+        ctx.db.insert("oauthAuthCodes", {
+          clientId: "c",
+          userId,
+          redirectUri: "https://a.example/cb",
+          codeChallenge: "x",
+          scope: "read write",
+          ...extra,
+        });
+      await code({ codeHash: "code-expired", expiresAt: PAST });
+      await code({ codeHash: "code-fresh", expiresAt: FUTURE });
+
+      const rt = (extra: { tokenHash: string; expiresAt: number; revokedAt?: number }) =>
+        ctx.db.insert("oauthRefreshTokens", { grantId, userId, clientId: "c", ...extra });
+      await rt({ tokenHash: "rt-expired", expiresAt: PAST });
+      // Revoked but not yet expired: must be KEPT so rotation reuse-detection
+      // can still revoke the whole grant if the stolen token is presented.
+      await rt({ tokenHash: "rt-revoked-unexpired", expiresAt: FUTURE, revokedAt: NOW });
+      await rt({ tokenHash: "rt-fresh", expiresAt: FUTURE });
+
+      const pat = (extra: { tokenHash: string; expiresAt?: number; revokedAt?: number }) =>
+        ctx.db.insert("personalAccessTokens", {
+          userId,
+          name: "p",
+          scopes: ["read", "write"],
+          createdAt: NOW,
+          ...extra,
+        });
+      await pat({ tokenHash: "pat-expired", expiresAt: PAST });
+      await pat({ tokenHash: "pat-revoked", revokedAt: NOW });
+      await pat({ tokenHash: "pat-active" });
+    });
+
+    await t.mutation(internal.cleanup.purgeExpired, {});
+
+    await t.run(async (ctx) => {
+      const codes = (await ctx.db.query("oauthAuthCodes").collect()).map((c) => c.codeHash);
+      expect(codes).toEqual(["code-fresh"]);
+
+      const rts = (await ctx.db.query("oauthRefreshTokens").collect())
+        .map((r) => r.tokenHash)
+        .sort();
+      expect(rts).toEqual(["rt-fresh", "rt-revoked-unexpired"]);
+
+      const pats = (await ctx.db.query("personalAccessTokens").collect()).map((p) => p.tokenHash);
+      expect(pats).toEqual(["pat-active"]);
+    });
+  });
+});

--- a/my-app/convex/cleanup.ts
+++ b/my-app/convex/cleanup.ts
@@ -1,0 +1,42 @@
+// convex/cleanup.ts
+// Scheduled housekeeping for the MCP OAuth tables so expired/dead rows don't
+// grow unbounded. Runs daily via convex/crons.ts. Nothing here weakens the
+// security model — every purged row is already unusable:
+//   - expired auth codes are rejected on exchange anyway;
+//   - refresh tokens are only removed AFTER their 90-day expiry (revoked but
+//     still-unexpired tokens are KEPT so rotation reuse-detection can still fire
+//     on a stolen token and revoke the whole grant);
+//   - PATs that are expired or revoked already validate to null.
+import { internalMutation } from "./_generated/server";
+
+export const purgeExpired = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    let deleted = 0;
+
+    for (const code of await ctx.db.query("oauthAuthCodes").collect()) {
+      if (code.expiresAt < now) {
+        await ctx.db.delete(code._id);
+        deleted++;
+      }
+    }
+
+    for (const token of await ctx.db.query("oauthRefreshTokens").collect()) {
+      // Only past-expiry: keep revoked-but-unexpired tokens for reuse-detection.
+      if (token.expiresAt < now) {
+        await ctx.db.delete(token._id);
+        deleted++;
+      }
+    }
+
+    for (const pat of await ctx.db.query("personalAccessTokens").collect()) {
+      if (pat.revokedAt !== undefined || (pat.expiresAt !== undefined && pat.expiresAt < now)) {
+        await ctx.db.delete(pat._id);
+        deleted++;
+      }
+    }
+
+    return { deleted };
+  },
+});

--- a/my-app/convex/crons.ts
+++ b/my-app/convex/crons.ts
@@ -1,0 +1,14 @@
+// convex/crons.ts
+// Daily purge of expired MCP OAuth rows (see convex/cleanup.ts).
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+crons.daily(
+  "purge expired oauth codes, refresh tokens, and PATs",
+  { hourUTC: 9, minuteUTC: 0 },
+  internal.cleanup.purgeExpired,
+);
+
+export default crons;

--- a/my-app/src/lib/mcp/verify-token.ts
+++ b/my-app/src/lib/mcp/verify-token.ts
@@ -68,6 +68,9 @@ export function createMcpTokenVerifier(deps: VerifierDeps = {}) {
       const { payload } = await jwtVerify(bearer, jwks, {
         issuer: deps.issuer ?? process.env.NEXT_PUBLIC_APP_URL,
         audience: MCP_JWT_AUDIENCE,
+        // Pin the algorithm: our tokens are always RS256. Defense-in-depth
+        // against alg-confusion (jose already refuses HS*/none for an RSA key).
+        algorithms: ["RS256"],
       });
       const [userId] = (payload.sub as string).split("|");
       return {


### PR DESCRIPTION
Post-review hardening from the epic/mcp security pass. Targets `epic/mcp`.

- **L1 — pin `algorithms: ["RS256"]`** in the OAuth-JWT branch of `verify-token.ts`. jose already refuses HS*/`none` for an RSA key; this is explicit defense-in-depth against alg-confusion.
- **L2 — `convex/crons.ts` daily cleanup** (`convex/cleanup.ts` `purgeExpired`): deletes expired auth codes, past-90-day-expiry refresh tokens, and expired/revoked PATs so the OAuth tables don't grow unbounded. **Revoked-but-unexpired refresh tokens are deliberately KEPT** so rotation reuse-detection can still revoke the whole grant if a stolen token is presented — the test asserts exactly this invariant.

Gate: `typecheck + lint + test:run (+1 cleanup test) + build` green. Cleanup mutation is `internalMutation` (not client-reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)