### PR TITLE
fix: make MCP signing kid configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ cd my-app && bun scripts/generate-mcp-keypair.mjs
 
 | Var | Where | Value |
 |---|---|---|
+| `MCP_JWT_KID` | Vercel + `.env.local` | Key ID passed to the generator; must identify `MCP_JWT_PRIVATE_KEY` |
 | `MCP_JWT_PRIVATE_KEY` | Vercel + `.env.local` | PKCS8 PEM from the generator script |
 | `NEXT_PUBLIC_APP_URL` | Vercel + `.env.local` | App origin; doubles as the JWT issuer |
 | `MCP_EXTRA_PUBLIC_JWKS` | Vercel (optional) | JSON array of extra public JWKs (dev-key strategy below) |
@@ -197,7 +198,8 @@ get a fresh random hostname each run, so re-set these env vars per session.
 1. Generate a new keypair with a **new `kid`**.
 2. Serve **both** public keys via `MCP_EXTRA_PUBLIC_JWKS` so tokens signed by the old key still
    verify (access tokens live ≤15 min, PAT bridge tokens ≤5 min).
-3. Switch `MCP_JWT_PRIVATE_KEY` to the new private key.
+3. Atomically switch `MCP_JWT_PRIVATE_KEY` and `MCP_JWT_KID` to the new pair. New tokens use the
+   new `kid`; already-issued tokens continue matching the old public JWK.
 4. After 24 h — well past every old token's expiry — drop the old public key from
    `MCP_EXTRA_PUBLIC_JWKS`.
 

--- a/my-app/scripts/generate-mcp-keypair.mjs
+++ b/my-app/scripts/generate-mcp-keypair.mjs
@@ -9,6 +9,8 @@ const pkcs8 = await exportPKCS8(privateKey);
 const jwk = await exportJWK(privateKey);
 for (const f of ["d", "p", "q", "dp", "dq", "qi"]) delete jwk[f];
 
+console.log("── MCP_JWT_KID (set beside the private key) ──");
+console.log(kid);
 console.log("── MCP_JWT_PRIVATE_KEY (set in Vercel / .env.local) ──");
 console.log(pkcs8);
 console.log("── Public JWK (informational; served by /api/oauth/jwks) ──");

--- a/my-app/src/lib/mcp/tokens.test.ts
+++ b/my-app/src/lib/mcp/tokens.test.ts
@@ -1,5 +1,5 @@
 // src/lib/mcp/tokens.test.ts
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { exportPKCS8, generateKeyPair, jwtVerify, createLocalJWKSet } from "jose";
 import {
   sha256Hex,
@@ -12,6 +12,9 @@ import {
 } from "./tokens";
 
 const ISSUER = "https://example.test";
+const TEST_KID = "mcp-test-1";
+
+afterEach(() => vi.unstubAllEnvs());
 
 async function testPem(): Promise<string> {
   const { privateKey } = await generateKeyPair("RS256", { extractable: true });
@@ -48,13 +51,15 @@ describe("mintAccessToken", () => {
       scope: "read write",
       privateKeyPem: pem,
       issuer: ISSUER,
+      kid: TEST_KID,
     });
-    const jwks = createLocalJWKSet(await getPublicJwks(pem));
+    const jwks = createLocalJWKSet(await getPublicJwks(pem, TEST_KID));
     const { payload, protectedHeader } = await jwtVerify(token, jwks, {
       issuer: ISSUER,
       audience: MCP_JWT_AUDIENCE,
     });
     expect(protectedHeader.alg).toBe("RS256");
+    expect(protectedHeader.kid).toBe(TEST_KID);
     expect(payload.sub).toBe("user123|mcp:grant456");
     expect(payload.client_id).toBe("client789");
     expect(payload.scope).toBe("read write");
@@ -72,8 +77,9 @@ describe("mintAccessToken", () => {
       scope: "read write",
       privateKeyPem: pemA,
       issuer: ISSUER,
+      kid: TEST_KID,
     });
-    const jwksB = createLocalJWKSet(await getPublicJwks(pemB));
+    const jwksB = createLocalJWKSet(await getPublicJwks(pemB, TEST_KID));
     await expect(
       jwtVerify(token, jwksB, { issuer: ISSUER, audience: MCP_JWT_AUDIENCE }),
     ).rejects.toThrow();
@@ -88,8 +94,9 @@ describe("mintPatBridgeToken", () => {
       tokenId: "tok789",
       privateKeyPem: pem,
       issuer: ISSUER,
+      kid: TEST_KID,
     });
-    const jwks = createLocalJWKSet(await getPublicJwks(pem));
+    const jwks = createLocalJWKSet(await getPublicJwks(pem, TEST_KID));
     const { payload } = await jwtVerify(token, jwks, { issuer: ISSUER, audience: MCP_JWT_AUDIENCE });
     expect(payload.sub).toBe("user123|pat:tok789");
     expect((payload.exp as number) - (payload.iat as number)).toBe(300);
@@ -98,12 +105,33 @@ describe("mintPatBridgeToken", () => {
 
 describe("getPublicJwks", () => {
   test("contains no private-key fields and carries kid/alg/use", async () => {
-    const { keys } = await getPublicJwks(await testPem());
+    const { keys } = await getPublicJwks(await testPem(), TEST_KID);
     expect(keys).toHaveLength(1);
     const k = keys[0] as Record<string, unknown>;
     for (const f of ["d", "p", "q", "dp", "dq", "qi"]) expect(k[f]).toBeUndefined();
-    expect(k.kid).toBe("mcp-1");
+    expect(k.kid).toBe(TEST_KID);
     expect(k.alg).toBe("RS256");
     expect(k.use).toBe("sig");
+  });
+
+  test("uses MCP_JWT_KID for both minted tokens and the primary JWK", async () => {
+    vi.stubEnv("MCP_JWT_KID", "mcp-stage-1");
+    const pem = await testPem();
+    const token = await mintAccessToken({
+      userId: "user123",
+      grantId: "grant456",
+      clientId: "client789",
+      scope: "read write",
+      privateKeyPem: pem,
+      issuer: ISSUER,
+    });
+    const { keys } = await getPublicJwks(pem);
+    const { protectedHeader } = await jwtVerify(token, createLocalJWKSet({ keys }), {
+      issuer: ISSUER,
+      audience: MCP_JWT_AUDIENCE,
+    });
+
+    expect(protectedHeader.kid).toBe("mcp-stage-1");
+    expect((keys[0] as Record<string, unknown>).kid).toBe("mcp-stage-1");
   });
 });

--- a/my-app/src/lib/mcp/tokens.test.ts
+++ b/my-app/src/lib/mcp/tokens.test.ts
@@ -134,4 +134,42 @@ describe("getPublicJwks", () => {
     expect(protectedHeader.kid).toBe("mcp-stage-1");
     expect((keys[0] as Record<string, unknown>).kid).toBe("mcp-stage-1");
   });
+
+  test("verifies old and new unexpired tokens during key rotation overlap", async () => {
+    const oldPem = await testPem();
+    const newPem = await testPem();
+    const oldToken = await mintAccessToken({
+      userId: "user123",
+      grantId: "old-grant",
+      clientId: "client789",
+      scope: "read write",
+      privateKeyPem: oldPem,
+      issuer: ISSUER,
+      kid: "mcp-old-1",
+    });
+    const newToken = await mintAccessToken({
+      userId: "user123",
+      grantId: "new-grant",
+      clientId: "client789",
+      scope: "read write",
+      privateKeyPem: newPem,
+      issuer: ISSUER,
+      kid: "mcp-new-1",
+    });
+    const oldJwk = (await getPublicJwks(oldPem, "mcp-old-1")).keys[0];
+    vi.stubEnv("MCP_EXTRA_PUBLIC_JWKS", JSON.stringify([oldJwk]));
+    const jwks = createLocalJWKSet(await getPublicJwks(newPem, "mcp-new-1"));
+
+    const oldResult = await jwtVerify(oldToken, jwks, {
+      issuer: ISSUER,
+      audience: MCP_JWT_AUDIENCE,
+    });
+    const newResult = await jwtVerify(newToken, jwks, {
+      issuer: ISSUER,
+      audience: MCP_JWT_AUDIENCE,
+    });
+
+    expect(oldResult.protectedHeader.kid).toBe("mcp-old-1");
+    expect(newResult.protectedHeader.kid).toBe("mcp-new-1");
+  });
 });

--- a/my-app/src/lib/mcp/tokens.ts
+++ b/my-app/src/lib/mcp/tokens.ts
@@ -6,7 +6,6 @@
 import { SignJWT, importPKCS8, exportJWK } from "jose";
 
 export const MCP_JWT_AUDIENCE = "fragrances-mcp";
-export const MCP_JWT_KID = "mcp-1";
 export const ACCESS_TOKEN_TTL_SECONDS = 900; // 15 min
 export const PAT_BRIDGE_TTL_SECONDS = 300; // 5 min
 export const PAT_PREFIX = "fgt_";
@@ -54,9 +53,11 @@ async function mint(
   ttlSeconds: number,
   privateKeyPem?: string,
   issuer?: string,
+  kid?: string,
 ): Promise<string> {
+  const signingKid = kid ?? requireEnv(process.env.MCP_JWT_KID, "MCP_JWT_KID");
   return await new SignJWT(claims)
-    .setProtectedHeader({ alg: "RS256", kid: MCP_JWT_KID })
+    .setProtectedHeader({ alg: "RS256", kid: signingKid })
     .setSubject(subject)
     .setIssuer(issuer ?? requireEnv(process.env.NEXT_PUBLIC_APP_URL, "NEXT_PUBLIC_APP_URL"))
     .setAudience(MCP_JWT_AUDIENCE)
@@ -74,6 +75,7 @@ export async function mintAccessToken(opts: {
   ttlSeconds?: number;
   privateKeyPem?: string;
   issuer?: string;
+  kid?: string;
 }): Promise<string> {
   return await mint(
     `${opts.userId}|mcp:${opts.grantId}`,
@@ -81,6 +83,7 @@ export async function mintAccessToken(opts: {
     opts.ttlSeconds ?? ACCESS_TOKEN_TTL_SECONDS,
     opts.privateKeyPem,
     opts.issuer,
+    opts.kid,
   );
 }
 
@@ -90,6 +93,7 @@ export async function mintPatBridgeToken(opts: {
   tokenId: string;
   privateKeyPem?: string;
   issuer?: string;
+  kid?: string;
 }): Promise<string> {
   return await mint(
     `${opts.userId}|pat:${opts.tokenId}`,
@@ -97,6 +101,7 @@ export async function mintPatBridgeToken(opts: {
     PAT_BRIDGE_TTL_SECONDS,
     opts.privateKeyPem,
     opts.issuer,
+    opts.kid,
   );
 }
 
@@ -105,10 +110,14 @@ export async function mintPatBridgeToken(opts: {
  * extra public keys from MCP_EXTRA_PUBLIC_JWKS (JSON array) — used to publish a
  * dev keypair's public half alongside prod (see verification sub-plan).
  */
-export async function getPublicJwks(privateKeyPem?: string): Promise<{ keys: object[] }> {
+export async function getPublicJwks(
+  privateKeyPem?: string,
+  kid?: string,
+): Promise<{ keys: object[] }> {
   const jwk = (await exportJWK(await signingKey(privateKeyPem))) as Record<string, unknown>;
   for (const f of ["d", "p", "q", "dp", "dq", "qi"]) delete jwk[f];
-  const keys: object[] = [{ ...jwk, kid: MCP_JWT_KID, alg: "RS256", use: "sig" }];
+  const signingKid = kid ?? requireEnv(process.env.MCP_JWT_KID, "MCP_JWT_KID");
+  const keys: object[] = [{ ...jwk, kid: signingKid, alg: "RS256", use: "sig" }];
   const extra = process.env.MCP_EXTRA_PUBLIC_JWKS;
   if (extra) keys.push(...(JSON.parse(extra) as object[]));
   return { keys };

--- a/my-app/src/lib/mcp/verify-token.test.ts
+++ b/my-app/src/lib/mcp/verify-token.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { exportPKCS8, generateKeyPair } from "jose";
 import { mintAccessToken, sha256Hex } from "./tokens";
 import { createMcpTokenVerifier, McpExtra } from "./verify-token";
 
 const ISSUER = "https://example.test";
 const REQ = new Request("https://example.test/api/mcp");
+
+beforeEach(() => vi.stubEnv("MCP_JWT_KID", "mcp-test-1"));
+afterEach(() => vi.unstubAllEnvs());
 
 async function makeVerifier(overrides: Partial<Parameters<typeof createMcpTokenVerifier>[0]> = {}) {
   const { privateKey } = await generateKeyPair("RS256", { extractable: true });


### PR DESCRIPTION
Closes #73.

## What changed

- require `MCP_JWT_KID` for runtime signing and primary JWKS publication
- keep the configured private key and `kid` paired across access tokens and PAT bridge tokens
- print the matching `MCP_JWT_KID` from the keypair generator
- document atomic private-key/`kid` rotation with old-key overlap
- cover a non-default `kid` in token and JWKS tests
- verify both old unexpired tokens and newly issued tokens during the rotation overlap

## Root cause

The runtime hard-coded `mcp-1` even when the generator produced a different key ID, so local keys and rotated keys could never select the correct public JWK.

## Validation

- `bun run typecheck`
- targeted ESLint
- `bun run test:run` — 230 tests
- `bun run build`