### PR TITLE
refactor: isolate browser PAT crypto

### DIFF
--- a/my-app/src/app/api/oauth/register/route.ts
+++ b/my-app/src/app/api/oauth/register/route.ts
@@ -3,7 +3,7 @@ import { ConvexHttpClient } from "convex/browser";
 import { ConvexError } from "convex/values";
 import { api } from "../../../../../convex/_generated/api";
 import { corsJson, corsPreflight } from "@/lib/mcp/cors";
-import { randomHex } from "@/lib/mcp/tokens";
+import { randomHex } from "@/lib/mcp/token-crypto";
 import { isValidRedirectUri } from "@/lib/mcp/oauth-validation";
 
 const MAX_REDIRECT_URIS = 10;

--- a/my-app/src/app/api/oauth/token/route.ts
+++ b/my-app/src/app/api/oauth/token/route.ts
@@ -3,7 +3,8 @@ import { ConvexHttpClient } from "convex/browser";
 import { ConvexError } from "convex/values";
 import { api } from "../../../../../convex/_generated/api";
 import { corsJson, corsPreflight } from "@/lib/mcp/cors";
-import { ACCESS_TOKEN_TTL_SECONDS, mintAccessToken, randomToken, sha256Hex } from "@/lib/mcp/tokens";
+import { ACCESS_TOKEN_TTL_SECONDS, mintAccessToken } from "@/lib/mcp/tokens";
+import { randomToken, sha256Hex } from "@/lib/mcp/token-crypto";
 import { computeS256Challenge } from "@/lib/mcp/oauth-validation";
 
 function tokenError(error: string, description?: string, status = 400): Response {

--- a/my-app/src/app/oauth/authorize/actions.ts
+++ b/my-app/src/app/oauth/authorize/actions.ts
@@ -5,7 +5,7 @@ import { fetchMutation, fetchQuery } from "convex/nextjs";
 import { convexAuthNextjsToken } from "@convex-dev/auth/nextjs/server";
 import { redirect } from "next/navigation";
 import { api } from "../../../../convex/_generated/api";
-import { randomToken, sha256Hex } from "@/lib/mcp/tokens";
+import { randomToken, sha256Hex } from "@/lib/mcp/token-crypto";
 import { matchesRegisteredRedirect } from "@/lib/mcp/oauth-validation";
 
 /** Builds redirect_uri?k=v... preserving existing query params on the URI. */

--- a/my-app/src/components/pat-manager.test.tsx
+++ b/my-app/src/components/pat-manager.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, test, vi, beforeEach } from "vitest";
 import { getFunctionName } from "convex/server";
 import { PatManager } from "./pat-manager";
-import { PAT_PREFIX, sha256Hex } from "@/lib/mcp/tokens";
+import { PAT_PREFIX, sha256Hex } from "@/lib/mcp/token-crypto";
 
 const mockUseQuery = vi.fn();
 const mockCreate = vi.fn();

--- a/my-app/src/components/pat-manager.tsx
+++ b/my-app/src/components/pat-manager.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/ui/dialog";
 import { ConfirmDeleteButton } from "@/components/confirm-delete-button";
 import { formatWearDate } from "@/lib/format";
-import { PAT_PREFIX, randomToken, sha256Hex } from "@/lib/mcp/tokens";
+import { PAT_PREFIX, randomToken, sha256Hex } from "@/lib/mcp/token-crypto";
 
 export function PatManager() {
   const tokens = useQuery(api.apiTokens.list);

--- a/my-app/src/lib/mcp/token-crypto.test.ts
+++ b/my-app/src/lib/mcp/token-crypto.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { randomHex, randomToken, sha256Hex } from "./token-crypto";
+
+describe("sha256Hex", () => {
+  test("hashes to the known vector for 'abc'", async () => {
+    expect(await sha256Hex("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  });
+});
+
+describe("randomToken / randomHex", () => {
+  test("randomToken is base64url and unique", () => {
+    const a = randomToken();
+    expect(a).toMatch(/^[A-Za-z0-9_-]{43}$/); // 32 bytes → 43 base64url chars
+    expect(randomToken()).not.toBe(a);
+  });
+
+  test("randomHex is lowercase hex of requested length", () => {
+    expect(randomHex(16)).toMatch(/^[0-9a-f]{32}$/);
+  });
+});

--- a/my-app/src/lib/mcp/token-crypto.ts
+++ b/my-app/src/lib/mcp/token-crypto.ts
@@ -1,0 +1,29 @@
+// Browser-safe opaque-token helpers. Keep this module free of server-only
+// imports so the PAT manager can generate and hash credentials client-side.
+export const PAT_PREFIX = "fgt_";
+
+export async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function randomBytes(n: number): Uint8Array {
+  const bytes = new Uint8Array(n);
+  crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+/** Opaque secret (refresh tokens, auth codes, PAT bodies): base64url, no padding. */
+export function randomToken(bytes = 32): string {
+  const bin = String.fromCharCode(...randomBytes(bytes));
+  return btoa(bin).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+/** Public identifiers (client_id): lowercase hex. */
+export function randomHex(bytes = 16): string {
+  return Array.from(randomBytes(bytes))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/my-app/src/lib/mcp/tokens.test.ts
+++ b/my-app/src/lib/mcp/tokens.test.ts
@@ -2,9 +2,6 @@
 import { describe, expect, test } from "vitest";
 import { exportPKCS8, generateKeyPair, jwtVerify, createLocalJWKSet } from "jose";
 import {
-  sha256Hex,
-  randomToken,
-  randomHex,
   mintAccessToken,
   mintPatBridgeToken,
   getPublicJwks,
@@ -17,26 +14,6 @@ async function testPem(): Promise<string> {
   const { privateKey } = await generateKeyPair("RS256", { extractable: true });
   return await exportPKCS8(privateKey);
 }
-
-describe("sha256Hex", () => {
-  test("hashes to the known vector for 'abc'", async () => {
-    expect(await sha256Hex("abc")).toBe(
-      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
-    );
-  });
-});
-
-describe("randomToken / randomHex", () => {
-  test("randomToken is base64url and unique", () => {
-    const a = randomToken();
-    expect(a).toMatch(/^[A-Za-z0-9_-]{43}$/); // 32 bytes → 43 base64url chars
-    expect(randomToken()).not.toBe(a);
-  });
-
-  test("randomHex is lowercase hex of requested length", () => {
-    expect(randomHex(16)).toMatch(/^[0-9a-f]{32}$/);
-  });
-});
 
 describe("mintAccessToken", () => {
   test("mints an RS256 JWT verifiable via the derived JWKS with expected claims", async () => {

--- a/my-app/src/lib/mcp/tokens.ts
+++ b/my-app/src/lib/mcp/tokens.ts
@@ -1,6 +1,7 @@
 // src/lib/mcp/tokens.ts
-// Server-only JWT helpers for the MCP OAuth server. Convex functions never
-// import this; they only receive minted credentials.
+// Server-only JWT helpers for the MCP OAuth server. The MCP endpoint runs in
+// this app's Next.js server route on Vercel; this code is not client payload.
+// Convex functions never import it; they only receive minted credentials.
 import "server-only";
 import { SignJWT, importPKCS8, exportJWK } from "jose";
 

--- a/my-app/src/lib/mcp/tokens.ts
+++ b/my-app/src/lib/mcp/tokens.ts
@@ -1,41 +1,13 @@
 // src/lib/mcp/tokens.ts
-// Crypto + JWT helpers for the MCP OAuth server. Isomorphic (Web Crypto only):
-// runs in Next.js route handlers, server actions, edge-runtime tests, and the
-// browser (PAT generation in the settings UI). Convex functions never import
-// this — they only ever receive pre-computed hashes.
+// Server-only JWT helpers for the MCP OAuth server. Convex functions never
+// import this; they only receive minted credentials.
+import "server-only";
 import { SignJWT, importPKCS8, exportJWK } from "jose";
 
 export const MCP_JWT_AUDIENCE = "fragrances-mcp";
 export const MCP_JWT_KID = "mcp-1";
 export const ACCESS_TOKEN_TTL_SECONDS = 900; // 15 min
 export const PAT_BRIDGE_TTL_SECONDS = 300; // 5 min
-export const PAT_PREFIX = "fgt_";
-
-export async function sha256Hex(input: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
-  return Array.from(new Uint8Array(digest))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
-function randomBytes(n: number): Uint8Array {
-  const bytes = new Uint8Array(n);
-  crypto.getRandomValues(bytes);
-  return bytes;
-}
-
-/** Opaque secret (refresh tokens, auth codes, PAT bodies): base64url, no padding. */
-export function randomToken(bytes = 32): string {
-  const bin = String.fromCharCode(...randomBytes(bytes));
-  return btoa(bin).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
-}
-
-/** Public identifiers (client_id): lowercase hex. */
-export function randomHex(bytes = 16): string {
-  return Array.from(randomBytes(bytes))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
 
 function requireEnv(value: string | undefined, name: string): string {
   if (!value) throw new Error(`Missing required env var ${name}.`);

--- a/my-app/src/lib/mcp/verify-token.test.ts
+++ b/my-app/src/lib/mcp/verify-token.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { exportPKCS8, generateKeyPair } from "jose";
-import { mintAccessToken, sha256Hex } from "./tokens";
+import { mintAccessToken } from "./tokens";
+import { sha256Hex } from "./token-crypto";
 import { createMcpTokenVerifier, McpExtra } from "./verify-token";
 
 const ISSUER = "https://example.test";

--- a/my-app/src/lib/mcp/verify-token.ts
+++ b/my-app/src/lib/mcp/verify-token.ts
@@ -7,13 +7,8 @@
 import { createLocalJWKSet, jwtVerify } from "jose";
 import { ConvexHttpClient } from "convex/browser";
 import { api } from "../../../convex/_generated/api";
-import {
-  getPublicJwks,
-  mintPatBridgeToken,
-  sha256Hex,
-  MCP_JWT_AUDIENCE,
-  PAT_PREFIX,
-} from "./tokens";
+import { getPublicJwks, mintPatBridgeToken, MCP_JWT_AUDIENCE } from "./tokens";
+import { PAT_PREFIX, sha256Hex } from "./token-crypto";
 
 export type McpExtra = { userId: string; convexToken: string };
 

--- a/my-app/vitest.config.mts
+++ b/my-app/vitest.config.mts
@@ -5,6 +5,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),
+      "server-only": fileURLToPath(new URL("./node_modules/server-only/empty.js", import.meta.url)),
     },
   },
   test: {


### PR DESCRIPTION
Closes #74.

## What changed

- move browser-safe PAT generation and SHA-256 helpers into `token-crypto.ts`
- update the PAT manager and server callers to use the new boundary
- mark JWT signing/JWKS code with `server-only`
- split browser-crypto tests from JWT tests
- alias the `server-only` marker to its empty test entrypoint in Vitest

## Root cause

The client PAT manager imported a shared module that also imported `jose` and read the MCP private key, leaving client/server isolation dependent on tree shaking.

## Validation

- `bun run typecheck`
- targeted ESLint
- `bun run test:run` — 228 tests across 28 files
- `bun run build`
- verified `.next/static/chunks` contains no `jose`, `mcp-handler`, or `@modelcontextprotocol` references