### PR TITLE
fix: harden OAuth server against security-review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ cd my-app && bun scripts/generate-mcp-keypair.mjs
 | `MCP_JWT_KID` | Vercel + `.env.local` | Key ID passed to the generator; must identify `MCP_JWT_PRIVATE_KEY` |
 | `MCP_JWT_PRIVATE_KEY` | Vercel + `.env.local` | PKCS8 PEM from the generator script |
 | `NEXT_PUBLIC_APP_URL` | Vercel + `.env.local` | App origin; doubles as the JWT issuer |
+| `OAUTH_INTERNAL_SECRET` | Vercel + Convex dashboard | Shared high-entropy secret; must be identical in the Vercel and Convex deployments |
 | `MCP_EXTRA_PUBLIC_JWKS` | Vercel (optional) | Same-environment rotation keys; production must never include dev/staging keys |
 | `MCP_JWT_ISSUER` | Convex dashboard | = the app origin of that environment |
 | `MCP_JWKS_URL` | Convex dashboard | JWKS URL **reachable from Convex Cloud** |

--- a/my-app/convex/oauth.test.ts
+++ b/my-app/convex/oauth.test.ts
@@ -1,22 +1,28 @@
 // convex/oauth.test.ts
 import { ConvexError } from "convex/values";
-import { beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api";
 import { createTestUser, setupTest } from "./test.setup";
 
 const IP = "203.0.113.7";
+const INTERNAL_SECRET = "test-oauth-internal-secret";
 const CLIENT = {
   clientId: "abc123abc123abc123abc123abc123ab",
   clientName: "Claude",
   redirectUris: ["https://claude.ai/api/mcp/auth_callback"],
   ip: IP,
+  internalSecret: INTERNAL_SECRET,
 };
 const REDIRECT = CLIENT.redirectUris[0];
 const CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
 
 type T = ReturnType<typeof setupTest>;
 
-async function mintCode(t: T, as: Awaited<ReturnType<typeof createTestUser>>["as"], codeHash: string) {
+async function mintCode(
+  t: T,
+  as: Awaited<ReturnType<typeof createTestUser>>["as"],
+  codeHash: string,
+) {
   await as.mutation(api.oauth.createAuthCode, {
     clientId: CLIENT.clientId,
     redirectUri: REDIRECT,
@@ -34,6 +40,7 @@ function exchangeArgs(codeHash: string, overrides: Partial<Record<string, string
     codeChallenge: CHALLENGE,
     refreshTokenHash: "rt-hash-1",
     ip: IP,
+    internalSecret: INTERNAL_SECRET,
     ...overrides,
   };
 }
@@ -41,8 +48,55 @@ function exchangeArgs(codeHash: string, overrides: Partial<Record<string, string
 describe("oauth", () => {
   let t: T;
   beforeEach(async () => {
+    vi.stubEnv("OAUTH_INTERNAL_SECRET", INTERNAL_SECRET);
     t = setupTest();
     await t.mutation(api.oauth.registerClient, CLIENT);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  test.each(["", "wrong-secret"])(
+    "server-only mutations reject an invalid internal secret",
+    async (internalSecret) => {
+      const expected = JSON.stringify({
+        code: "internal_error",
+        message: "Internal server error.",
+      });
+      await expect(
+        t.mutation(api.oauth.registerClient, {
+          ...CLIENT,
+          clientId: "otherotherotherotherotherotherot",
+          internalSecret,
+        }),
+      ).rejects.toThrow(expected);
+      await expect(
+        t.mutation(api.oauth.exchangeAuthCode, {
+          ...exchangeArgs("unknown"),
+          internalSecret,
+        }),
+      ).rejects.toThrow(expected);
+      await expect(
+        t.mutation(api.oauth.rotateRefreshToken, {
+          tokenHash: "unknown",
+          newTokenHash: "new",
+          clientId: CLIENT.clientId,
+          ip: IP,
+          internalSecret,
+        }),
+      ).rejects.toThrow(expected);
+    },
+  );
+
+  test("server-only mutations fail uniformly when the deployment secret is missing", async () => {
+    vi.stubEnv("OAUTH_INTERNAL_SECRET", "");
+    await expect(
+      t.mutation(api.oauth.registerClient, {
+        ...CLIENT,
+        clientId: "otherotherotherotherotherotherot",
+      }),
+    ).rejects.toThrow(
+      JSON.stringify({ code: "internal_error", message: "Internal server error." }),
+    );
   });
 
   test("registerClient rejects invalid redirect URIs", async () => {
@@ -53,6 +107,12 @@ describe("oauth", () => {
         redirectUris: ["http://evil.com/cb"],
       }),
     ).rejects.toThrow(ConvexError);
+  });
+
+  test("registerClient rejects a duplicate clientId", async () => {
+    await expect(t.mutation(api.oauth.registerClient, CLIENT)).rejects.toThrow(
+      JSON.stringify({ code: "invalid_client_metadata", message: "Client registration failed." }),
+    );
   });
 
   test("getClientPublic returns registered metadata, null for unknown", async () => {
@@ -73,6 +133,21 @@ describe("oauth", () => {
     ).rejects.toThrow("Unauthenticated");
   });
 
+  test("createAuthCode rejects a malformed PKCE challenge", async () => {
+    const { as } = await createTestUser(t);
+    await expect(
+      as.mutation(api.oauth.createAuthCode, {
+        clientId: CLIENT.clientId,
+        redirectUri: REDIRECT,
+        codeHash: "h",
+        codeChallenge: "too-short",
+        scope: "read write",
+      }),
+    ).rejects.toThrow(
+      JSON.stringify({ code: "invalid_request", message: "Invalid PKCE code challenge." }),
+    );
+  });
+
   test("exchangeAuthCode happy path creates a grant and returns it", async () => {
     const { userId, as } = await createTestUser(t);
     await mintCode(t, as, "code-hash-1");
@@ -87,7 +162,10 @@ describe("oauth", () => {
     const { as } = await createTestUser(t);
     await mintCode(t, as, "code-hash-2");
     await expect(
-      t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-2", { codeChallenge: "WRONG" })),
+      t.mutation(
+        api.oauth.exchangeAuthCode,
+        exchangeArgs("code-hash-2", { codeChallenge: "WRONG" }),
+      ),
     ).rejects.toThrow(ConvexError);
   });
 
@@ -113,9 +191,9 @@ describe("oauth", () => {
     await mintCode(t, as, "code-hash-4");
     await t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-4"));
     // Reuse returns the revocation sentinel (not a throw) so the revoke commits.
-    expect(
-      await t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-4")),
-    ).toEqual({ revoked: true });
+    expect(await t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-4"))).toEqual({
+      revoked: true,
+    });
     expect(await as.query(api.oauth.listGrants, {})).toHaveLength(0);
   });
 
@@ -134,6 +212,47 @@ describe("oauth", () => {
     ).rejects.toThrow(ConvexError);
   });
 
+  test("replay of an expired consumed code does not revoke its grant", async () => {
+    const { as } = await createTestUser(t);
+    await mintCode(t, as, "code-hash-expired-replay");
+    await t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-expired-replay"));
+    await t.run(async (ctx) => {
+      const code = await ctx.db
+        .query("oauthAuthCodes")
+        .withIndex("by_code_hash", (q) => q.eq("codeHash", "code-hash-expired-replay"))
+        .unique();
+      await ctx.db.patch(code!._id, { expiresAt: Date.now() - 1 });
+    });
+
+    await expect(
+      t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-expired-replay")),
+    ).rejects.toThrow(ConvexError);
+    expect(await as.query(api.oauth.listGrants, {})).toHaveLength(1);
+  });
+
+  test("replay revokes only the grant created by that authorization code", async () => {
+    const { as } = await createTestUser(t);
+    await mintCode(t, as, "code-hash-old-grant");
+    const first = await t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-old-grant"));
+    if ("revoked" in first) throw new Error("Expected initial exchange to succeed.");
+    await as.mutation(api.oauth.revokeGrant, { grantId: first.grantId });
+
+    await mintCode(t, as, "code-hash-new-grant");
+    const second = await t.mutation(
+      api.oauth.exchangeAuthCode,
+      exchangeArgs("code-hash-new-grant", { refreshTokenHash: "rt-hash-new-grant" }),
+    );
+    if ("revoked" in second) throw new Error("Expected second exchange to succeed.");
+    expect(second.grantId).not.toBe(first.grantId);
+
+    expect(
+      await t.mutation(api.oauth.exchangeAuthCode, exchangeArgs("code-hash-old-grant")),
+    ).toEqual({ revoked: true });
+    const grants = await as.query(api.oauth.listGrants, {});
+    expect(grants).toHaveLength(1);
+    expect(grants[0]._id).toBe(second.grantId);
+  });
+
   test("refresh rotation works and reuse of a rotated token revokes the whole grant", async () => {
     const { as } = await createTestUser(t);
     await mintCode(t, as, "code-hash-6");
@@ -145,6 +264,7 @@ describe("oauth", () => {
       newTokenHash: "rt-hash-2",
       clientId: CLIENT.clientId,
       ip: IP,
+      internalSecret: INTERNAL_SECRET,
     });
     expect(rotated).toMatchObject({ scope: "read write" });
 
@@ -156,6 +276,7 @@ describe("oauth", () => {
         newTokenHash: "rt-hash-3",
         clientId: CLIENT.clientId,
         ip: IP,
+        internalSecret: INTERNAL_SECRET,
       }),
     ).toEqual({ revoked: true });
     expect(await as.query(api.oauth.listGrants, {})).toHaveLength(0);
@@ -167,6 +288,7 @@ describe("oauth", () => {
         newTokenHash: "rt-hash-4",
         clientId: CLIENT.clientId,
         ip: IP,
+        internalSecret: INTERNAL_SECRET,
       }),
     ).toEqual({ revoked: true });
   });
@@ -185,6 +307,7 @@ describe("oauth", () => {
         newTokenHash: "rt-hash-9",
         clientId: CLIENT.clientId,
         ip: IP,
+        internalSecret: INTERNAL_SECRET,
       }),
     ).toEqual({ revoked: true });
   });

--- a/my-app/convex/oauth.ts
+++ b/my-app/convex/oauth.ts
@@ -3,20 +3,31 @@
 // raw secret and hash it; these functions only store/compare hashes and opaque
 // strings — no crypto here (Convex's default runtime lacks async crypto.subtle).
 // registerClient / exchangeAuthCode / rotateRefreshToken are public mutations
-// called server-side without user auth; they are IP-rate-limited, operate only
-// on hashes, and fail uniformly with `invalid_grant` so nothing is enumerable.
+// called server-side without user auth; an internal shared secret limits them
+// to the Next.js routes, then IP rate limits and opaque hashes protect the flow.
 import { ConvexError, v } from "convex/values";
 import { mutation, query, MutationCtx } from "./_generated/server";
 import { Doc, Id } from "./_generated/dataModel";
 import { getUserId } from "./helpers";
 import { rateLimiter } from "./rateLimits";
-import { isValidRedirectUri, matchesRegisteredRedirect } from "../src/lib/mcp/oauth-validation";
+import {
+  isValidCodeChallenge,
+  isValidRedirectUri,
+  matchesRegisteredRedirect,
+} from "../src/lib/mcp/oauth-validation";
 
 const AUTH_CODE_TTL_MS = 10 * 60 * 1000; // RFC 6749 §4.1.2: codes MUST be short-lived
 const REFRESH_TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000;
 
 function invalidGrant(message: string): ConvexError<{ code: string; message: string }> {
   return new ConvexError({ code: "invalid_grant", message });
+}
+
+function assertInternalSecret(secret: string): void {
+  const configured = process.env.OAUTH_INTERNAL_SECRET;
+  if (!configured || secret !== configured) {
+    throw new ConvexError({ code: "internal_error", message: "Internal server error." });
+  }
 }
 
 async function revokeGrantById(ctx: MutationCtx, grantId: Id<"oauthGrants">): Promise<void> {
@@ -56,14 +67,26 @@ export const registerClient = mutation({
     clientName: v.string(),
     redirectUris: v.array(v.string()),
     ip: v.string(),
+    internalSecret: v.string(),
   },
   handler: async (ctx, args) => {
+    assertInternalSecret(args.internalSecret);
     await rateLimiter.limit(ctx, "oauthRegister", { key: args.ip, throws: true });
     // Defense in depth: the Next route already validated; never trust one layer.
     if (args.redirectUris.length === 0 || !args.redirectUris.every(isValidRedirectUri)) {
       throw new ConvexError({
         code: "invalid_redirect_uri",
         message: "redirect_uris must be https, or http on localhost only, without fragments.",
+      });
+    }
+    const existing = await ctx.db
+      .query("oauthClients")
+      .withIndex("by_client_id", (q) => q.eq("clientId", args.clientId))
+      .first();
+    if (existing) {
+      throw new ConvexError({
+        code: "invalid_client_metadata",
+        message: "Client registration failed.",
       });
     }
     await ctx.db.insert("oauthClients", {
@@ -112,7 +135,13 @@ export const createAuthCode = mutation({
       .withIndex("by_client_id", (q) => q.eq("clientId", args.clientId))
       .unique();
     if (!client || !matchesRegisteredRedirect(args.redirectUri, client.redirectUris)) {
-      throw new ConvexError({ code: "invalid_request", message: "Unknown client or redirect URI." });
+      throw new ConvexError({
+        code: "invalid_request",
+        message: "Unknown client or redirect URI.",
+      });
+    }
+    if (!isValidCodeChallenge(args.codeChallenge)) {
+      throw new ConvexError({ code: "invalid_request", message: "Invalid PKCE code challenge." });
     }
     await ctx.db.insert("oauthAuthCodes", {
       codeHash: args.codeHash,
@@ -142,8 +171,10 @@ export const exchangeAuthCode = mutation({
     codeChallenge: v.string(),
     refreshTokenHash: v.string(),
     ip: v.string(),
+    internalSecret: v.string(),
   },
   handler: async (ctx, args) => {
+    assertInternalSecret(args.internalSecret);
     await rateLimiter.limit(ctx, "oauthTokenExchange", { key: args.ip, throws: true });
     const now = Date.now();
     const code = await ctx.db
@@ -151,21 +182,19 @@ export const exchangeAuthCode = mutation({
       .withIndex("by_code_hash", (q) => q.eq("codeHash", args.codeHash))
       .unique();
     if (!code) throw invalidGrant("Unknown authorization code.");
+    if (code.expiresAt < now) throw invalidGrant("Authorization code expired.");
     if (code.usedAt !== undefined) {
-      // Reuse of a consumed code is theft evidence: revoke the grant and RETURN
+      // Reuse of a consumed code is theft evidence: revoke only the grant this
+      // code created and RETURN
       // (not throw) so the revocation commits — a throwing mutation rolls back
       // all its writes in Convex. The token route maps `{ revoked }` to 400
       // invalid_grant.
-      const grant = await findGrantForUserClient(ctx, code.userId, code.clientId);
-      if (grant) await revokeGrantById(ctx, grant._id);
+      if (code.grantId) await revokeGrantById(ctx, code.grantId);
       return { revoked: true as const };
     }
-    if (code.expiresAt < now) throw invalidGrant("Authorization code expired.");
     if (code.clientId !== args.clientId) throw invalidGrant("Client mismatch.");
     if (code.redirectUri !== args.redirectUri) throw invalidGrant("redirect_uri mismatch.");
     if (code.codeChallenge !== args.codeChallenge) throw invalidGrant("PKCE verification failed.");
-
-    await ctx.db.patch(code._id, { usedAt: now });
 
     let grant = await findGrantForUserClient(ctx, code.userId, code.clientId);
     if (grant) {
@@ -184,6 +213,8 @@ export const exchangeAuthCode = mutation({
       });
       grant = (await ctx.db.get(grantId))!;
     }
+
+    await ctx.db.patch(code._id, { usedAt: now, grantId: grant._id });
 
     await ctx.db.insert("oauthRefreshTokens", {
       tokenHash: args.refreshTokenHash,
@@ -210,8 +241,10 @@ export const rotateRefreshToken = mutation({
     newTokenHash: v.string(),
     clientId: v.string(),
     ip: v.string(),
+    internalSecret: v.string(),
   },
   handler: async (ctx, args) => {
+    assertInternalSecret(args.internalSecret);
     await rateLimiter.limit(ctx, "oauthTokenExchange", { key: args.ip, throws: true });
     const now = Date.now();
     const token = await ctx.db

--- a/my-app/convex/schema.ts
+++ b/my-app/convex/schema.ts
@@ -62,6 +62,7 @@ export default defineSchema({
     resource: v.optional(v.string()),
     expiresAt: v.number(),
     usedAt: v.optional(v.number()),
+    grantId: v.optional(v.id("oauthGrants")),
   }).index("by_code_hash", ["codeHash"]),
 
   oauthGrants: defineTable({

--- a/my-app/src/app/api/oauth/register/route.test.ts
+++ b/my-app/src/app/api/oauth/register/route.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const mockMutation = vi.hoisted(() => vi.fn());
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: class {
+    mutation(...args: unknown[]) {
+      return mockMutation(...args);
+    }
+  },
+}));
+
+vi.mock("@/lib/mcp/token-crypto", () => ({ randomHex: () => "generated-client-id" }));
+
+import { POST } from "./route";
+
+const INTERNAL_SECRET = "test-oauth-internal-secret";
+
+describe("OAuth registration route", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_CONVEX_URL", "https://convex.example");
+    vi.stubEnv("OAUTH_INTERNAL_SECRET", INTERNAL_SECRET);
+    mockMutation.mockReset().mockResolvedValue(null);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  test("passes the internal secret to Convex", async () => {
+    const response = await POST(
+      new Request("https://app.example/api/oauth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_name: "Example client",
+          redirect_uris: ["https://client.example/callback"],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockMutation).toHaveBeenCalledTimes(1);
+    expect(mockMutation.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ internalSecret: INTERNAL_SECRET }),
+    );
+  });
+});

--- a/my-app/src/app/api/oauth/register/route.ts
+++ b/my-app/src/app/api/oauth/register/route.ts
@@ -5,6 +5,7 @@ import { api } from "../../../../../convex/_generated/api";
 import { corsJson, corsPreflight } from "@/lib/mcp/cors";
 import { randomHex } from "@/lib/mcp/token-crypto";
 import { isValidRedirectUri } from "@/lib/mcp/oauth-validation";
+import { oauthInternalSecret } from "@/lib/mcp/internal-secret";
 
 const MAX_REDIRECT_URIS = 10;
 const MAX_URI_LENGTH = 2000;
@@ -62,6 +63,7 @@ export async function POST(req: Request) {
       clientName,
       redirectUris: uris as string[],
       ip: clientIp(req),
+      internalSecret: oauthInternalSecret(),
     });
   } catch (error) {
     if (error instanceof ConvexError) {

--- a/my-app/src/app/api/oauth/token/route.test.ts
+++ b/my-app/src/app/api/oauth/token/route.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  mutation: vi.fn(),
+  mintAccessToken: vi.fn(),
+}));
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: class {
+    mutation(...args: unknown[]) {
+      return mocks.mutation(...args);
+    }
+  },
+}));
+
+vi.mock("@/lib/mcp/tokens", () => ({
+  ACCESS_TOKEN_TTL_SECONDS: 900,
+  mintAccessToken: (...args: unknown[]) => mocks.mintAccessToken(...args),
+}));
+
+vi.mock("@/lib/mcp/token-crypto", () => ({
+  randomToken: () => "new-refresh-token",
+  sha256Hex: async (value: string) => `hash:${value}`,
+}));
+
+import { POST } from "./route";
+
+const INTERNAL_SECRET = "test-oauth-internal-secret";
+const VALID_VERIFIER = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+
+function tokenRequest(params: Record<string, string>): Request {
+  return new Request("https://app.example/api/oauth/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(params),
+  });
+}
+
+describe("OAuth token route", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_CONVEX_URL", "https://convex.example");
+    vi.stubEnv("OAUTH_INTERNAL_SECRET", INTERNAL_SECRET);
+    mocks.mutation.mockReset().mockResolvedValue({
+      userId: "user-1",
+      grantId: "grant-1",
+      scope: "read write",
+    });
+    mocks.mintAccessToken.mockReset().mockResolvedValue("access-token");
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  test.each(["a".repeat(42), "a".repeat(129), `${"a".repeat(42)}+`])(
+    "rejects malformed code_verifier syntax",
+    async (codeVerifier) => {
+      const response = await POST(
+        tokenRequest({
+          grant_type: "authorization_code",
+          code: "authorization-code",
+          code_verifier: codeVerifier,
+          client_id: "client-1",
+          redirect_uri: "https://client.example/callback",
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({ error: "invalid_request" });
+      expect(mocks.mutation).not.toHaveBeenCalled();
+    },
+  );
+
+  test("passes the internal secret during authorization-code exchange", async () => {
+    const response = await POST(
+      tokenRequest({
+        grant_type: "authorization_code",
+        code: "authorization-code",
+        code_verifier: VALID_VERIFIER,
+        client_id: "client-1",
+        redirect_uri: "https://client.example/callback",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.mutation).toHaveBeenCalledTimes(1);
+    expect(mocks.mutation.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        internalSecret: INTERNAL_SECRET,
+        codeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+      }),
+    );
+  });
+
+  test("passes the internal secret during refresh-token rotation", async () => {
+    const response = await POST(
+      tokenRequest({
+        grant_type: "refresh_token",
+        refresh_token: "old-refresh-token",
+        client_id: "client-1",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.mutation).toHaveBeenCalledTimes(1);
+    expect(mocks.mutation.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ internalSecret: INTERNAL_SECRET }),
+    );
+  });
+});

--- a/my-app/src/app/api/oauth/token/route.ts
+++ b/my-app/src/app/api/oauth/token/route.ts
@@ -5,7 +5,8 @@ import { api } from "../../../../../convex/_generated/api";
 import { corsJson, corsPreflight } from "@/lib/mcp/cors";
 import { ACCESS_TOKEN_TTL_SECONDS, mintAccessToken } from "@/lib/mcp/tokens";
 import { randomToken, sha256Hex } from "@/lib/mcp/token-crypto";
-import { computeS256Challenge } from "@/lib/mcp/oauth-validation";
+import { computeS256Challenge, isValidCodeVerifier } from "@/lib/mcp/oauth-validation";
+import { oauthInternalSecret } from "@/lib/mcp/internal-secret";
 
 function tokenError(error: string, description?: string, status = 400): Response {
   return corsJson(
@@ -72,6 +73,9 @@ export async function POST(req: Request) {
         "code, code_verifier, client_id and redirect_uri are required.",
       );
     }
+    if (!isValidCodeVerifier(codeVerifier)) {
+      return tokenError("invalid_request", "code_verifier has invalid PKCE syntax.");
+    }
     const refreshToken = randomToken();
     try {
       const result = await convex.mutation(api.oauth.exchangeAuthCode, {
@@ -81,8 +85,10 @@ export async function POST(req: Request) {
         codeChallenge: await computeS256Challenge(codeVerifier),
         refreshTokenHash: await sha256Hex(refreshToken),
         ip,
+        internalSecret: oauthInternalSecret(),
       });
-      if ("revoked" in result) return tokenError("invalid_grant", "Authorization code already used.");
+      if ("revoked" in result)
+        return tokenError("invalid_grant", "Authorization code already used.");
       return await successResponse(result, clientId, refreshToken);
     } catch (error) {
       return mapConvexError(error);
@@ -102,8 +108,10 @@ export async function POST(req: Request) {
         newTokenHash: await sha256Hex(newRefreshToken),
         clientId,
         ip,
+        internalSecret: oauthInternalSecret(),
       });
-      if ("revoked" in result) return tokenError("invalid_grant", "Refresh token reuse detected; grant revoked.");
+      if ("revoked" in result)
+        return tokenError("invalid_grant", "Refresh token reuse detected; grant revoked.");
       return await successResponse(result, clientId, newRefreshToken);
     } catch (error) {
       return mapConvexError(error);

--- a/my-app/src/app/oauth/authorize/actions.ts
+++ b/my-app/src/app/oauth/authorize/actions.ts
@@ -6,7 +6,7 @@ import { convexAuthNextjsToken } from "@convex-dev/auth/nextjs/server";
 import { redirect } from "next/navigation";
 import { api } from "../../../../convex/_generated/api";
 import { randomToken, sha256Hex } from "@/lib/mcp/token-crypto";
-import { matchesRegisteredRedirect } from "@/lib/mcp/oauth-validation";
+import { isValidCodeChallenge, matchesRegisteredRedirect } from "@/lib/mcp/oauth-validation";
 
 /** Builds redirect_uri?k=v... preserving existing query params on the URI. */
 export async function buildCallbackUrl(
@@ -44,7 +44,11 @@ export async function approveAuthorization(formData: FormData): Promise<void> {
   const f = readFields(formData);
   // Re-validate everything server-side; hidden form fields are attacker input.
   const client = await fetchQuery(api.oauth.getClientPublic, { clientId: f.clientId });
-  if (!client || !matchesRegisteredRedirect(f.redirectUri, client.redirectUris) || !f.codeChallenge) {
+  if (
+    !client ||
+    !matchesRegisteredRedirect(f.redirectUri, client.redirectUris) ||
+    !isValidCodeChallenge(f.codeChallenge)
+  ) {
     throw new Error("Invalid authorization request.");
   }
 

--- a/my-app/src/app/oauth/authorize/page.test.tsx
+++ b/my-app/src/app/oauth/authorize/page.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchQuery: vi.fn(),
+  redirect: vi.fn(),
+}));
+
+vi.mock("convex/nextjs", () => ({
+  fetchQuery: (...args: unknown[]) => mocks.fetchQuery(...args),
+}));
+
+vi.mock("@convex-dev/auth/nextjs/server", () => ({
+  convexAuthNextjsToken: async () => "auth-token",
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (...args: unknown[]) => mocks.redirect(...args),
+}));
+
+vi.mock("./actions", () => ({
+  approveAuthorization: vi.fn(),
+  denyAuthorization: vi.fn(),
+}));
+
+import AuthorizePage from "./page";
+
+const VALID_PARAMS = {
+  client_id: "client-1",
+  redirect_uri: "https://client.example/callback?existing=1",
+  response_type: "code",
+  code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+  code_challenge_method: "S256",
+};
+
+describe("AuthorizePage", () => {
+  beforeEach(() => {
+    mocks.fetchQuery.mockReset();
+    mocks.redirect.mockReset().mockImplementation(() => {
+      throw new Error("NEXT_REDIRECT");
+    });
+  });
+
+  test("prominently identifies the redirect origin and unverified client status", async () => {
+    mocks.fetchQuery
+      .mockResolvedValueOnce({
+        clientId: "client-1",
+        clientName: "Friendly-looking name",
+        redirectUris: [VALID_PARAMS.redirect_uri],
+      })
+      .mockResolvedValueOnce({ email: "user@example.test" });
+
+    render(await AuthorizePage({ searchParams: Promise.resolve(VALID_PARAMS) }));
+
+    expect(screen.getByText("https://client.example")).toBeInTheDocument();
+    expect(
+      screen.getByText(/This app was registered automatically and is not verified/),
+    ).toBeInTheDocument();
+  });
+
+  test("rejects malformed PKCE challenges before rendering consent", async () => {
+    mocks.fetchQuery.mockResolvedValueOnce({
+      clientId: "client-1",
+      clientName: "Example",
+      redirectUris: [VALID_PARAMS.redirect_uri],
+    });
+
+    await expect(
+      AuthorizePage({
+        searchParams: Promise.resolve({ ...VALID_PARAMS, code_challenge: "too-short" }),
+      }),
+    ).rejects.toThrow("NEXT_REDIRECT");
+    expect(mocks.redirect).toHaveBeenCalledWith(expect.stringContaining("error=invalid_request"));
+  });
+});

--- a/my-app/src/app/oauth/authorize/page.tsx
+++ b/my-app/src/app/oauth/authorize/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import { fetchQuery } from "convex/nextjs";
 import { convexAuthNextjsToken } from "@convex-dev/auth/nextjs/server";
 import { api } from "../../../../convex/_generated/api";
-import { matchesRegisteredRedirect } from "@/lib/mcp/oauth-validation";
+import { isValidCodeChallenge, matchesRegisteredRedirect } from "@/lib/mcp/oauth-validation";
 import { approveAuthorization, denyAuthorization } from "./actions";
 import { Button } from "@/components/ui/button";
 
@@ -37,11 +37,11 @@ export default async function AuthorizePage({
   // Rule 1: bad client or redirect_uri → render, NEVER redirect.
   const clientId = str("client_id");
   const redirectUri = str("redirect_uri");
-  const client = clientId
-    ? await fetchQuery(api.oauth.getClientPublic, { clientId })
-    : null;
+  const client = clientId ? await fetchQuery(api.oauth.getClientPublic, { clientId }) : null;
   if (!client) {
-    return <ErrorCard message="Unknown or missing client_id. The connecting app may need to re-register." />;
+    return (
+      <ErrorCard message="Unknown or missing client_id. The connecting app may need to re-register." />
+    );
   }
   if (!redirectUri || !matchesRegisteredRedirect(redirectUri, client.redirectUris)) {
     return <ErrorCard message="The redirect URI does not match this app's registration." />;
@@ -60,12 +60,21 @@ export default async function AuthorizePage({
     bounce("unsupported_response_type", "Only response_type=code is supported.");
   }
   const codeChallenge = str("code_challenge");
-  if (!codeChallenge || str("code_challenge_method") !== "S256") {
+  if (
+    !codeChallenge ||
+    !isValidCodeChallenge(codeChallenge) ||
+    str("code_challenge_method") !== "S256"
+  ) {
     bounce("invalid_request", "PKCE with code_challenge_method=S256 is required.");
   }
+  const redirectOrigin = new URL(redirectUri).origin;
 
   // Middleware guarantees an authenticated session here.
-  const user = await fetchQuery(api.users.currentUser, {}, { token: await convexAuthNextjsToken() });
+  const user = await fetchQuery(
+    api.users.currentUser,
+    {},
+    { token: await convexAuthNextjsToken() },
+  );
 
   const hidden = (
     <>
@@ -80,9 +89,7 @@ export default async function AuthorizePage({
   return (
     <main className="flex min-h-dvh items-center justify-center bg-bg px-5">
       <div className="w-full max-w-[400px] rounded-2xl border border-border/40 bg-surface/80 p-8">
-        <p className="font-display text-xl tracking-tight text-text">
-          Connect {client.clientName}
-        </p>
+        <p className="font-display text-xl tracking-tight text-text">Connect {client.clientName}</p>
         <p className="mt-2 text-sm leading-relaxed text-text-secondary">
           <span className="font-medium text-text">{client.clientName}</span> wants to read and
           update the fragrance collection and wear history of{" "}
@@ -92,6 +99,10 @@ export default async function AuthorizePage({
           <li>View bottles, wear logs, and collection stats</li>
           <li>Add, edit, and delete bottles and wear logs</li>
         </ul>
+        <p className="mt-4 rounded-lg border border-border/40 bg-surface-alt px-3 py-2.5 text-sm leading-relaxed text-text-secondary">
+          Requests will be sent to <span className="font-medium text-text">{redirectOrigin}</span>.
+          This app was registered automatically and is not verified.
+        </p>
         <div className="mt-6 flex gap-3">
           <form action={denyAuthorization} className="flex-1">
             {hidden}

--- a/my-app/src/lib/mcp/cors.ts
+++ b/my-app/src/lib/mcp/cors.ts
@@ -23,7 +23,11 @@ export function corsPreflight(): Response {
 }
 
 export function appOrigin(): string {
-  const origin = process.env.NEXT_PUBLIC_APP_URL;
-  if (!origin) throw new Error("Missing required env var NEXT_PUBLIC_APP_URL.");
-  return origin.replace(/\/$/, "");
+  const value = process.env.NEXT_PUBLIC_APP_URL;
+  if (!value) throw new Error("Missing required env var NEXT_PUBLIC_APP_URL.");
+  const url = new URL(value);
+  if (url.origin === "null" || url.href !== `${url.origin}/`) {
+    throw new Error("NEXT_PUBLIC_APP_URL must be an origin without a path, query, or fragment.");
+  }
+  return url.origin;
 }

--- a/my-app/src/lib/mcp/internal-secret.ts
+++ b/my-app/src/lib/mcp/internal-secret.ts
@@ -1,0 +1,7 @@
+import "server-only";
+
+export function oauthInternalSecret(): string {
+  const secret = process.env.OAUTH_INTERNAL_SECRET;
+  if (!secret) throw new Error("Missing required env var OAUTH_INTERNAL_SECRET.");
+  return secret;
+}

--- a/my-app/src/lib/mcp/oauth-validation.test.ts
+++ b/my-app/src/lib/mcp/oauth-validation.test.ts
@@ -4,6 +4,8 @@ import {
   isValidRedirectUri,
   matchesRegisteredRedirect,
   computeS256Challenge,
+  isValidCodeVerifier,
+  isValidCodeChallenge,
   isSafeInternalPath,
 } from "./oauth-validation";
 
@@ -43,6 +45,29 @@ describe("computeS256Challenge", () => {
     expect(await computeS256Challenge("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")).toBe(
       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
     );
+  });
+});
+
+describe("PKCE syntax", () => {
+  test.each([
+    ["a".repeat(43), true],
+    ["A0-._~".repeat(22).slice(0, 128), true],
+    ["a".repeat(42), false],
+    ["a".repeat(129), false],
+    [`${"a".repeat(42)}+`, false],
+    [`${"a".repeat(42)}=`, false],
+  ])("validates verifier %s", (verifier, valid) => {
+    expect(isValidCodeVerifier(verifier)).toBe(valid);
+  });
+
+  test.each([
+    ["E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM", true],
+    ["a".repeat(42), false],
+    ["a".repeat(44), false],
+    [`${"a".repeat(42)}=`, false],
+    [`${"a".repeat(42)}~`, false],
+  ])("validates challenge %s", (challenge, valid) => {
+    expect(isValidCodeChallenge(challenge)).toBe(valid);
   });
 });
 

--- a/my-app/src/lib/mcp/oauth-validation.ts
+++ b/my-app/src/lib/mcp/oauth-validation.ts
@@ -20,6 +20,16 @@ export function matchesRegisteredRedirect(uri: string, registered: string[]): bo
   return registered.includes(uri);
 }
 
+/** RFC 7636 §4.1: 43-128 characters from the unreserved URI character set. */
+export function isValidCodeVerifier(verifier: string): boolean {
+  return /^[A-Za-z0-9._~-]{43,128}$/.test(verifier);
+}
+
+/** S256 produces exactly 32 bytes, encoded as 43 unpadded base64url characters. */
+export function isValidCodeChallenge(challenge: string): boolean {
+  return /^[A-Za-z0-9_-]{43}$/.test(challenge);
+}
+
 /** PKCE S256: base64url(SHA-256(ascii(code_verifier))), unpadded (RFC 7636 §4.2). */
 export async function computeS256Challenge(codeVerifier: string): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(codeVerifier));

--- a/my-app/src/lib/mcp/tokens.test.ts
+++ b/my-app/src/lib/mcp/tokens.test.ts
@@ -1,12 +1,7 @@
 // src/lib/mcp/tokens.test.ts
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { exportPKCS8, generateKeyPair, jwtVerify, createLocalJWKSet } from "jose";
-import {
-  mintAccessToken,
-  mintPatBridgeToken,
-  getPublicJwks,
-  MCP_JWT_AUDIENCE,
-} from "./tokens";
+import { exportJWK, exportPKCS8, generateKeyPair, jwtVerify, createLocalJWKSet } from "jose";
+import { mintAccessToken, mintPatBridgeToken, getPublicJwks, MCP_JWT_AUDIENCE } from "./tokens";
 
 const ISSUER = "https://example.test";
 const TEST_KID = "mcp-test-1";
@@ -61,6 +56,51 @@ describe("mintAccessToken", () => {
       jwtVerify(token, jwksB, { issuer: ISSUER, audience: MCP_JWT_AUDIENCE }),
     ).rejects.toThrow();
   });
+
+  test("canonicalizes the configured app origin for the default issuer", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://example.test/");
+    const pem = await testPem();
+    const token = await mintAccessToken({
+      userId: "user123",
+      grantId: "grant456",
+      clientId: "client789",
+      scope: "read write",
+      privateKeyPem: pem,
+      kid: TEST_KID,
+    });
+    const { payload } = await jwtVerify(
+      token,
+      createLocalJWKSet(await getPublicJwks(pem, TEST_KID)),
+      {
+        issuer: ISSUER,
+        audience: MCP_JWT_AUDIENCE,
+      },
+    );
+    expect(payload.iss).toBe(ISSUER);
+  });
+
+  test("rejects a configured app URL with path, query, or fragment", async () => {
+    const pem = await testPem();
+    for (const value of [
+      "https://example.test/oauth",
+      "https://example.test/?env=prod",
+      "https://example.test/#issuer",
+      "https://example.test/?",
+      "https://example.test/#",
+    ]) {
+      vi.stubEnv("NEXT_PUBLIC_APP_URL", value);
+      await expect(
+        mintAccessToken({
+          userId: "user123",
+          grantId: "grant456",
+          clientId: "client789",
+          scope: "read write",
+          privateKeyPem: pem,
+          kid: TEST_KID,
+        }),
+      ).rejects.toThrow("NEXT_PUBLIC_APP_URL must be an origin without a path, query, or fragment");
+    }
+  });
 });
 
 describe("mintPatBridgeToken", () => {
@@ -74,7 +114,10 @@ describe("mintPatBridgeToken", () => {
       kid: TEST_KID,
     });
     const jwks = createLocalJWKSet(await getPublicJwks(pem, TEST_KID));
-    const { payload } = await jwtVerify(token, jwks, { issuer: ISSUER, audience: MCP_JWT_AUDIENCE });
+    const { payload } = await jwtVerify(token, jwks, {
+      issuer: ISSUER,
+      audience: MCP_JWT_AUDIENCE,
+    });
     expect(payload.sub).toBe("user123|pat:tok789");
     expect((payload.exp as number) - (payload.iat as number)).toBe(300);
   });
@@ -148,5 +191,39 @@ describe("getPublicJwks", () => {
 
     expect(oldResult.protectedHeader.kid).toBe("mcp-old-1");
     expect(newResult.protectedHeader.kid).toBe("mcp-new-1");
+  });
+
+  test("accepts only distinct public RSA signing keys from MCP_EXTRA_PUBLIC_JWKS", async () => {
+    const primaryPem = await testPem();
+    const { publicKey } = await generateKeyPair("RS256", { extractable: true });
+    const extra = { ...(await exportJWK(publicKey)), kid: "mcp-old-1", use: "sig" };
+    vi.stubEnv("MCP_EXTRA_PUBLIC_JWKS", JSON.stringify([extra]));
+
+    const { keys } = await getPublicJwks(primaryPem, "mcp-new-1");
+    expect(keys).toHaveLength(2);
+    expect(keys[1]).toEqual(extra);
+  });
+
+  test.each([
+    [{ kty: "EC", use: "sig", alg: "RS256", kid: "extra" }, "kty"],
+    [{ kty: "RSA", use: "enc", alg: "RS256", kid: "extra" }, "use"],
+    [{ kty: "RSA", use: "sig", alg: "RS512", kid: "extra" }, "alg"],
+    [{ kty: "RSA", use: "sig", alg: "RS256", kid: "" }, "kid"],
+    [{ kty: "RSA", use: "sig", alg: "RS256", kid: "primary" }, "duplicate kid"],
+    [{ kty: "RSA", use: "sig", alg: "RS256", kid: "extra", d: "private" }, "private"],
+  ])("rejects an unsafe extra JWK %#", async (extra, message) => {
+    vi.stubEnv("MCP_EXTRA_PUBLIC_JWKS", JSON.stringify([extra]));
+    await expect(getPublicJwks(await testPem(), "primary")).rejects.toThrow(message);
+  });
+
+  test("rejects duplicate kids among extra JWKs", async () => {
+    vi.stubEnv(
+      "MCP_EXTRA_PUBLIC_JWKS",
+      JSON.stringify([
+        { kty: "RSA", use: "sig", kid: "old" },
+        { kty: "RSA", use: "sig", kid: "old" },
+      ]),
+    );
+    await expect(getPublicJwks(await testPem(), "primary")).rejects.toThrow("duplicate kid");
   });
 });

--- a/my-app/src/lib/mcp/tokens.ts
+++ b/my-app/src/lib/mcp/tokens.ts
@@ -4,6 +4,7 @@
 // Convex functions never import it; they only receive minted credentials.
 import "server-only";
 import { SignJWT, importPKCS8, exportJWK } from "jose";
+import { appOrigin } from "./cors";
 
 export const MCP_JWT_AUDIENCE = "fragrances-mcp";
 export const ACCESS_TOKEN_TTL_SECONDS = 900; // 15 min
@@ -32,7 +33,7 @@ async function mint(
   return await new SignJWT(claims)
     .setProtectedHeader({ alg: "RS256", kid: signingKid })
     .setSubject(subject)
-    .setIssuer(issuer ?? requireEnv(process.env.NEXT_PUBLIC_APP_URL, "NEXT_PUBLIC_APP_URL"))
+    .setIssuer(issuer ?? appOrigin())
     .setAudience(MCP_JWT_AUDIENCE)
     .setIssuedAt()
     .setExpirationTime(`${ttlSeconds}s`)
@@ -92,6 +93,32 @@ export async function getPublicJwks(
   const signingKid = kid ?? requireEnv(process.env.MCP_JWT_KID, "MCP_JWT_KID");
   const keys: object[] = [{ ...jwk, kid: signingKid, alg: "RS256", use: "sig" }];
   const extra = process.env.MCP_EXTRA_PUBLIC_JWKS;
-  if (extra) keys.push(...(JSON.parse(extra) as object[]));
+  if (extra) {
+    const parsed: unknown = JSON.parse(extra);
+    if (!Array.isArray(parsed)) throw new Error("MCP_EXTRA_PUBLIC_JWKS must be a JSON array.");
+
+    const seenKids = new Set([signingKid]);
+    for (const value of parsed) {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new Error("Each extra JWK must be an object.");
+      }
+      const extraJwk = value as Record<string, unknown>;
+      if (["d", "p", "q", "dp", "dq", "qi"].some((field) => field in extraJwk)) {
+        throw new Error("Extra JWKs must not contain private key fields.");
+      }
+      if (extraJwk.kty !== "RSA") throw new Error("Extra JWK kty must be RSA.");
+      if (extraJwk.use !== "sig") throw new Error("Extra JWK use must be sig.");
+      if (extraJwk.alg !== undefined && extraJwk.alg !== "RS256") {
+        throw new Error("Extra JWK alg must be RS256 or absent.");
+      }
+      if (typeof extraJwk.kid !== "string" || extraJwk.kid.trim() === "") {
+        throw new Error("Extra JWK kid must be a non-empty string.");
+      }
+      if (seenKids.has(extraJwk.kid))
+        throw new Error(`Extra JWK has duplicate kid: ${extraJwk.kid}.`);
+      seenKids.add(extraJwk.kid);
+      keys.push(extraJwk);
+    }
+  }
   return { keys };
 }

--- a/my-app/src/lib/mcp/verify-token.test.ts
+++ b/my-app/src/lib/mcp/verify-token.test.ts
@@ -28,8 +28,12 @@ describe("verifyMcpToken — OAuth JWT path", () => {
   test("valid JWT yields authInfo whose convexToken is the JWT itself", async () => {
     const { pem, verify } = await makeVerifier();
     const jwt = await mintAccessToken({
-      userId: "user123", grantId: "grant456", clientId: "client789",
-      scope: "read write", privateKeyPem: pem, issuer: ISSUER,
+      userId: "user123",
+      grantId: "grant456",
+      clientId: "client789",
+      scope: "read write",
+      privateKeyPem: pem,
+      issuer: ISSUER,
     });
     const info = await verify(REQ, jwt);
     expect(info?.clientId).toBe("client789");
@@ -41,8 +45,12 @@ describe("verifyMcpToken — OAuth JWT path", () => {
     const { verify } = await makeVerifier();
     const other = await generateKeyPair("RS256", { extractable: true });
     const forged = await mintAccessToken({
-      userId: "user123", grantId: "g", clientId: "c", scope: "read write",
-      privateKeyPem: await exportPKCS8(other.privateKey), issuer: ISSUER,
+      userId: "user123",
+      grantId: "g",
+      clientId: "c",
+      scope: "read write",
+      privateKeyPem: await exportPKCS8(other.privateKey),
+      issuer: ISSUER,
     });
     expect(await verify(REQ, forged)).toBeUndefined();
   });
@@ -51,6 +59,21 @@ describe("verifyMcpToken — OAuth JWT path", () => {
     const { verify } = await makeVerifier();
     expect(await verify(REQ, undefined)).toBeUndefined();
     expect(await verify(REQ, "not-a-jwt")).toBeUndefined();
+  });
+
+  test("uses the canonical app origin for the default issuer", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://example.test/");
+    const { pem, verify } = await makeVerifier({ issuer: undefined });
+    const jwt = await mintAccessToken({
+      userId: "user123",
+      grantId: "grant456",
+      clientId: "client789",
+      scope: "read write",
+      privateKeyPem: pem,
+      issuer: ISSUER,
+    });
+
+    expect(await verify(REQ, jwt)).toMatchObject({ clientId: "client789" });
   });
 });
 

--- a/my-app/src/lib/mcp/verify-token.ts
+++ b/my-app/src/lib/mcp/verify-token.ts
@@ -9,6 +9,7 @@ import { ConvexHttpClient } from "convex/browser";
 import { api } from "../../../convex/_generated/api";
 import { getPublicJwks, mintPatBridgeToken, MCP_JWT_AUDIENCE } from "./tokens";
 import { PAT_PREFIX, sha256Hex } from "./token-crypto";
+import { appOrigin } from "./cors";
 
 export type McpExtra = { userId: string; convexToken: string };
 
@@ -61,7 +62,7 @@ export function createMcpTokenVerifier(deps: VerifierDeps = {}) {
     try {
       const jwks = createLocalJWKSet(await getPublicJwks(deps.privateKeyPem));
       const { payload } = await jwtVerify(bearer, jwks, {
-        issuer: deps.issuer ?? process.env.NEXT_PUBLIC_APP_URL,
+        issuer: deps.issuer ?? appOrigin(),
         audience: MCP_JWT_AUDIENCE,
         // Pin the algorithm: our tokens are always RS256. Defense-in-depth
         // against alg-confusion (jose already refuses HS*/none for an RSA key).


### PR DESCRIPTION
Fixes all 6 findings from the gpt-5.6-sol high-effort security review of epic/mcp, each independently verified against the code before implementation.

## Findings addressed

1. **(medium) Public Convex mutations callable directly** — `registerClient`/`exchangeAuthCode`/`rotateRefreshToken` now require an `internalSecret` checked against `OAUTH_INTERNAL_SECRET` on the Convex side, closing rate-limit bypass via caller-supplied `ip`, duplicate-`clientId` DoS, and registration spam. Duplicate `clientId` also rejected atomically.
2. **(medium) `MCP_EXTRA_PUBLIC_JWKS` published verbatim** — extras now validated: public RSA `sig` keys only, private fields rejected, `kid` required and unique; misconfiguration throws.
3. **(medium) Consent-screen impersonation** — consent page now shows the redirect origin and an unverified-client notice alongside the attacker-choosable `client_name`.
4. **(medium-low) PKCE syntax unenforced** — RFC 7636 verifier (43–128 unreserved chars) enforced at the token endpoint; 43-char base64url challenge enforced at authorize page, consent action, and Convex `createAuthCode`.
5. **(low) Consumed-code replay revoked newer grants** — expiry checked before reuse handling; auth codes store the `grantId` they created and reuse revokes only that grant.
6. **(low) Trailing-slash issuer mismatch** — `appOrigin()` canonicalizes `NEXT_PUBLIC_APP_URL` (rejects path/query/fragment) and is the single source for JWT `iss`, metadata, and verification.

## Deployment prerequisite

`OAUTH_INTERNAL_SECRET` must be set **identically** in Vercel (Preview) and the Convex dev deployment before this deploys, or the OAuth token surface breaks. Local `.env.local` already has it.

## Validation

- `bun run typecheck`, `bun run lint`
- `bun run test:run` — 267 tests (37 new) across 31 files
- `bun run build` + client-chunk scan: no `jose`, private key material, or `OAUTH_INTERNAL_SECRET` in browser assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)