### PR TITLE
Reject invalid backend numeric inputs

### DIFF
--- a/my-app/convex/bottles.test.ts
+++ b/my-app/convex/bottles.test.ts
@@ -415,6 +415,14 @@ describe("update semantics (null clears, undefined preserves)", () => {
 // ── P2: Validation boundaries ───────────────────────────────────────────────
 
 describe("validation", () => {
+  test("blank name is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    await expect(user.as.mutation(api.bottles.addBottle, { name: "   " })).rejects.toThrowError(
+      "Name is required.",
+    );
+  });
+
   test("name at 200 chars is accepted", async () => {
     const t = setupTest();
     const user = await createTestUser(t);
@@ -510,6 +518,17 @@ describe("validation", () => {
     ).rejects.toThrowError("sizeMl must be greater than 0.");
   });
 
+  test("NaN sizeMl is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    await expect(
+      user.as.mutation(api.bottles.addBottle, {
+        name: "Test",
+        sizeMl: Number.NaN,
+      }),
+    ).rejects.toThrowError("sizeMl must be a finite number.");
+  });
+
   test("sizeMl of 10000 is accepted", async () => {
     const t = setupTest();
     const user = await createTestUser(t);
@@ -536,6 +555,20 @@ describe("validation", () => {
 // ── P2: updateBottle validation ──────────────────────────────────────────────
 
 describe("updateBottle validation", () => {
+  test("blank name is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    const bottleId = await user.as.mutation(api.bottles.addBottle, {
+      name: "Test",
+    });
+    await expect(
+      user.as.mutation(api.bottles.updateBottle, {
+        bottleId,
+        name: "   ",
+      }),
+    ).rejects.toThrowError("Name is required.");
+  });
+
   test("name at 201 chars is rejected", async () => {
     const t = setupTest();
     const user = await createTestUser(t);
@@ -586,6 +619,21 @@ describe("updateBottle validation", () => {
     await expect(
       user.as.mutation(api.bottles.updateBottle, { bottleId, sizeMl: -1 }),
     ).rejects.toThrowError("sizeMl must be greater than 0.");
+  });
+
+  test("NaN sizeMl is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    const bottleId = await user.as.mutation(api.bottles.addBottle, {
+      name: "Test",
+      sizeMl: 100,
+    });
+    await expect(
+      user.as.mutation(api.bottles.updateBottle, {
+        bottleId,
+        sizeMl: Number.NaN,
+      }),
+    ).rejects.toThrowError("sizeMl must be a finite number.");
   });
 
   test("null sizeMl does not trigger the >0 validation guard", async () => {

--- a/my-app/convex/bottles.ts
+++ b/my-app/convex/bottles.ts
@@ -22,8 +22,13 @@ function assertValidBottleInput(args: {
   tags?: string[] | null;
   sizeMl?: number | null;
 }) {
-  if (args.name !== undefined && args.name.length > MAX_NAME_LENGTH) {
-    throw new Error(`Name must be at most ${MAX_NAME_LENGTH} characters.`);
+  if (args.name !== undefined) {
+    if (args.name.trim().length === 0) {
+      throw new Error("Name is required.");
+    }
+    if (args.name.length > MAX_NAME_LENGTH) {
+      throw new Error(`Name must be at most ${MAX_NAME_LENGTH} characters.`);
+    }
   }
   if (args.brand && args.brand.length > MAX_BRAND_LENGTH) {
     throw new Error(`Brand must be at most ${MAX_BRAND_LENGTH} characters.`);
@@ -39,8 +44,16 @@ function assertValidBottleInput(args: {
       throw new Error(`Each tag must be at most ${MAX_TAG_LENGTH} characters.`);
     }
   }
-  if (args.sizeMl !== undefined && args.sizeMl !== null && args.sizeMl > MAX_SIZE_ML) {
-    throw new Error(`Size must be at most ${MAX_SIZE_ML} mL.`);
+  if (args.sizeMl !== undefined && args.sizeMl !== null) {
+    if (!Number.isFinite(args.sizeMl)) {
+      throw new Error("sizeMl must be a finite number.");
+    }
+    if (args.sizeMl <= 0) {
+      throw new Error("sizeMl must be greater than 0.");
+    }
+    if (args.sizeMl > MAX_SIZE_ML) {
+      throw new Error(`Size must be at most ${MAX_SIZE_ML} mL.`);
+    }
   }
 }
 
@@ -87,9 +100,6 @@ export const addBottle = mutation({
     comments: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    if (args.sizeMl !== undefined && args.sizeMl <= 0) {
-      throw new Error("sizeMl must be greater than 0.");
-    }
     assertValidBottleInput(args);
 
     const userId = await getUserId(ctx);
@@ -122,10 +132,6 @@ export const updateBottle = mutation({
     await rateLimiter.limit(ctx, "updateBottle", { key: userId, throws: true });
     await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
 
-    // Validate sizeMl when a real value (not a clear) is being set.
-    if (args.sizeMl !== undefined && args.sizeMl !== null && args.sizeMl <= 0) {
-      throw new Error("sizeMl must be greater than 0.");
-    }
     assertValidBottleInput(args);
 
     await ctx.db.patch(args.bottleId, {

--- a/my-app/convex/wearLogs.test.ts
+++ b/my-app/convex/wearLogs.test.ts
@@ -599,6 +599,33 @@ describe("update semantics (null clears, undefined preserves)", () => {
 // ── P2: Validation boundaries ───────────────────────────────────────────────
 
 describe("validation", () => {
+  test("NaN wornAt is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    const bottleId = await addBottle(user.as);
+    await expect(
+      user.as.mutation(api.wearLogs.addWearLog, {
+        bottleId,
+        wornAt: Number.NaN,
+        sprays: 1,
+      }),
+    ).rejects.toThrowError("wornAt must be a finite number.");
+  });
+
+  test("NaN rating is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    const bottleId = await addBottle(user.as);
+    await expect(
+      user.as.mutation(api.wearLogs.addWearLog, {
+        bottleId,
+        wornAt: Date.now(),
+        sprays: 1,
+        rating: Number.NaN,
+      }),
+    ).rejects.toThrowError("rating must be a finite number.");
+  });
+
   test("sprays of 0 is rejected", async () => {
     const t = setupTest();
     const user = await createTestUser(t);
@@ -827,6 +854,40 @@ describe("validation", () => {
 // ── P2: updateWearLog validation ─────────────────────────────────────────────
 
 describe("updateWearLog validation", () => {
+  test("NaN wornAt is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    const bottleId = await addBottle(user.as);
+    const logId = await user.as.mutation(api.wearLogs.addWearLog, {
+      bottleId,
+      wornAt: Date.now(),
+      sprays: 1,
+    });
+    await expect(
+      user.as.mutation(api.wearLogs.updateWearLog, {
+        wearLogId: logId,
+        wornAt: Number.NaN,
+      }),
+    ).rejects.toThrowError("wornAt must be a finite number.");
+  });
+
+  test("NaN rating is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    const bottleId = await addBottle(user.as);
+    const logId = await user.as.mutation(api.wearLogs.addWearLog, {
+      bottleId,
+      wornAt: Date.now(),
+      sprays: 1,
+    });
+    await expect(
+      user.as.mutation(api.wearLogs.updateWearLog, {
+        wearLogId: logId,
+        rating: Number.NaN,
+      }),
+    ).rejects.toThrowError("rating must be a finite number.");
+  });
+
   test("sprays of 0 is rejected", async () => {
     const t = setupTest();
     const user = await createTestUser(t);

--- a/my-app/convex/wearLogs.ts
+++ b/my-app/convex/wearLogs.ts
@@ -113,6 +113,9 @@ export const getWearLog = query({
 // ── Validation helpers ────────────────────────────────────────────────────────
 
 function assertValidWornAt(wornAt: number): void {
+  if (!Number.isFinite(wornAt)) {
+    throw new Error("wornAt must be a finite number.");
+  }
   if (wornAt <= 0) {
     throw new Error("wornAt must be a positive Unix timestamp (ms).");
   }
@@ -131,6 +134,9 @@ function assertValidSprays(sprays: number): void {
 }
 
 function assertValidRating(rating: number): void {
+  if (!Number.isFinite(rating)) {
+    throw new Error("rating must be a finite number.");
+  }
   if (rating < 1 || rating > 10) {
     throw new Error("rating must be between 1 and 10 inclusive.");
   }


### PR DESCRIPTION
## Summary

- reject blank bottle names at the backend boundary
- reject non-finite bottle sizes, wear timestamps, and ratings before range checks
- keep create and update behavior aligned through shared validation helpers

## Why

Convex numeric validators accept IEEE-754 special values. `NaN` bypassed the existing relational checks and could persist into indexed fields or poison rating aggregates. Direct API clients could also bypass the UI's required-name check.

## Validation

- focused red/green regression run: 8 failures before the fix, 110/110 passing after
- `bun run test:run` (17 files, 172 tests)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check`

## Scope

Backend validation and focused regression coverage only. No schema or UI changes.
