### PR TITLE
Harden Convex response contracts

### DIFF
--- a/my-app/convex/bottles.ts
+++ b/my-app/convex/bottles.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
 import { rateLimiter } from "./rateLimits";
 import { buildPatch } from "./patch";
+import { bottleDocValidator } from "./validators";
 
 // ── Validation helpers ────────────────────────────────────────────────────────
 // HTML min/max attributes are client-side only and trivially bypassed, so we
@@ -61,6 +62,7 @@ function assertValidBottleInput(args: {
 
 export const listBottles = query({
   args: {},
+  returns: v.array(bottleDocValidator),
   handler: async (ctx) => {
     const userId = await getOptionalUserId(ctx);
     if (userId === null) {
@@ -77,6 +79,7 @@ export const listBottles = query({
 
 export const getBottle = query({
   args: { bottleId: v.id("bottles") },
+  returns: v.union(bottleDocValidator, v.null()),
   handler: async (ctx, args) => {
     const userId = await getOptionalUserId(ctx);
     if (userId === null) {
@@ -99,6 +102,7 @@ export const addBottle = mutation({
     tags: v.optional(v.array(v.string())),
     comments: v.optional(v.string()),
   },
+  returns: v.id("bottles"),
   handler: async (ctx, args) => {
     assertValidBottleInput(args);
 
@@ -127,6 +131,7 @@ export const updateBottle = mutation({
     tags: v.optional(v.union(v.array(v.string()), v.null())),
     comments: v.optional(v.union(v.string(), v.null())),
   },
+  returns: v.null(),
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "updateBottle", { key: userId, throws: true });
@@ -144,11 +149,13 @@ export const updateBottle = mutation({
       }),
       updatedAt: Date.now(),
     });
+    return null;
   },
 });
 
 export const deleteBottle = mutation({
   args: { bottleId: v.id("bottles") },
+  returns: v.null(),
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "deleteBottle", { key: userId, throws: true });
@@ -164,11 +171,13 @@ export const deleteBottle = mutation({
     await Promise.all(orphanedLogs.map((log) => ctx.db.delete(log._id)));
 
     await ctx.db.delete(args.bottleId);
+    return null;
   },
 });
 
 export const toggleFavorite = mutation({
   args: { bottleId: v.id("bottles") },
+  returns: v.null(),
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "toggleFavorite", {
@@ -183,5 +192,6 @@ export const toggleFavorite = mutation({
     await ctx.db.patch(args.bottleId, {
       isFavorite: !(bottle.isFavorite ?? false),
     });
+    return null;
   },
 });

--- a/my-app/convex/users.test.ts
+++ b/my-app/convex/users.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import { setupTest } from "./test.setup";
+
+describe("currentUser", () => {
+  test("returns null without an authenticated user", async () => {
+    const t = setupTest();
+
+    expect(await t.query(api.users.currentUser)).toBeNull();
+  });
+
+  test("returns only the public profile fields", async () => {
+    const t = setupTest();
+    const userId = await t.run(async (ctx) => {
+      return await ctx.db.insert("users", {
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        phone: "+15555550123",
+      });
+    });
+    const asUser = t.withIdentity({ subject: `${userId}|testSession` });
+
+    const result = await asUser.query(api.users.currentUser);
+
+    expect(result).toEqual({
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+    });
+    expect(result).not.toHaveProperty("phone");
+    expect(result).not.toHaveProperty("_id");
+    expect(result).not.toHaveProperty("_creationTime");
+  });
+});

--- a/my-app/convex/users.ts
+++ b/my-app/convex/users.ts
@@ -1,14 +1,34 @@
 import { getAuthUserId } from "@convex-dev/auth/server";
+import { v } from "convex/values";
 import { query } from "./_generated/server";
 
 export const currentUser = query({
   args: {},
+  returns: v.union(
+    v.object({
+      name: v.optional(v.string()),
+      email: v.optional(v.string()),
+    }),
+    v.null(),
+  ),
   handler: async (ctx) => {
     const userId = await getAuthUserId(ctx);
     if (userId === null) {
       return null;
     }
 
-    return await ctx.db.get(userId);
+    const user = await ctx.db.get(userId);
+    if (user === null) {
+      return null;
+    }
+
+    const profile: { name?: string; email?: string } = {};
+    if (user.name !== undefined) {
+      profile.name = user.name;
+    }
+    if (user.email !== undefined) {
+      profile.email = user.email;
+    }
+    return profile;
   },
 });

--- a/my-app/convex/validators.ts
+++ b/my-app/convex/validators.ts
@@ -1,0 +1,33 @@
+import { v } from "convex/values";
+
+export const bottleDocValidator = v.object({
+  _id: v.id("bottles"),
+  _creationTime: v.number(),
+  userId: v.id("users"),
+  name: v.string(),
+  brand: v.optional(v.string()),
+  sizeMl: v.optional(v.number()),
+  tags: v.optional(v.array(v.string())),
+  comments: v.optional(v.string()),
+  isFavorite: v.optional(v.boolean()),
+  createdAt: v.number(),
+  updatedAt: v.optional(v.number()),
+});
+
+export const wearLogDocValidator = v.object({
+  _id: v.id("wearLogs"),
+  _creationTime: v.number(),
+  userId: v.id("users"),
+  bottleId: v.id("bottles"),
+  wornAt: v.number(),
+  sprays: v.number(),
+  context: v.optional(v.string()),
+  rating: v.optional(v.number()),
+  comment: v.optional(v.string()),
+});
+
+export const bottleStatsValidator = v.object({
+  wears: v.number(),
+  sprays: v.number(),
+  avgRating: v.union(v.number(), v.null()),
+});

--- a/my-app/convex/wearLogs.ts
+++ b/my-app/convex/wearLogs.ts
@@ -4,6 +4,7 @@ import { getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
 import { rateLimiter } from "./rateLimits";
 import { MAX_SPRAYS } from "../src/lib/constants";
 import { buildPatch } from "./patch";
+import { bottleStatsValidator, wearLogDocValidator } from "./validators";
 
 // ── Validation constants ──────────────────────────────────────────────────────
 
@@ -15,6 +16,7 @@ const FUTURE_WORN_AT_TOLERANCE_MS = 60_000;
 
 export const listBottleStats = query({
   args: {},
+  returns: v.record(v.string(), bottleStatsValidator),
   handler: async (ctx) => {
     const userId = await getOptionalUserId(ctx);
     if (userId === null) {
@@ -62,6 +64,7 @@ export const listBottleStats = query({
 
 export const listWearLogs = query({
   args: {},
+  returns: v.array(wearLogDocValidator),
   handler: async (ctx) => {
     const userId = await getOptionalUserId(ctx);
     if (userId === null) {
@@ -79,6 +82,7 @@ export const listWearLogs = query({
 
 export const listWearLogsByBottle = query({
   args: { bottleId: v.id("bottles") },
+  returns: v.array(wearLogDocValidator),
   handler: async (ctx, args) => {
     const userId = await getOptionalUserId(ctx);
     if (userId === null) {
@@ -98,6 +102,7 @@ export const listWearLogsByBottle = query({
 
 export const getWearLog = query({
   args: { wearLogId: v.id("wearLogs") },
+  returns: v.union(wearLogDocValidator, v.null()),
   handler: async (ctx, args) => {
     const userId = await getOptionalUserId(ctx);
     if (userId === null) {
@@ -165,6 +170,7 @@ export const addWearLog = mutation({
     rating: v.optional(v.number()),
     comment: v.optional(v.string()),
   },
+  returns: v.id("wearLogs"),
   handler: async (ctx, args) => {
     assertValidWornAt(args.wornAt);
     assertValidSprays(args.sprays);
@@ -202,6 +208,7 @@ export const updateWearLog = mutation({
     rating: v.optional(v.union(v.number(), v.null())),
     comment: v.optional(v.union(v.string(), v.null())),
   },
+  returns: v.null(),
   handler: async (ctx, args) => {
     // Run validation before the ownership check so the error is clear even
     // in cases where the log is not found.
@@ -226,15 +233,18 @@ export const updateWearLog = mutation({
         comment: args.comment,
       }),
     );
+    return null;
   },
 });
 
 export const deleteWearLog = mutation({
   args: { wearLogId: v.id("wearLogs") },
+  returns: v.null(),
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "deleteWearLog", { key: userId, throws: true });
     await getOwnedDoc(ctx, "wearLogs", args.wearLogId, userId);
     await ctx.db.delete(args.wearLogId);
+    return null;
   },
 });


### PR DESCRIPTION
## Summary

- add explicit return validators to every custom public Convex query and mutation
- reuse schema-aligned validators for bottles, wear logs, and statistics
- return explicit `null` from void mutations
- minimize `currentUser` to the `name` and `email` fields consumed by the UI

## Why

Explicit response contracts prevent accidental data-shape drift and keep backend responses within reviewed boundaries. The previous `currentUser` query returned the complete auth user document, including fields the client did not need.

## Validation

- focused Convex tests (112/112)
- full suite (18 files, 174 tests)
- application and Convex TypeScript checks
- ESLint
- Prettier
- `git diff --check`
- independent review found no issues

## Scope

Backend response contracts and focused data-minimization coverage only. No schema migration or UI behavior change.
