### PR TITLE
Batch cascading bottle deletion

### DIFF
--- a/my-app/convex/bottles.test.ts
+++ b/my-app/convex/bottles.test.ts
@@ -1,5 +1,5 @@
-import { expect, test, describe } from "vitest";
-import { api } from "./_generated/api";
+import { expect, test, describe, vi } from "vitest";
+import { api, internal } from "./_generated/api";
 import { setupTest, createTestUser } from "./test.setup";
 
 // ── P0: Auth enforcement ────────────────────────────────────────────────────
@@ -228,81 +228,264 @@ describe("updateBottle", () => {
 });
 
 describe("deleteBottle", () => {
-  test("removes the bottle", async () => {
+  test("hides the bottle immediately", async () => {
     const t = setupTest();
     const user = await createTestUser(t);
     const bottleId = await user.as.mutation(api.bottles.addBottle, {
       name: "Doomed",
     });
 
-    await user.as.mutation(api.bottles.deleteBottle, { bottleId });
+    vi.useFakeTimers();
+    try {
+      await user.as.mutation(api.bottles.deleteBottle, { bottleId });
 
-    const bottle = await user.as.query(api.bottles.getBottle, { bottleId });
-    expect(bottle).toBeNull();
+      const bottle = await user.as.query(api.bottles.getBottle, { bottleId });
+      expect(bottle).toBeNull();
+      expect(await user.as.query(api.bottles.listBottles)).toEqual([]);
+
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+      const completedDeletion = await t.run(async (ctx) => ({
+        bottle: await ctx.db.get(bottleId),
+        failedJobs: (await ctx.db.system.query("_scheduled_functions").collect()).filter(
+          (job) => job.state.kind === "failed",
+        ),
+      }));
+      expect(completedDeletion.bottle).toBeNull();
+      expect(completedDeletion.failedJobs).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
 // ── P1: Cascade delete ──────────────────────────────────────────────────────
 
 describe("cascade delete", () => {
-  test("deleteBottle removes all associated wear logs", async () => {
+  test("cleans more than two batches without touching another bottle or its logs", async () => {
     const t = setupTest();
     const user = await createTestUser(t);
-    const bottleId = await user.as.mutation(api.bottles.addBottle, {
-      name: "Aventus",
+    const doomedBottleId = await user.as.mutation(api.bottles.addBottle, {
+      name: "Doomed",
+    });
+    const retainedBottleId = await user.as.mutation(api.bottles.addBottle, {
+      name: "Retained",
+    });
+    const now = Date.now();
+    const { firstDoomedLogId, retainedLogId } = await t.run(async (ctx) => {
+      let firstDoomedLogId = null;
+      for (let index = 0; index < 205; index += 1) {
+        const logId = await ctx.db.insert("wearLogs", {
+          userId: user.userId,
+          bottleId: doomedBottleId,
+          wornAt: now - index,
+          sprays: 1,
+        });
+        firstDoomedLogId ??= logId;
+      }
+      const retainedLogId = await ctx.db.insert("wearLogs", {
+        userId: user.userId,
+        bottleId: retainedBottleId,
+        wornAt: now,
+        sprays: 2,
+      });
+      return { firstDoomedLogId: firstDoomedLogId!, retainedLogId };
     });
 
-    await user.as.mutation(api.wearLogs.addWearLog, {
-      bottleId,
-      wornAt: Date.now(),
-      sprays: 3,
-    });
-    await user.as.mutation(api.wearLogs.addWearLog, {
-      bottleId,
-      wornAt: Date.now(),
-      sprays: 2,
-    });
+    vi.useFakeTimers();
+    try {
+      expect(
+        await user.as.mutation(api.bottles.deleteBottle, {
+          bottleId: doomedBottleId,
+        }),
+      ).toBeNull();
 
-    await user.as.mutation(api.bottles.deleteBottle, { bottleId });
+      expect(await user.as.query(api.bottles.getBottle, { bottleId: doomedBottleId })).toBeNull();
+      expect((await user.as.query(api.bottles.listBottles)).map((bottle) => bottle._id)).toEqual([
+        retainedBottleId,
+      ]);
 
-    // Verify via direct DB access
-    const remainingLogs = await t.run(async (ctx) => {
-      return await ctx.db
-        .query("wearLogs")
-        .withIndex("by_bottle", (q) => q.eq("bottleId", bottleId))
-        .collect();
-    });
-    expect(remainingLogs).toHaveLength(0);
+      const pendingCleanup = await t.run(async (ctx) => ({
+        bottle: await ctx.db.get(doomedBottleId),
+        logs: await ctx.db
+          .query("wearLogs")
+          .withIndex("by_bottle", (q) => q.eq("bottleId", doomedBottleId))
+          .collect(),
+        pendingJobs: (await ctx.db.system.query("_scheduled_functions").collect()).filter(
+          (job) => job.state.kind === "pending",
+        ).length,
+      }));
+      expect(pendingCleanup.bottle?.deletingAt).toBeTypeOf("number");
+      expect(pendingCleanup.bottle?.cleanupJobId).toBeDefined();
+      expect(pendingCleanup.logs).toHaveLength(205);
+      expect(
+        await user.as.query(api.wearLogs.listWearLogsByBottle, {
+          bottleId: doomedBottleId,
+        }),
+      ).toEqual([]);
+      expect(
+        await user.as.query(api.wearLogs.getWearLog, {
+          wearLogId: firstDoomedLogId,
+        }),
+      ).toBeNull();
+      const visibleLogs = await user.as.query(api.wearLogs.listWearLogs);
+      expect(visibleLogs).toHaveLength(1);
+      expect(visibleLogs[0]._id).toBe(retainedLogId);
+      expect(await user.as.query(api.wearLogs.listBottleStats)).toEqual({
+        [retainedBottleId]: { wears: 1, sprays: 2, avgRating: null },
+      });
+
+      await expect(
+        user.as.mutation(api.bottles.updateBottle, {
+          bottleId: doomedBottleId,
+          name: "Too late",
+        }),
+      ).rejects.toThrowError("Bottle not found or access denied.");
+      await expect(
+        user.as.mutation(api.bottles.toggleFavorite, { bottleId: doomedBottleId }),
+      ).rejects.toThrowError("Bottle not found or access denied.");
+      await expect(
+        user.as.mutation(api.wearLogs.addWearLog, {
+          bottleId: doomedBottleId,
+          wornAt: now,
+          sprays: 1,
+        }),
+      ).rejects.toThrowError("Bottle not found or access denied.");
+      await expect(
+        user.as.mutation(api.wearLogs.updateWearLog, {
+          wearLogId: firstDoomedLogId,
+          sprays: 2,
+        }),
+      ).rejects.toThrowError("Bottle not found or access denied.");
+
+      // Pending retries are true no-ops, including beyond the limiter's burst
+      // capacity, and keep pointing at the same cleanup job.
+      vi.setSystemTime(now + 1_000);
+      for (let retry = 0; retry < 5; retry += 1) {
+        expect(
+          await user.as.mutation(api.bottles.deleteBottle, {
+            bottleId: doomedBottleId,
+          }),
+        ).toBeNull();
+      }
+      const afterRetries = await t.run(async (ctx) => ({
+        bottle: await ctx.db.get(doomedBottleId),
+        pendingJobs: (await ctx.db.system.query("_scheduled_functions").collect()).filter(
+          (job) => job.state.kind === "pending",
+        ).length,
+      }));
+      expect(afterRetries.bottle?.deletingAt).toBe(pendingCleanup.bottle?.deletingAt);
+      expect(afterRetries.bottle?.cleanupJobId).toBe(pendingCleanup.bottle?.cleanupJobId);
+      expect(afterRetries.pendingJobs).toBe(pendingCleanup.pendingJobs);
+
+      // The delayed watchdog repairs terminally canceled work without another
+      // public delete call or removing the tombstone.
+      await t.run(async (ctx) => {
+        await ctx.scheduler.cancel(pendingCleanup.bottle!.cleanupJobId!);
+      });
+      vi.advanceTimersByTime(5 * 60 * 1000);
+      await t.finishInProgressScheduledFunctions();
+      const afterRepair = await t.run(async (ctx) => ctx.db.get(doomedBottleId));
+      expect(afterRepair?.cleanupJobId).toBeDefined();
+      expect(afterRepair?.cleanupJobId).not.toBe(pendingCleanup.bottle?.cleanupJobId);
+
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+      const completedCleanup = await t.run(async (ctx) => ({
+        bottle: await ctx.db.get(doomedBottleId),
+        doomedLogs: await ctx.db
+          .query("wearLogs")
+          .withIndex("by_bottle", (q) => q.eq("bottleId", doomedBottleId))
+          .collect(),
+        retainedBottle: await ctx.db.get(retainedBottleId),
+        retainedLog: await ctx.db.get(retainedLogId),
+        scheduledFunctions: await ctx.db.system.query("_scheduled_functions").collect(),
+      }));
+      expect(completedCleanup.bottle).toBeNull();
+      expect(completedCleanup.doomedLogs).toEqual([]);
+      expect(completedCleanup.retainedBottle?.name).toBe("Retained");
+      expect(completedCleanup.retainedLog?.bottleId).toBe(retainedBottleId);
+      expect(
+        completedCleanup.scheduledFunctions.filter((job) => job.state.kind === "failed"),
+      ).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  test("deleteBottle does NOT remove other bottles' wear logs", async () => {
+  test("internal cleanup enforces ownership and a strict 50-log batch boundary", async () => {
     const t = setupTest();
-    const user = await createTestUser(t);
-    const bottleA = await user.as.mutation(api.bottles.addBottle, {
-      name: "Bottle A",
-    });
-    const bottleB = await user.as.mutation(api.bottles.addBottle, {
-      name: "Bottle B",
+    const owner = await createTestUser(t, "Owner");
+    const otherUser = await createTestUser(t, "Other");
+    const deletingAt = Date.now();
+    const bottleId = await t.run(async (ctx) => {
+      const id = await ctx.db.insert("bottles", {
+        userId: owner.userId,
+        name: "Boundary",
+        createdAt: deletingAt,
+        deletingAt,
+      });
+      for (let index = 0; index < 51; index += 1) {
+        await ctx.db.insert("wearLogs", {
+          userId: owner.userId,
+          bottleId: id,
+          wornAt: deletingAt - index,
+          sprays: 1,
+        });
+      }
+      return id;
     });
 
-    await user.as.mutation(api.wearLogs.addWearLog, {
-      bottleId: bottleA,
-      wornAt: Date.now(),
-      sprays: 1,
-    });
-    await user.as.mutation(api.wearLogs.addWearLog, {
-      bottleId: bottleB,
-      wornAt: Date.now(),
-      sprays: 2,
-    });
+    const args = {
+      bottleId,
+      expectedUserId: owner.userId,
+      expectedDeletingAt: deletingAt,
+    };
+    vi.useFakeTimers();
+    try {
+      expect(
+        await t.mutation(internal.bottles.deleteBottleBatch, {
+          ...args,
+          expectedUserId: otherUser.userId,
+        }),
+      ).toBeNull();
+      expect(
+        await t.run(async (ctx) =>
+          ctx.db
+            .query("wearLogs")
+            .withIndex("by_bottle", (q) => q.eq("bottleId", bottleId))
+            .collect(),
+        ),
+      ).toHaveLength(51);
 
-    await user.as.mutation(api.bottles.deleteBottle, { bottleId: bottleA });
+      expect(await t.mutation(internal.bottles.deleteBottleBatch, args)).toBeNull();
+      const afterFirstBatch = await t.run(async (ctx) => ({
+        bottle: await ctx.db.get(bottleId),
+        logs: await ctx.db
+          .query("wearLogs")
+          .withIndex("by_bottle", (q) => q.eq("bottleId", bottleId))
+          .collect(),
+      }));
+      expect(afterFirstBatch.bottle).not.toBeNull();
+      expect(afterFirstBatch.logs).toHaveLength(1);
 
-    const bottleBLogs = await user.as.query(api.wearLogs.listWearLogsByBottle, {
-      bottleId: bottleB,
-    });
-    expect(bottleBLogs).toHaveLength(1);
-    expect(bottleBLogs[0].sprays).toBe(2);
+      expect(await t.mutation(internal.bottles.deleteBottleBatch, args)).toBeNull();
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+      const afterSecondBatch = await t.run(async (ctx) => ({
+        bottle: await ctx.db.get(bottleId),
+        logs: await ctx.db
+          .query("wearLogs")
+          .withIndex("by_bottle", (q) => q.eq("bottleId", bottleId))
+          .collect(),
+        failedJobs: (await ctx.db.system.query("_scheduled_functions").collect()).filter(
+          (job) => job.state.kind === "failed",
+        ),
+      }));
+      expect(afterSecondBatch.bottle).toBeNull();
+      expect(afterSecondBatch.logs).toEqual([]);
+      expect(afterSecondBatch.failedJobs).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/my-app/convex/bottles.ts
+++ b/my-app/convex/bottles.ts
@@ -1,6 +1,7 @@
-import { mutation, query } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { internalMutation, mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import { getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
+import { getActiveOwnedBottle, getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
 import { rateLimiter } from "./rateLimits";
 import { buildPatch } from "./patch";
 import { bottleDocValidator } from "./validators";
@@ -15,6 +16,8 @@ const MAX_COMMENTS_LENGTH = 2000;
 const MAX_TAG_LENGTH = 50;
 const MAX_TAGS_COUNT = 20;
 const MAX_SIZE_ML = 10_000; // 10 litres ought to be enough for anybody
+const BOTTLE_DELETE_BATCH_SIZE = 50;
+const BOTTLE_DELETE_WATCHDOG_DELAY_MS = 5 * 60 * 1000;
 
 function assertValidBottleInput(args: {
   name?: string;
@@ -71,7 +74,9 @@ export const listBottles = query({
 
     return await ctx.db
       .query("bottles")
-      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .withIndex("by_user_and_deleting_at", (q) =>
+        q.eq("userId", userId).eq("deletingAt", undefined),
+      )
       .order("desc")
       .collect();
   },
@@ -87,7 +92,7 @@ export const getBottle = query({
     }
 
     const bottle = await ctx.db.get(args.bottleId);
-    if (!bottle || bottle.userId !== userId) return null;
+    if (!bottle || bottle.userId !== userId || bottle.deletingAt !== undefined) return null;
     return bottle;
   },
 });
@@ -135,7 +140,7 @@ export const updateBottle = mutation({
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "updateBottle", { key: userId, throws: true });
-    await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
+    await getActiveOwnedBottle(ctx, args.bottleId, userId);
 
     assertValidBottleInput(args);
 
@@ -158,19 +163,129 @@ export const deleteBottle = mutation({
   returns: v.null(),
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
-    await rateLimiter.limit(ctx, "deleteBottle", { key: userId, throws: true });
-    await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
+    const bottle = await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
+    if (bottle.deletingAt !== undefined) {
+      const cleanupJob = bottle.cleanupJobId
+        ? await ctx.db.system.get("_scheduled_functions", bottle.cleanupJobId)
+        : null;
+      if (cleanupJob?.state.kind === "pending" || cleanupJob?.state.kind === "inProgress") {
+        return null;
+      }
 
-    // Cascade-delete all wear logs that reference this bottle so no orphaned
-    // records are left behind after the bottle document is removed.
-    const orphanedLogs = await ctx.db
+      // A failed, canceled, completed-but-stale, or expired job record can be
+      // repaired by a later delete request without changing the tombstone.
+      await rateLimiter.limit(ctx, "deleteBottle", { key: userId, throws: true });
+      const cleanupJobId = await ctx.scheduler.runAfter(0, internal.bottles.deleteBottleBatch, {
+        bottleId: args.bottleId,
+        expectedUserId: userId,
+        expectedDeletingAt: bottle.deletingAt,
+      });
+      await ctx.db.patch(args.bottleId, { cleanupJobId });
+      return null;
+    }
+
+    await rateLimiter.limit(ctx, "deleteBottle", { key: userId, throws: true });
+    const deletingAt = Date.now();
+    const cleanupJobId = await ctx.scheduler.runAfter(0, internal.bottles.deleteBottleBatch, {
+      bottleId: args.bottleId,
+      expectedUserId: userId,
+      expectedDeletingAt: deletingAt,
+    });
+    await ctx.scheduler.runAfter(
+      BOTTLE_DELETE_WATCHDOG_DELAY_MS,
+      internal.bottles.watchBottleDeletion,
+      {
+        bottleId: args.bottleId,
+        expectedUserId: userId,
+        expectedDeletingAt: deletingAt,
+      },
+    );
+    await ctx.db.patch(args.bottleId, { deletingAt, cleanupJobId });
+    return null;
+  },
+});
+
+/**
+ * Removes one bounded batch of a bottle's children, then schedules the next
+ * batch. The expected owner and tombstone make stale or misrouted jobs no-op;
+ * the parent is only removed after no children remain.
+ */
+export const deleteBottleBatch = internalMutation({
+  args: {
+    bottleId: v.id("bottles"),
+    expectedUserId: v.id("users"),
+    expectedDeletingAt: v.number(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const bottle = await ctx.db.get(args.bottleId);
+    if (
+      !bottle ||
+      bottle.userId !== args.expectedUserId ||
+      bottle.deletingAt !== args.expectedDeletingAt
+    ) {
+      return null;
+    }
+
+    const logs = await ctx.db
       .query("wearLogs")
       .withIndex("by_bottle", (q) => q.eq("bottleId", args.bottleId))
-      .collect();
+      .take(BOTTLE_DELETE_BATCH_SIZE);
+    await Promise.all(logs.map((log) => ctx.db.delete(log._id)));
 
-    await Promise.all(orphanedLogs.map((log) => ctx.db.delete(log._id)));
+    if (logs.length === BOTTLE_DELETE_BATCH_SIZE) {
+      const cleanupJobId = await ctx.scheduler.runAfter(
+        0,
+        internal.bottles.deleteBottleBatch,
+        args,
+      );
+      await ctx.db.patch(args.bottleId, { cleanupJobId });
+    } else {
+      await ctx.db.delete(args.bottleId);
+    }
+    return null;
+  },
+});
 
-    await ctx.db.delete(args.bottleId);
+/**
+ * Maintains one delayed recovery chain for each tombstone. Active cleanup is
+ * left alone; terminal or missing work is replaced. Once the parent is gone or
+ * the nonce no longer matches, the chain stops without touching data.
+ */
+export const watchBottleDeletion = internalMutation({
+  args: {
+    bottleId: v.id("bottles"),
+    expectedUserId: v.id("users"),
+    expectedDeletingAt: v.number(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const bottle = await ctx.db.get(args.bottleId);
+    if (
+      !bottle ||
+      bottle.userId !== args.expectedUserId ||
+      bottle.deletingAt !== args.expectedDeletingAt
+    ) {
+      return null;
+    }
+
+    const cleanupJob = bottle.cleanupJobId
+      ? await ctx.db.system.get("_scheduled_functions", bottle.cleanupJobId)
+      : null;
+    if (cleanupJob?.state.kind !== "pending" && cleanupJob?.state.kind !== "inProgress") {
+      const cleanupJobId = await ctx.scheduler.runAfter(
+        0,
+        internal.bottles.deleteBottleBatch,
+        args,
+      );
+      await ctx.db.patch(args.bottleId, { cleanupJobId });
+    }
+
+    await ctx.scheduler.runAfter(
+      BOTTLE_DELETE_WATCHDOG_DELAY_MS,
+      internal.bottles.watchBottleDeletion,
+      args,
+    );
     return null;
   },
 });
@@ -185,7 +300,7 @@ export const toggleFavorite = mutation({
       throws: true,
     });
 
-    const bottle = await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
+    const bottle = await getActiveOwnedBottle(ctx, args.bottleId, userId);
 
     // Intentionally do NOT touch updatedAt — favoriting is metadata, not a
     // content edit. Keeps any future "last modified" view honest.

--- a/my-app/convex/helpers.ts
+++ b/my-app/convex/helpers.ts
@@ -41,3 +41,20 @@ export async function getOwnedDoc<T extends OwnedTable>(
   }
   return doc as unknown as Doc<T>;
 }
+
+/**
+ * Fetches an owned bottle that is still active. Tombstoned bottles use the
+ * same ownership-safe error as missing and foreign bottles so background
+ * deletion state never expands the public information surface.
+ */
+export async function getActiveOwnedBottle(
+  ctx: QueryCtx | MutationCtx,
+  bottleId: Id<"bottles">,
+  userId: Id<"users">,
+): Promise<Doc<"bottles">> {
+  const bottle = await getOwnedDoc(ctx, "bottles", bottleId, userId);
+  if (bottle.deletingAt !== undefined) {
+    throw new Error("Bottle not found or access denied.");
+  }
+  return bottle;
+}

--- a/my-app/convex/schema.ts
+++ b/my-app/convex/schema.ts
@@ -17,9 +17,16 @@ export default defineSchema({
 
     isFavorite: v.optional(v.boolean()),
 
+    // A tombstone makes deletion immediate to readers while the associated
+    // wear logs are removed in bounded background batches.
+    deletingAt: v.optional(v.number()),
+    cleanupJobId: v.optional(v.id("_scheduled_functions")),
+
     createdAt: v.number(),
     updatedAt: v.optional(v.number()),
-  }).index("by_user", ["userId"]),
+  })
+    .index("by_user", ["userId"])
+    .index("by_user_and_deleting_at", ["userId", "deletingAt"]),
 
   wearLogs: defineTable({
     userId: v.id("users"),

--- a/my-app/convex/validators.ts
+++ b/my-app/convex/validators.ts
@@ -10,6 +10,8 @@ export const bottleDocValidator = v.object({
   tags: v.optional(v.array(v.string())),
   comments: v.optional(v.string()),
   isFavorite: v.optional(v.boolean()),
+  deletingAt: v.optional(v.number()),
+  cleanupJobId: v.optional(v.id("_scheduled_functions")),
   createdAt: v.number(),
   updatedAt: v.optional(v.number()),
 });

--- a/my-app/convex/wearLogs.test.ts
+++ b/my-app/convex/wearLogs.test.ts
@@ -229,15 +229,22 @@ describe("cross-table integrity", () => {
     const t = setupTest();
     const user = await createTestUser(t);
     const bottleId = await addBottle(user.as);
-    await user.as.mutation(api.bottles.deleteBottle, { bottleId });
+    vi.useFakeTimers();
+    try {
+      await user.as.mutation(api.bottles.deleteBottle, { bottleId });
 
-    await expect(
-      user.as.mutation(api.wearLogs.addWearLog, {
-        bottleId,
-        wornAt: Date.now(),
-        sprays: 1,
-      }),
-    ).rejects.toThrowError("Bottle not found or access denied.");
+      await expect(
+        user.as.mutation(api.wearLogs.addWearLog, {
+          bottleId,
+          wornAt: Date.now(),
+          sprays: 1,
+        }),
+      ).rejects.toThrowError("Bottle not found or access denied.");
+
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/my-app/convex/wearLogs.ts
+++ b/my-app/convex/wearLogs.ts
@@ -1,6 +1,6 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import { getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
+import { getActiveOwnedBottle, getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
 import { rateLimiter } from "./rateLimits";
 import { MAX_SPRAYS } from "../src/lib/constants";
 import { buildPatch } from "./patch";
@@ -23,10 +23,17 @@ export const listBottleStats = query({
       return {};
     }
 
-    const logs = await ctx.db
-      .query("wearLogs")
-      .withIndex("by_user", (q) => q.eq("userId", userId))
-      .collect();
+    const [logs, deletingBottles] = await Promise.all([
+      ctx.db
+        .query("wearLogs")
+        .withIndex("by_user", (q) => q.eq("userId", userId))
+        .collect(),
+      ctx.db
+        .query("bottles")
+        .withIndex("by_user_and_deleting_at", (q) => q.eq("userId", userId).gt("deletingAt", 0))
+        .collect(),
+    ]);
+    const deletingBottleIds = new Set(deletingBottles.map((bottle) => bottle._id));
     // Aggregate wear count, spray totals, and average rating per bottle
     // server-side so the collection view never needs to download the full
     // wear-log history.
@@ -35,6 +42,7 @@ export const listBottleStats = query({
       { wears: number; sprays: number; ratingSum: number; ratingCount: number }
     >();
     for (const log of logs) {
+      if (deletingBottleIds.has(log.bottleId)) continue;
       const existing = stats.get(log.bottleId) ?? {
         wears: 0,
         sprays: 0,
@@ -71,12 +79,19 @@ export const listWearLogs = query({
       return [];
     }
 
-    // Uses the by_user_time index so results arrive sorted by wornAt.
-    return await ctx.db
-      .query("wearLogs")
-      .withIndex("by_user_time", (q) => q.eq("userId", userId))
-      .order("desc")
-      .collect();
+    const [logs, deletingBottles] = await Promise.all([
+      ctx.db
+        .query("wearLogs")
+        .withIndex("by_user_time", (q) => q.eq("userId", userId))
+        .order("desc")
+        .collect(),
+      ctx.db
+        .query("bottles")
+        .withIndex("by_user_and_deleting_at", (q) => q.eq("userId", userId).gt("deletingAt", 0))
+        .collect(),
+    ]);
+    const deletingBottleIds = new Set(deletingBottles.map((bottle) => bottle._id));
+    return logs.filter((log) => !deletingBottleIds.has(log.bottleId));
   },
 });
 
@@ -86,6 +101,11 @@ export const listWearLogsByBottle = query({
   handler: async (ctx, args) => {
     const userId = await getOptionalUserId(ctx);
     if (userId === null) {
+      return [];
+    }
+
+    const bottle = await ctx.db.get(args.bottleId);
+    if (!bottle || bottle.userId !== userId || bottle.deletingAt !== undefined) {
       return [];
     }
 
@@ -111,6 +131,8 @@ export const getWearLog = query({
 
     const log = await ctx.db.get(args.wearLogId);
     if (!log || log.userId !== userId) return null;
+    const bottle = await ctx.db.get(log.bottleId);
+    if (!bottle || bottle.userId !== userId || bottle.deletingAt !== undefined) return null;
     return log;
   },
 });
@@ -179,8 +201,8 @@ export const addWearLog = mutation({
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "addWearLog", { key: userId, throws: true });
 
-    // Verify the bottle belongs to this user.
-    await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
+    // Verify the bottle belongs to this user and is not being deleted.
+    await getActiveOwnedBottle(ctx, args.bottleId, userId);
 
     // Validate string lengths server-side (HTML max is client-only).
     assertValidWearLogStrings(args);
@@ -218,7 +240,12 @@ export const updateWearLog = mutation({
 
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "updateWearLog", { key: userId, throws: true });
-    await getOwnedDoc(ctx, "wearLogs", args.wearLogId, userId);
+    const log = await getOwnedDoc(ctx, "wearLogs", args.wearLogId, userId);
+
+    // Updates to a child that is already scheduled for deletion are rejected:
+    // the change would never become durable user-visible state. Deletes remain
+    // allowed and safely reduce the cleanup worker's remaining batch.
+    await getActiveOwnedBottle(ctx, log.bottleId, userId);
 
     // Validate string lengths server-side.
     assertValidWearLogStrings(args);


### PR DESCRIPTION
## Summary

- replace the unbounded transactional bottle cascade with indexed 50-row internal batches
- hide a bottle and all related public wear-log/stat reads immediately through a deletion tombstone
- make retries idempotent by tracking the active cleanup job
- add a bounded five-minute watchdog that repairs canceled, failed, or stale cleanup jobs
- prevent updates and new logs once deletion begins; delete the parent only after its children

## Why

The previous mutation collected and deleted every child log in one transaction. A sufficiently large valid history could exceed Convex read/write limits, permanently preventing deletion. Because the rate limiter participated in the failed transaction, its debit also rolled back and allowed repeated maximum-cost retries.

## Correctness and safety

- internal-only worker validates the expected owner and tombstone nonce
- stale or misrouted jobs safely no-op
- pending public retries do not create duplicate worker chains or spend rate-limit tokens
- the watchdog uses a five-minute interval to avoid hot retry loops
- unrelated bottles and logs are isolated

## Validation

- full suite: 18 files, 174 tests
- focused backend suite: 110 tests
- explicit 205-child cleanup across five batches
- exact 50/51 boundary and mismatched-owner worker coverage
- cancellation recovery and failed-scheduled-job assertions
- independent resource-limit run with `documentsWritten=60`
- application and Convex TypeScript checks
- Convex dry-run codegen/typecheck
- ESLint and Prettier
- Next.js production build
- `bun audit --json` (clean)
- `git diff --check`

## Scope

This fixes destructive-path boundedness and deletion visibility. Broader pagination and materialized-statistics work remains separate because it requires coordinated query/UI semantics and a data backfill.
