### PR TITLE
Integrate backend security and data-safety fixes

### DIFF
--- a/my-app/bun.lock
+++ b/my-app/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "my-app",
       "dependencies": {
-        "@auth/core": "0.37.0",
-        "@convex-dev/auth": "^0.0.91",
+        "@auth/core": "0.41.3",
+        "@convex-dev/auth": "^0.0.95",
         "@convex-dev/rate-limiter": "^0.3.2",
         "@radix-ui/react-dialog": "^1.1.17",
         "@radix-ui/react-dropdown-menu": "^2.1.18",
@@ -21,7 +21,7 @@
         "clsx": "^2.1.1",
         "convex": "^1.42.0",
         "lucide-react": "^0.577.0",
-        "next": "16.2.6",
+        "next": "16.3.0",
         "next-themes": "^0.4.6",
         "postcss": "^8.5.16",
         "react": "19.2.3",
@@ -42,7 +42,7 @@
         "@types/react-dom": "^19.2.3",
         "convex-test": "^0.0.47",
         "eslint": "^9.39.4",
-        "eslint-config-next": "16.2.6",
+        "eslint-config-next": "16.3.0",
         "jsdom": "^29.1.1",
         "prettier": "^3.9.1",
         "typescript": "^5.9.3",
@@ -56,12 +56,12 @@
   ],
   "overrides": {
     "@babel/core": "7.29.7",
-    "brace-expansion": "^1.1.13",
+    "brace-expansion": "^1.1.18",
     "flatted": ">=3.4.2",
-    "js-yaml": "5.2.0",
+    "js-yaml": "5.2.3",
     "picomatch": ">=4.0.4",
-    "postcss": "8.5.16",
-    "undici": "7.28.0",
+    "postcss": "8.5.26",
+    "undici": "7.29.0",
     "vite": "8.1.0",
     "ws": "8.21.0",
   },
@@ -78,7 +78,7 @@
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
-    "@auth/core": ["@auth/core@0.37.0", "", { "dependencies": { "@panva/hkdf": "^1.2.1", "@types/cookie": "0.6.0", "cookie": "0.7.1", "jose": "^5.9.3", "oauth4webapi": "^3.0.0", "preact": "10.11.3", "preact-render-to-string": "5.2.3" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "nodemailer": "^6.8.0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-LybAgfFC5dta3Mu3al0UbnzMGVBpZRqLMvvXupQOfETtPNlL7rXgTO13EVRTCdvPqMQrVYjODUDvgVfQM1M3Qg=="],
+    "@auth/core": ["@auth/core@0.41.3", "", { "dependencies": { "@panva/hkdf": "^1.2.1", "jose": "^6.0.6", "oauth4webapi": "^3.3.0", "preact": "10.24.3", "preact-render-to-string": "6.5.11" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "nodemailer": "^7.0.7 || ^8.0.5" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -116,7 +116,7 @@
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
-    "@convex-dev/auth": ["@convex-dev/auth@0.0.91", "", { "dependencies": { "@oslojs/crypto": "^1.0.1", "@oslojs/encoding": "^1.1.0", "cookie": "^1.0.1", "is-network-error": "^1.1.0", "jose": "^5.2.2", "jwt-decode": "^4.0.0", "lucia": "^3.2.0", "oauth4webapi": "^3.1.2", "path-to-regexp": "^6.3.0", "server-only": "^0.0.1" }, "peerDependencies": { "@auth/core": "^0.37.0", "convex": "^1.17.0", "react": "^18.2.0 || ^19.0.0-0" }, "optionalPeers": ["react"], "bin": { "auth": "dist/bin.cjs" } }, "sha512-wLD4hszo3IhhMkwPs6ozWf0cUauwmhOvjUVn0g//kC338n/jApOjeDYWKCrn/qYUkveyDsbag5zrY8mVzA09Qg=="],
+    "@convex-dev/auth": ["@convex-dev/auth@0.0.95", "", { "dependencies": { "@oslojs/crypto": "^1.0.1", "@oslojs/encoding": "^1.1.0", "cookie": "^1.0.1", "is-network-error": "^1.1.0", "jose": "^5.2.2", "jwt-decode": "^4.0.0", "lucia": "^3.2.0", "oauth4webapi": "^3.1.2", "path-to-regexp": "^6.3.0", "server-only": "^0.0.1" }, "peerDependencies": { "@auth/core": "^0.41.1", "convex": "^1.17.0", "react": "^18.2.0 || ^19.0.0-0" }, "optionalPeers": ["react"], "bin": { "auth": "dist/bin.cjs" } }, "sha512-LgUujfXRm7FcdYpTozjn0MHdVFxaxvZdWVFOQEkrL4AkY+k/8E8B4EFjJOG9S8Pq6QWfLJ8MCObeMJg0hAfKzA=="],
 
     "@convex-dev/rate-limiter": ["@convex-dev/rate-limiter@0.3.2", "", { "peerDependencies": { "convex": "^1.24.8", "react": "^18.2.0 || ^19.0.0" }, "optionalPeers": ["react"] }, "sha512-+oBPsBfFbzdxiF/9XaaTQmVnvDlvEfg/c69/v8LxTbw4VLuiflIKlfnPQL8OS0azXQQ11hcPWHmU8ytFmHKDXA=="],
 
@@ -138,7 +138,7 @@
 
     "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
@@ -232,53 +232,57 @@
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.2" }, "os": "darwin", "cpu": "x64" }, "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "os": "freebsd" }, "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ=="],
 
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA=="],
 
-    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.2" }, "os": "linux", "cpu": "arm" }, "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA=="],
 
-    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ=="],
 
-    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.2" }, "os": "linux", "cpu": "ppc64" }, "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.2" }, "os": "linux", "cpu": "none" }, "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.2" }, "os": "linux", "cpu": "s390x" }, "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg=="],
 
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "cpu": "none" }, "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.3", "", { "os": "win32", "cpu": "x64" }, "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -292,25 +296,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@next/env": ["@next/env@16.2.6", "", {}, "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw=="],
+    "@next/env": ["@next/env@16.3.0", "", {}, "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw=="],
 
-    "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.2.6", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw=="],
+    "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.3.0", "", { "dependencies": { "@eslint-community/eslint-utils": "4.9.1", "fast-glob": "3.3.1" } }, "sha512-OqgJ8PN0d04KcPhDX/PTY5tJUJZxlbrt7O7FBsm4XE0XW2JDrKnDXsc9uo9WUimJGPoo2j+JRGhyXApC//mvbw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -484,8 +488,6 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
-    "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
-
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -638,7 +640,7 @@
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
-    "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+    "brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -688,7 +690,7 @@
 
     "convex-test": ["convex-test@0.0.47", "", { "peerDependencies": { "convex": "^1.32.0" } }, "sha512-EBJQ2Ys2sHWFCZYYO1bAqudrrMW3y+SP7BF2+E5rYIGVntU4v+EoWxx1h/X+2ISMKvecf4RJLV6ojBvWNUFDcw=="],
 
-    "cookie": ["cookie@0.7.1", "", {}, "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="],
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -768,7 +770,7 @@
 
     "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
 
-    "eslint-config-next": ["eslint-config-next@16.2.6", "", { "dependencies": { "@next/eslint-plugin-next": "16.2.6", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^7.0.0", "globals": "16.4.0", "typescript-eslint": "^8.46.0" }, "peerDependencies": { "eslint": ">=9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-z2ELYSkyrrJ6cuunTU8vhsT/RpouPkjaSah06nVW6Rg2Hpg0Vs8s497/e5s8G8qtdp4ccsiovz5P1rv+5VSW2Q=="],
+    "eslint-config-next": ["eslint-config-next@16.3.0", "", { "dependencies": { "@next/eslint-plugin-next": "16.3.0", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^7.0.0", "globals": "16.4.0", "typescript-eslint": "^8.46.0" }, "peerDependencies": { "eslint": ">=9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-lPrf1kHsMJEZqO0uXkNB400c5MGrhrTk3BNX7P0ol4gt61+iUlQfjy9TyIOEA9eOXrf+5+mYbT/JsY8+zqUByQ=="],
 
     "eslint-import-resolver-node": ["eslint-import-resolver-node@0.3.9", "", { "dependencies": { "debug": "^3.2.7", "is-core-module": "^2.13.0", "resolve": "^1.22.4" } }, "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g=="],
 
@@ -974,11 +976,11 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
-    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+    "jose": ["jose@6.2.8", "", {}, "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@5.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.mjs" } }, "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw=="],
+    "js-yaml": ["js-yaml@5.2.3", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.mjs" } }, "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw=="],
 
     "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 
@@ -1150,13 +1152,13 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "next": ["next@16.2.6", "", { "dependencies": { "@next/env": "16.2.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.6", "@next/swc-darwin-x64": "16.2.6", "@next/swc-linux-arm64-gnu": "16.2.6", "@next/swc-linux-arm64-musl": "16.2.6", "@next/swc-linux-x64-gnu": "16.2.6", "@next/swc-linux-x64-musl": "16.2.6", "@next/swc-win32-arm64-msvc": "16.2.6", "@next/swc-win32-x64-msvc": "16.2.6", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw=="],
+    "next": ["next@16.3.0", "", { "dependencies": { "@next/env": "16.3.0", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.23", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0", "@next/swc-darwin-x64": "16.3.0", "@next/swc-linux-arm64-gnu": "16.3.0", "@next/swc-linux-arm64-musl": "16.3.0", "@next/swc-linux-x64-gnu": "16.3.0", "@next/swc-linux-x64-musl": "16.3.0", "@next/swc-win32-arm64-msvc": "16.3.0", "@next/swc-win32-x64-msvc": "16.3.0", "sharp": "^0.35.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
@@ -1214,11 +1216,11 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+    "postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
 
-    "preact": ["preact@10.11.3", "", {}, "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg=="],
+    "preact": ["preact@10.24.3", "", {}, "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA=="],
 
-    "preact-render-to-string": ["preact-render-to-string@5.2.3", "", { "dependencies": { "pretty-format": "^3.8.0" }, "peerDependencies": { "preact": ">=10" } }, "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA=="],
+    "preact-render-to-string": ["preact-render-to-string@6.5.11", "", { "peerDependencies": { "preact": ">=10" } }, "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -1296,7 +1298,7 @@
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
 
-    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+    "sharp": ["sharp@0.35.3", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.5" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.3", "@img/sharp-darwin-x64": "0.35.3", "@img/sharp-freebsd-wasm32": "0.35.3", "@img/sharp-libvips-darwin-arm64": "1.3.2", "@img/sharp-libvips-darwin-x64": "1.3.2", "@img/sharp-libvips-linux-arm": "1.3.2", "@img/sharp-libvips-linux-arm64": "1.3.2", "@img/sharp-libvips-linux-ppc64": "1.3.2", "@img/sharp-libvips-linux-riscv64": "1.3.2", "@img/sharp-libvips-linux-s390x": "1.3.2", "@img/sharp-libvips-linux-x64": "1.3.2", "@img/sharp-libvips-linuxmusl-arm64": "1.3.2", "@img/sharp-libvips-linuxmusl-x64": "1.3.2", "@img/sharp-linux-arm": "0.35.3", "@img/sharp-linux-arm64": "0.35.3", "@img/sharp-linux-ppc64": "0.35.3", "@img/sharp-linux-riscv64": "0.35.3", "@img/sharp-linux-s390x": "0.35.3", "@img/sharp-linux-x64": "0.35.3", "@img/sharp-linuxmusl-arm64": "0.35.3", "@img/sharp-linuxmusl-x64": "0.35.3", "@img/sharp-webcontainers-wasm32": "0.35.3", "@img/sharp-win32-arm64": "0.35.3", "@img/sharp-win32-ia32": "0.35.3", "@img/sharp-win32-x64": "0.35.3" } }, "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -1408,7 +1410,7 @@
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -1504,7 +1506,7 @@
 
     "@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
-    "@convex-dev/auth/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+    "@convex-dev/auth/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -1512,7 +1514,7 @@
 
     "@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
-    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+    "@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
@@ -1558,13 +1560,11 @@
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
-    "preact-render-to-string/pretty-format": ["pretty-format@3.8.0", "", {}, "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="],
-
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
-    "sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+    "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 

--- a/my-app/convex/bottles.test.ts
+++ b/my-app/convex/bottles.test.ts
@@ -415,6 +415,14 @@ describe("update semantics (null clears, undefined preserves)", () => {
 // ── P2: Validation boundaries ───────────────────────────────────────────────
 
 describe("validation", () => {
+  test("blank name is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    await expect(user.as.mutation(api.bottles.addBottle, { name: "   " })).rejects.toThrowError(
+      "Name is required.",
+    );
+  });
+
   test("name at 200 chars is accepted", async () => {
     const t = setupTest();
     const user = await createTestUser(t);
@@ -510,6 +518,17 @@ describe("validation", () => {
     ).rejects.toThrowError("sizeMl must be greater than 0.");
   });
 
+  test("NaN sizeMl is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    await expect(
+      user.as.mutation(api.bottles.addBottle, {
+        name: "Test",
+        sizeMl: Number.NaN,
+      }),
+    ).rejects.toThrowError("sizeMl must be a finite number.");
+  });
+
   test("sizeMl of 10000 is accepted", async () => {
     const t = setupTest();
     const user = await createTestUser(t);
@@ -536,6 +555,20 @@ describe("validation", () => {
 // ── P2: updateBottle validation ──────────────────────────────────────────────
 
 describe("updateBottle validation", () => {
+  test("blank name is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    const bottleId = await user.as.mutation(api.bottles.addBottle, {
+      name: "Test",
+    });
+    await expect(
+      user.as.mutation(api.bottles.updateBottle, {
+        bottleId,
+        name: "   ",
+      }),
+    ).rejects.toThrowError("Name is required.");
+  });
+
   test("name at 201 chars is rejected", async () => {
     const t = setupTest();
     const user = await createTestUser(t);
@@ -586,6 +619,21 @@ describe("updateBottle validation", () => {
     await expect(
       user.as.mutation(api.bottles.updateBottle, { bottleId, sizeMl: -1 }),
     ).rejects.toThrowError("sizeMl must be greater than 0.");
+  });
+
+  test("NaN sizeMl is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    const bottleId = await user.as.mutation(api.bottles.addBottle, {
+      name: "Test",
+      sizeMl: 100,
+    });
+    await expect(
+      user.as.mutation(api.bottles.updateBottle, {
+        bottleId,
+        sizeMl: Number.NaN,
+      }),
+    ).rejects.toThrowError("sizeMl must be a finite number.");
   });
 
   test("null sizeMl does not trigger the >0 validation guard", async () => {

--- a/my-app/convex/bottles.test.ts
+++ b/my-app/convex/bottles.test.ts
@@ -1,5 +1,5 @@
-import { expect, test, describe } from "vitest";
-import { api } from "./_generated/api";
+import { expect, test, describe, vi } from "vitest";
+import { api, internal } from "./_generated/api";
 import { setupTest, createTestUser } from "./test.setup";
 
 // ── P0: Auth enforcement ────────────────────────────────────────────────────
@@ -228,81 +228,264 @@ describe("updateBottle", () => {
 });
 
 describe("deleteBottle", () => {
-  test("removes the bottle", async () => {
+  test("hides the bottle immediately", async () => {
     const t = setupTest();
     const user = await createTestUser(t);
     const bottleId = await user.as.mutation(api.bottles.addBottle, {
       name: "Doomed",
     });
 
-    await user.as.mutation(api.bottles.deleteBottle, { bottleId });
+    vi.useFakeTimers();
+    try {
+      await user.as.mutation(api.bottles.deleteBottle, { bottleId });
 
-    const bottle = await user.as.query(api.bottles.getBottle, { bottleId });
-    expect(bottle).toBeNull();
+      const bottle = await user.as.query(api.bottles.getBottle, { bottleId });
+      expect(bottle).toBeNull();
+      expect(await user.as.query(api.bottles.listBottles)).toEqual([]);
+
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+      const completedDeletion = await t.run(async (ctx) => ({
+        bottle: await ctx.db.get(bottleId),
+        failedJobs: (await ctx.db.system.query("_scheduled_functions").collect()).filter(
+          (job) => job.state.kind === "failed",
+        ),
+      }));
+      expect(completedDeletion.bottle).toBeNull();
+      expect(completedDeletion.failedJobs).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
 // ── P1: Cascade delete ──────────────────────────────────────────────────────
 
 describe("cascade delete", () => {
-  test("deleteBottle removes all associated wear logs", async () => {
+  test("cleans more than two batches without touching another bottle or its logs", async () => {
     const t = setupTest();
     const user = await createTestUser(t);
-    const bottleId = await user.as.mutation(api.bottles.addBottle, {
-      name: "Aventus",
+    const doomedBottleId = await user.as.mutation(api.bottles.addBottle, {
+      name: "Doomed",
+    });
+    const retainedBottleId = await user.as.mutation(api.bottles.addBottle, {
+      name: "Retained",
+    });
+    const now = Date.now();
+    const { firstDoomedLogId, retainedLogId } = await t.run(async (ctx) => {
+      let firstDoomedLogId = null;
+      for (let index = 0; index < 205; index += 1) {
+        const logId = await ctx.db.insert("wearLogs", {
+          userId: user.userId,
+          bottleId: doomedBottleId,
+          wornAt: now - index,
+          sprays: 1,
+        });
+        firstDoomedLogId ??= logId;
+      }
+      const retainedLogId = await ctx.db.insert("wearLogs", {
+        userId: user.userId,
+        bottleId: retainedBottleId,
+        wornAt: now,
+        sprays: 2,
+      });
+      return { firstDoomedLogId: firstDoomedLogId!, retainedLogId };
     });
 
-    await user.as.mutation(api.wearLogs.addWearLog, {
-      bottleId,
-      wornAt: Date.now(),
-      sprays: 3,
-    });
-    await user.as.mutation(api.wearLogs.addWearLog, {
-      bottleId,
-      wornAt: Date.now(),
-      sprays: 2,
-    });
+    vi.useFakeTimers();
+    try {
+      expect(
+        await user.as.mutation(api.bottles.deleteBottle, {
+          bottleId: doomedBottleId,
+        }),
+      ).toBeNull();
 
-    await user.as.mutation(api.bottles.deleteBottle, { bottleId });
+      expect(await user.as.query(api.bottles.getBottle, { bottleId: doomedBottleId })).toBeNull();
+      expect((await user.as.query(api.bottles.listBottles)).map((bottle) => bottle._id)).toEqual([
+        retainedBottleId,
+      ]);
 
-    // Verify via direct DB access
-    const remainingLogs = await t.run(async (ctx) => {
-      return await ctx.db
-        .query("wearLogs")
-        .withIndex("by_bottle", (q) => q.eq("bottleId", bottleId))
-        .collect();
-    });
-    expect(remainingLogs).toHaveLength(0);
+      const pendingCleanup = await t.run(async (ctx) => ({
+        bottle: await ctx.db.get(doomedBottleId),
+        logs: await ctx.db
+          .query("wearLogs")
+          .withIndex("by_bottle", (q) => q.eq("bottleId", doomedBottleId))
+          .collect(),
+        pendingJobs: (await ctx.db.system.query("_scheduled_functions").collect()).filter(
+          (job) => job.state.kind === "pending",
+        ).length,
+      }));
+      expect(pendingCleanup.bottle?.deletingAt).toBeTypeOf("number");
+      expect(pendingCleanup.bottle?.cleanupJobId).toBeDefined();
+      expect(pendingCleanup.logs).toHaveLength(205);
+      expect(
+        await user.as.query(api.wearLogs.listWearLogsByBottle, {
+          bottleId: doomedBottleId,
+        }),
+      ).toEqual([]);
+      expect(
+        await user.as.query(api.wearLogs.getWearLog, {
+          wearLogId: firstDoomedLogId,
+        }),
+      ).toBeNull();
+      const visibleLogs = await user.as.query(api.wearLogs.listWearLogs);
+      expect(visibleLogs).toHaveLength(1);
+      expect(visibleLogs[0]._id).toBe(retainedLogId);
+      expect(await user.as.query(api.wearLogs.listBottleStats)).toEqual({
+        [retainedBottleId]: { wears: 1, sprays: 2, avgRating: null },
+      });
+
+      await expect(
+        user.as.mutation(api.bottles.updateBottle, {
+          bottleId: doomedBottleId,
+          name: "Too late",
+        }),
+      ).rejects.toThrowError("Bottle not found or access denied.");
+      await expect(
+        user.as.mutation(api.bottles.toggleFavorite, { bottleId: doomedBottleId }),
+      ).rejects.toThrowError("Bottle not found or access denied.");
+      await expect(
+        user.as.mutation(api.wearLogs.addWearLog, {
+          bottleId: doomedBottleId,
+          wornAt: now,
+          sprays: 1,
+        }),
+      ).rejects.toThrowError("Bottle not found or access denied.");
+      await expect(
+        user.as.mutation(api.wearLogs.updateWearLog, {
+          wearLogId: firstDoomedLogId,
+          sprays: 2,
+        }),
+      ).rejects.toThrowError("Bottle not found or access denied.");
+
+      // Pending retries are true no-ops, including beyond the limiter's burst
+      // capacity, and keep pointing at the same cleanup job.
+      vi.setSystemTime(now + 1_000);
+      for (let retry = 0; retry < 5; retry += 1) {
+        expect(
+          await user.as.mutation(api.bottles.deleteBottle, {
+            bottleId: doomedBottleId,
+          }),
+        ).toBeNull();
+      }
+      const afterRetries = await t.run(async (ctx) => ({
+        bottle: await ctx.db.get(doomedBottleId),
+        pendingJobs: (await ctx.db.system.query("_scheduled_functions").collect()).filter(
+          (job) => job.state.kind === "pending",
+        ).length,
+      }));
+      expect(afterRetries.bottle?.deletingAt).toBe(pendingCleanup.bottle?.deletingAt);
+      expect(afterRetries.bottle?.cleanupJobId).toBe(pendingCleanup.bottle?.cleanupJobId);
+      expect(afterRetries.pendingJobs).toBe(pendingCleanup.pendingJobs);
+
+      // The delayed watchdog repairs terminally canceled work without another
+      // public delete call or removing the tombstone.
+      await t.run(async (ctx) => {
+        await ctx.scheduler.cancel(pendingCleanup.bottle!.cleanupJobId!);
+      });
+      vi.advanceTimersByTime(5 * 60 * 1000);
+      await t.finishInProgressScheduledFunctions();
+      const afterRepair = await t.run(async (ctx) => ctx.db.get(doomedBottleId));
+      expect(afterRepair?.cleanupJobId).toBeDefined();
+      expect(afterRepair?.cleanupJobId).not.toBe(pendingCleanup.bottle?.cleanupJobId);
+
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+      const completedCleanup = await t.run(async (ctx) => ({
+        bottle: await ctx.db.get(doomedBottleId),
+        doomedLogs: await ctx.db
+          .query("wearLogs")
+          .withIndex("by_bottle", (q) => q.eq("bottleId", doomedBottleId))
+          .collect(),
+        retainedBottle: await ctx.db.get(retainedBottleId),
+        retainedLog: await ctx.db.get(retainedLogId),
+        scheduledFunctions: await ctx.db.system.query("_scheduled_functions").collect(),
+      }));
+      expect(completedCleanup.bottle).toBeNull();
+      expect(completedCleanup.doomedLogs).toEqual([]);
+      expect(completedCleanup.retainedBottle?.name).toBe("Retained");
+      expect(completedCleanup.retainedLog?.bottleId).toBe(retainedBottleId);
+      expect(
+        completedCleanup.scheduledFunctions.filter((job) => job.state.kind === "failed"),
+      ).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  test("deleteBottle does NOT remove other bottles' wear logs", async () => {
+  test("internal cleanup enforces ownership and a strict 50-log batch boundary", async () => {
     const t = setupTest();
-    const user = await createTestUser(t);
-    const bottleA = await user.as.mutation(api.bottles.addBottle, {
-      name: "Bottle A",
-    });
-    const bottleB = await user.as.mutation(api.bottles.addBottle, {
-      name: "Bottle B",
+    const owner = await createTestUser(t, "Owner");
+    const otherUser = await createTestUser(t, "Other");
+    const deletingAt = Date.now();
+    const bottleId = await t.run(async (ctx) => {
+      const id = await ctx.db.insert("bottles", {
+        userId: owner.userId,
+        name: "Boundary",
+        createdAt: deletingAt,
+        deletingAt,
+      });
+      for (let index = 0; index < 51; index += 1) {
+        await ctx.db.insert("wearLogs", {
+          userId: owner.userId,
+          bottleId: id,
+          wornAt: deletingAt - index,
+          sprays: 1,
+        });
+      }
+      return id;
     });
 
-    await user.as.mutation(api.wearLogs.addWearLog, {
-      bottleId: bottleA,
-      wornAt: Date.now(),
-      sprays: 1,
-    });
-    await user.as.mutation(api.wearLogs.addWearLog, {
-      bottleId: bottleB,
-      wornAt: Date.now(),
-      sprays: 2,
-    });
+    const args = {
+      bottleId,
+      expectedUserId: owner.userId,
+      expectedDeletingAt: deletingAt,
+    };
+    vi.useFakeTimers();
+    try {
+      expect(
+        await t.mutation(internal.bottles.deleteBottleBatch, {
+          ...args,
+          expectedUserId: otherUser.userId,
+        }),
+      ).toBeNull();
+      expect(
+        await t.run(async (ctx) =>
+          ctx.db
+            .query("wearLogs")
+            .withIndex("by_bottle", (q) => q.eq("bottleId", bottleId))
+            .collect(),
+        ),
+      ).toHaveLength(51);
 
-    await user.as.mutation(api.bottles.deleteBottle, { bottleId: bottleA });
+      expect(await t.mutation(internal.bottles.deleteBottleBatch, args)).toBeNull();
+      const afterFirstBatch = await t.run(async (ctx) => ({
+        bottle: await ctx.db.get(bottleId),
+        logs: await ctx.db
+          .query("wearLogs")
+          .withIndex("by_bottle", (q) => q.eq("bottleId", bottleId))
+          .collect(),
+      }));
+      expect(afterFirstBatch.bottle).not.toBeNull();
+      expect(afterFirstBatch.logs).toHaveLength(1);
 
-    const bottleBLogs = await user.as.query(api.wearLogs.listWearLogsByBottle, {
-      bottleId: bottleB,
-    });
-    expect(bottleBLogs).toHaveLength(1);
-    expect(bottleBLogs[0].sprays).toBe(2);
+      expect(await t.mutation(internal.bottles.deleteBottleBatch, args)).toBeNull();
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+      const afterSecondBatch = await t.run(async (ctx) => ({
+        bottle: await ctx.db.get(bottleId),
+        logs: await ctx.db
+          .query("wearLogs")
+          .withIndex("by_bottle", (q) => q.eq("bottleId", bottleId))
+          .collect(),
+        failedJobs: (await ctx.db.system.query("_scheduled_functions").collect()).filter(
+          (job) => job.state.kind === "failed",
+        ),
+      }));
+      expect(afterSecondBatch.bottle).toBeNull();
+      expect(afterSecondBatch.logs).toEqual([]);
+      expect(afterSecondBatch.failedJobs).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/my-app/convex/bottles.ts
+++ b/my-app/convex/bottles.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
 import { rateLimiter } from "./rateLimits";
 import { buildPatch } from "./patch";
+import { bottleDocValidator } from "./validators";
 
 // ── Validation helpers ────────────────────────────────────────────────────────
 // HTML min/max attributes are client-side only and trivially bypassed, so we
@@ -61,6 +62,7 @@ function assertValidBottleInput(args: {
 
 export const listBottles = query({
   args: {},
+  returns: v.array(bottleDocValidator),
   handler: async (ctx) => {
     const userId = await getOptionalUserId(ctx);
     if (userId === null) {
@@ -77,6 +79,7 @@ export const listBottles = query({
 
 export const getBottle = query({
   args: { bottleId: v.id("bottles") },
+  returns: v.union(bottleDocValidator, v.null()),
   handler: async (ctx, args) => {
     const userId = await getOptionalUserId(ctx);
     if (userId === null) {
@@ -99,6 +102,7 @@ export const addBottle = mutation({
     tags: v.optional(v.array(v.string())),
     comments: v.optional(v.string()),
   },
+  returns: v.id("bottles"),
   handler: async (ctx, args) => {
     assertValidBottleInput(args);
 
@@ -127,6 +131,7 @@ export const updateBottle = mutation({
     tags: v.optional(v.union(v.array(v.string()), v.null())),
     comments: v.optional(v.union(v.string(), v.null())),
   },
+  returns: v.null(),
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "updateBottle", { key: userId, throws: true });
@@ -144,11 +149,13 @@ export const updateBottle = mutation({
       }),
       updatedAt: Date.now(),
     });
+    return null;
   },
 });
 
 export const deleteBottle = mutation({
   args: { bottleId: v.id("bottles") },
+  returns: v.null(),
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "deleteBottle", { key: userId, throws: true });
@@ -164,11 +171,13 @@ export const deleteBottle = mutation({
     await Promise.all(orphanedLogs.map((log) => ctx.db.delete(log._id)));
 
     await ctx.db.delete(args.bottleId);
+    return null;
   },
 });
 
 export const toggleFavorite = mutation({
   args: { bottleId: v.id("bottles") },
+  returns: v.null(),
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "toggleFavorite", {
@@ -183,5 +192,6 @@ export const toggleFavorite = mutation({
     await ctx.db.patch(args.bottleId, {
       isFavorite: !(bottle.isFavorite ?? false),
     });
+    return null;
   },
 });

--- a/my-app/convex/bottles.ts
+++ b/my-app/convex/bottles.ts
@@ -1,6 +1,7 @@
-import { mutation, query } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { internalMutation, mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import { getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
+import { getActiveOwnedBottle, getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
 import { rateLimiter } from "./rateLimits";
 import { buildPatch } from "./patch";
 import { bottleDocValidator } from "./validators";
@@ -15,6 +16,8 @@ const MAX_COMMENTS_LENGTH = 2000;
 const MAX_TAG_LENGTH = 50;
 const MAX_TAGS_COUNT = 20;
 const MAX_SIZE_ML = 10_000; // 10 litres ought to be enough for anybody
+const BOTTLE_DELETE_BATCH_SIZE = 50;
+const BOTTLE_DELETE_WATCHDOG_DELAY_MS = 5 * 60 * 1000;
 
 function assertValidBottleInput(args: {
   name?: string;
@@ -71,7 +74,9 @@ export const listBottles = query({
 
     return await ctx.db
       .query("bottles")
-      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .withIndex("by_user_and_deleting_at", (q) =>
+        q.eq("userId", userId).eq("deletingAt", undefined),
+      )
       .order("desc")
       .collect();
   },
@@ -87,7 +92,7 @@ export const getBottle = query({
     }
 
     const bottle = await ctx.db.get(args.bottleId);
-    if (!bottle || bottle.userId !== userId) return null;
+    if (!bottle || bottle.userId !== userId || bottle.deletingAt !== undefined) return null;
     return bottle;
   },
 });
@@ -135,7 +140,7 @@ export const updateBottle = mutation({
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "updateBottle", { key: userId, throws: true });
-    await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
+    await getActiveOwnedBottle(ctx, args.bottleId, userId);
 
     assertValidBottleInput(args);
 
@@ -158,19 +163,129 @@ export const deleteBottle = mutation({
   returns: v.null(),
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
-    await rateLimiter.limit(ctx, "deleteBottle", { key: userId, throws: true });
-    await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
+    const bottle = await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
+    if (bottle.deletingAt !== undefined) {
+      const cleanupJob = bottle.cleanupJobId
+        ? await ctx.db.system.get("_scheduled_functions", bottle.cleanupJobId)
+        : null;
+      if (cleanupJob?.state.kind === "pending" || cleanupJob?.state.kind === "inProgress") {
+        return null;
+      }
 
-    // Cascade-delete all wear logs that reference this bottle so no orphaned
-    // records are left behind after the bottle document is removed.
-    const orphanedLogs = await ctx.db
+      // A failed, canceled, completed-but-stale, or expired job record can be
+      // repaired by a later delete request without changing the tombstone.
+      await rateLimiter.limit(ctx, "deleteBottle", { key: userId, throws: true });
+      const cleanupJobId = await ctx.scheduler.runAfter(0, internal.bottles.deleteBottleBatch, {
+        bottleId: args.bottleId,
+        expectedUserId: userId,
+        expectedDeletingAt: bottle.deletingAt,
+      });
+      await ctx.db.patch(args.bottleId, { cleanupJobId });
+      return null;
+    }
+
+    await rateLimiter.limit(ctx, "deleteBottle", { key: userId, throws: true });
+    const deletingAt = Date.now();
+    const cleanupJobId = await ctx.scheduler.runAfter(0, internal.bottles.deleteBottleBatch, {
+      bottleId: args.bottleId,
+      expectedUserId: userId,
+      expectedDeletingAt: deletingAt,
+    });
+    await ctx.scheduler.runAfter(
+      BOTTLE_DELETE_WATCHDOG_DELAY_MS,
+      internal.bottles.watchBottleDeletion,
+      {
+        bottleId: args.bottleId,
+        expectedUserId: userId,
+        expectedDeletingAt: deletingAt,
+      },
+    );
+    await ctx.db.patch(args.bottleId, { deletingAt, cleanupJobId });
+    return null;
+  },
+});
+
+/**
+ * Removes one bounded batch of a bottle's children, then schedules the next
+ * batch. The expected owner and tombstone make stale or misrouted jobs no-op;
+ * the parent is only removed after no children remain.
+ */
+export const deleteBottleBatch = internalMutation({
+  args: {
+    bottleId: v.id("bottles"),
+    expectedUserId: v.id("users"),
+    expectedDeletingAt: v.number(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const bottle = await ctx.db.get(args.bottleId);
+    if (
+      !bottle ||
+      bottle.userId !== args.expectedUserId ||
+      bottle.deletingAt !== args.expectedDeletingAt
+    ) {
+      return null;
+    }
+
+    const logs = await ctx.db
       .query("wearLogs")
       .withIndex("by_bottle", (q) => q.eq("bottleId", args.bottleId))
-      .collect();
+      .take(BOTTLE_DELETE_BATCH_SIZE);
+    await Promise.all(logs.map((log) => ctx.db.delete(log._id)));
 
-    await Promise.all(orphanedLogs.map((log) => ctx.db.delete(log._id)));
+    if (logs.length === BOTTLE_DELETE_BATCH_SIZE) {
+      const cleanupJobId = await ctx.scheduler.runAfter(
+        0,
+        internal.bottles.deleteBottleBatch,
+        args,
+      );
+      await ctx.db.patch(args.bottleId, { cleanupJobId });
+    } else {
+      await ctx.db.delete(args.bottleId);
+    }
+    return null;
+  },
+});
 
-    await ctx.db.delete(args.bottleId);
+/**
+ * Maintains one delayed recovery chain for each tombstone. Active cleanup is
+ * left alone; terminal or missing work is replaced. Once the parent is gone or
+ * the nonce no longer matches, the chain stops without touching data.
+ */
+export const watchBottleDeletion = internalMutation({
+  args: {
+    bottleId: v.id("bottles"),
+    expectedUserId: v.id("users"),
+    expectedDeletingAt: v.number(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const bottle = await ctx.db.get(args.bottleId);
+    if (
+      !bottle ||
+      bottle.userId !== args.expectedUserId ||
+      bottle.deletingAt !== args.expectedDeletingAt
+    ) {
+      return null;
+    }
+
+    const cleanupJob = bottle.cleanupJobId
+      ? await ctx.db.system.get("_scheduled_functions", bottle.cleanupJobId)
+      : null;
+    if (cleanupJob?.state.kind !== "pending" && cleanupJob?.state.kind !== "inProgress") {
+      const cleanupJobId = await ctx.scheduler.runAfter(
+        0,
+        internal.bottles.deleteBottleBatch,
+        args,
+      );
+      await ctx.db.patch(args.bottleId, { cleanupJobId });
+    }
+
+    await ctx.scheduler.runAfter(
+      BOTTLE_DELETE_WATCHDOG_DELAY_MS,
+      internal.bottles.watchBottleDeletion,
+      args,
+    );
     return null;
   },
 });
@@ -185,7 +300,7 @@ export const toggleFavorite = mutation({
       throws: true,
     });
 
-    const bottle = await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
+    const bottle = await getActiveOwnedBottle(ctx, args.bottleId, userId);
 
     // Intentionally do NOT touch updatedAt — favoriting is metadata, not a
     // content edit. Keeps any future "last modified" view honest.

--- a/my-app/convex/bottles.ts
+++ b/my-app/convex/bottles.ts
@@ -22,8 +22,13 @@ function assertValidBottleInput(args: {
   tags?: string[] | null;
   sizeMl?: number | null;
 }) {
-  if (args.name !== undefined && args.name.length > MAX_NAME_LENGTH) {
-    throw new Error(`Name must be at most ${MAX_NAME_LENGTH} characters.`);
+  if (args.name !== undefined) {
+    if (args.name.trim().length === 0) {
+      throw new Error("Name is required.");
+    }
+    if (args.name.length > MAX_NAME_LENGTH) {
+      throw new Error(`Name must be at most ${MAX_NAME_LENGTH} characters.`);
+    }
   }
   if (args.brand && args.brand.length > MAX_BRAND_LENGTH) {
     throw new Error(`Brand must be at most ${MAX_BRAND_LENGTH} characters.`);
@@ -39,8 +44,16 @@ function assertValidBottleInput(args: {
       throw new Error(`Each tag must be at most ${MAX_TAG_LENGTH} characters.`);
     }
   }
-  if (args.sizeMl !== undefined && args.sizeMl !== null && args.sizeMl > MAX_SIZE_ML) {
-    throw new Error(`Size must be at most ${MAX_SIZE_ML} mL.`);
+  if (args.sizeMl !== undefined && args.sizeMl !== null) {
+    if (!Number.isFinite(args.sizeMl)) {
+      throw new Error("sizeMl must be a finite number.");
+    }
+    if (args.sizeMl <= 0) {
+      throw new Error("sizeMl must be greater than 0.");
+    }
+    if (args.sizeMl > MAX_SIZE_ML) {
+      throw new Error(`Size must be at most ${MAX_SIZE_ML} mL.`);
+    }
   }
 }
 
@@ -87,9 +100,6 @@ export const addBottle = mutation({
     comments: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    if (args.sizeMl !== undefined && args.sizeMl <= 0) {
-      throw new Error("sizeMl must be greater than 0.");
-    }
     assertValidBottleInput(args);
 
     const userId = await getUserId(ctx);
@@ -122,10 +132,6 @@ export const updateBottle = mutation({
     await rateLimiter.limit(ctx, "updateBottle", { key: userId, throws: true });
     await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
 
-    // Validate sizeMl when a real value (not a clear) is being set.
-    if (args.sizeMl !== undefined && args.sizeMl !== null && args.sizeMl <= 0) {
-      throw new Error("sizeMl must be greater than 0.");
-    }
     assertValidBottleInput(args);
 
     await ctx.db.patch(args.bottleId, {

--- a/my-app/convex/helpers.ts
+++ b/my-app/convex/helpers.ts
@@ -41,3 +41,20 @@ export async function getOwnedDoc<T extends OwnedTable>(
   }
   return doc as unknown as Doc<T>;
 }
+
+/**
+ * Fetches an owned bottle that is still active. Tombstoned bottles use the
+ * same ownership-safe error as missing and foreign bottles so background
+ * deletion state never expands the public information surface.
+ */
+export async function getActiveOwnedBottle(
+  ctx: QueryCtx | MutationCtx,
+  bottleId: Id<"bottles">,
+  userId: Id<"users">,
+): Promise<Doc<"bottles">> {
+  const bottle = await getOwnedDoc(ctx, "bottles", bottleId, userId);
+  if (bottle.deletingAt !== undefined) {
+    throw new Error("Bottle not found or access denied.");
+  }
+  return bottle;
+}

--- a/my-app/convex/schema.ts
+++ b/my-app/convex/schema.ts
@@ -17,9 +17,16 @@ export default defineSchema({
 
     isFavorite: v.optional(v.boolean()),
 
+    // A tombstone makes deletion immediate to readers while the associated
+    // wear logs are removed in bounded background batches.
+    deletingAt: v.optional(v.number()),
+    cleanupJobId: v.optional(v.id("_scheduled_functions")),
+
     createdAt: v.number(),
     updatedAt: v.optional(v.number()),
-  }).index("by_user", ["userId"]),
+  })
+    .index("by_user", ["userId"])
+    .index("by_user_and_deleting_at", ["userId", "deletingAt"]),
 
   wearLogs: defineTable({
     userId: v.id("users"),

--- a/my-app/convex/users.test.ts
+++ b/my-app/convex/users.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import { setupTest } from "./test.setup";
+
+describe("currentUser", () => {
+  test("returns null without an authenticated user", async () => {
+    const t = setupTest();
+
+    expect(await t.query(api.users.currentUser)).toBeNull();
+  });
+
+  test("returns only the public profile fields", async () => {
+    const t = setupTest();
+    const userId = await t.run(async (ctx) => {
+      return await ctx.db.insert("users", {
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        phone: "+15555550123",
+      });
+    });
+    const asUser = t.withIdentity({ subject: `${userId}|testSession` });
+
+    const result = await asUser.query(api.users.currentUser);
+
+    expect(result).toEqual({
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+    });
+    expect(result).not.toHaveProperty("phone");
+    expect(result).not.toHaveProperty("_id");
+    expect(result).not.toHaveProperty("_creationTime");
+  });
+});

--- a/my-app/convex/users.ts
+++ b/my-app/convex/users.ts
@@ -1,14 +1,34 @@
 import { getAuthUserId } from "@convex-dev/auth/server";
+import { v } from "convex/values";
 import { query } from "./_generated/server";
 
 export const currentUser = query({
   args: {},
+  returns: v.union(
+    v.object({
+      name: v.optional(v.string()),
+      email: v.optional(v.string()),
+    }),
+    v.null(),
+  ),
   handler: async (ctx) => {
     const userId = await getAuthUserId(ctx);
     if (userId === null) {
       return null;
     }
 
-    return await ctx.db.get(userId);
+    const user = await ctx.db.get(userId);
+    if (user === null) {
+      return null;
+    }
+
+    const profile: { name?: string; email?: string } = {};
+    if (user.name !== undefined) {
+      profile.name = user.name;
+    }
+    if (user.email !== undefined) {
+      profile.email = user.email;
+    }
+    return profile;
   },
 });

--- a/my-app/convex/validators.ts
+++ b/my-app/convex/validators.ts
@@ -1,0 +1,33 @@
+import { v } from "convex/values";
+
+export const bottleDocValidator = v.object({
+  _id: v.id("bottles"),
+  _creationTime: v.number(),
+  userId: v.id("users"),
+  name: v.string(),
+  brand: v.optional(v.string()),
+  sizeMl: v.optional(v.number()),
+  tags: v.optional(v.array(v.string())),
+  comments: v.optional(v.string()),
+  isFavorite: v.optional(v.boolean()),
+  createdAt: v.number(),
+  updatedAt: v.optional(v.number()),
+});
+
+export const wearLogDocValidator = v.object({
+  _id: v.id("wearLogs"),
+  _creationTime: v.number(),
+  userId: v.id("users"),
+  bottleId: v.id("bottles"),
+  wornAt: v.number(),
+  sprays: v.number(),
+  context: v.optional(v.string()),
+  rating: v.optional(v.number()),
+  comment: v.optional(v.string()),
+});
+
+export const bottleStatsValidator = v.object({
+  wears: v.number(),
+  sprays: v.number(),
+  avgRating: v.union(v.number(), v.null()),
+});

--- a/my-app/convex/validators.ts
+++ b/my-app/convex/validators.ts
@@ -10,6 +10,8 @@ export const bottleDocValidator = v.object({
   tags: v.optional(v.array(v.string())),
   comments: v.optional(v.string()),
   isFavorite: v.optional(v.boolean()),
+  deletingAt: v.optional(v.number()),
+  cleanupJobId: v.optional(v.id("_scheduled_functions")),
   createdAt: v.number(),
   updatedAt: v.optional(v.number()),
 });

--- a/my-app/convex/wearLogs.test.ts
+++ b/my-app/convex/wearLogs.test.ts
@@ -229,15 +229,22 @@ describe("cross-table integrity", () => {
     const t = setupTest();
     const user = await createTestUser(t);
     const bottleId = await addBottle(user.as);
-    await user.as.mutation(api.bottles.deleteBottle, { bottleId });
+    vi.useFakeTimers();
+    try {
+      await user.as.mutation(api.bottles.deleteBottle, { bottleId });
 
-    await expect(
-      user.as.mutation(api.wearLogs.addWearLog, {
-        bottleId,
-        wornAt: Date.now(),
-        sprays: 1,
-      }),
-    ).rejects.toThrowError("Bottle not found or access denied.");
+      await expect(
+        user.as.mutation(api.wearLogs.addWearLog, {
+          bottleId,
+          wornAt: Date.now(),
+          sprays: 1,
+        }),
+      ).rejects.toThrowError("Bottle not found or access denied.");
+
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/my-app/convex/wearLogs.test.ts
+++ b/my-app/convex/wearLogs.test.ts
@@ -599,6 +599,33 @@ describe("update semantics (null clears, undefined preserves)", () => {
 // ── P2: Validation boundaries ───────────────────────────────────────────────
 
 describe("validation", () => {
+  test("NaN wornAt is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    const bottleId = await addBottle(user.as);
+    await expect(
+      user.as.mutation(api.wearLogs.addWearLog, {
+        bottleId,
+        wornAt: Number.NaN,
+        sprays: 1,
+      }),
+    ).rejects.toThrowError("wornAt must be a finite number.");
+  });
+
+  test("NaN rating is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    const bottleId = await addBottle(user.as);
+    await expect(
+      user.as.mutation(api.wearLogs.addWearLog, {
+        bottleId,
+        wornAt: Date.now(),
+        sprays: 1,
+        rating: Number.NaN,
+      }),
+    ).rejects.toThrowError("rating must be a finite number.");
+  });
+
   test("sprays of 0 is rejected", async () => {
     const t = setupTest();
     const user = await createTestUser(t);
@@ -827,6 +854,40 @@ describe("validation", () => {
 // ── P2: updateWearLog validation ─────────────────────────────────────────────
 
 describe("updateWearLog validation", () => {
+  test("NaN wornAt is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    const bottleId = await addBottle(user.as);
+    const logId = await user.as.mutation(api.wearLogs.addWearLog, {
+      bottleId,
+      wornAt: Date.now(),
+      sprays: 1,
+    });
+    await expect(
+      user.as.mutation(api.wearLogs.updateWearLog, {
+        wearLogId: logId,
+        wornAt: Number.NaN,
+      }),
+    ).rejects.toThrowError("wornAt must be a finite number.");
+  });
+
+  test("NaN rating is rejected", async () => {
+    const t = setupTest();
+    const user = await createTestUser(t);
+    const bottleId = await addBottle(user.as);
+    const logId = await user.as.mutation(api.wearLogs.addWearLog, {
+      bottleId,
+      wornAt: Date.now(),
+      sprays: 1,
+    });
+    await expect(
+      user.as.mutation(api.wearLogs.updateWearLog, {
+        wearLogId: logId,
+        rating: Number.NaN,
+      }),
+    ).rejects.toThrowError("rating must be a finite number.");
+  });
+
   test("sprays of 0 is rejected", async () => {
     const t = setupTest();
     const user = await createTestUser(t);

--- a/my-app/convex/wearLogs.ts
+++ b/my-app/convex/wearLogs.ts
@@ -4,6 +4,7 @@ import { getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
 import { rateLimiter } from "./rateLimits";
 import { MAX_SPRAYS } from "../src/lib/constants";
 import { buildPatch } from "./patch";
+import { bottleStatsValidator, wearLogDocValidator } from "./validators";
 
 // ── Validation constants ──────────────────────────────────────────────────────
 
@@ -15,6 +16,7 @@ const FUTURE_WORN_AT_TOLERANCE_MS = 60_000;
 
 export const listBottleStats = query({
   args: {},
+  returns: v.record(v.string(), bottleStatsValidator),
   handler: async (ctx) => {
     const userId = await getOptionalUserId(ctx);
     if (userId === null) {
@@ -62,6 +64,7 @@ export const listBottleStats = query({
 
 export const listWearLogs = query({
   args: {},
+  returns: v.array(wearLogDocValidator),
   handler: async (ctx) => {
     const userId = await getOptionalUserId(ctx);
     if (userId === null) {
@@ -79,6 +82,7 @@ export const listWearLogs = query({
 
 export const listWearLogsByBottle = query({
   args: { bottleId: v.id("bottles") },
+  returns: v.array(wearLogDocValidator),
   handler: async (ctx, args) => {
     const userId = await getOptionalUserId(ctx);
     if (userId === null) {
@@ -98,6 +102,7 @@ export const listWearLogsByBottle = query({
 
 export const getWearLog = query({
   args: { wearLogId: v.id("wearLogs") },
+  returns: v.union(wearLogDocValidator, v.null()),
   handler: async (ctx, args) => {
     const userId = await getOptionalUserId(ctx);
     if (userId === null) {
@@ -165,6 +170,7 @@ export const addWearLog = mutation({
     rating: v.optional(v.number()),
     comment: v.optional(v.string()),
   },
+  returns: v.id("wearLogs"),
   handler: async (ctx, args) => {
     assertValidWornAt(args.wornAt);
     assertValidSprays(args.sprays);
@@ -202,6 +208,7 @@ export const updateWearLog = mutation({
     rating: v.optional(v.union(v.number(), v.null())),
     comment: v.optional(v.union(v.string(), v.null())),
   },
+  returns: v.null(),
   handler: async (ctx, args) => {
     // Run validation before the ownership check so the error is clear even
     // in cases where the log is not found.
@@ -226,15 +233,18 @@ export const updateWearLog = mutation({
         comment: args.comment,
       }),
     );
+    return null;
   },
 });
 
 export const deleteWearLog = mutation({
   args: { wearLogId: v.id("wearLogs") },
+  returns: v.null(),
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "deleteWearLog", { key: userId, throws: true });
     await getOwnedDoc(ctx, "wearLogs", args.wearLogId, userId);
     await ctx.db.delete(args.wearLogId);
+    return null;
   },
 });

--- a/my-app/convex/wearLogs.ts
+++ b/my-app/convex/wearLogs.ts
@@ -1,6 +1,6 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import { getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
+import { getActiveOwnedBottle, getOptionalUserId, getOwnedDoc, getUserId } from "./helpers";
 import { rateLimiter } from "./rateLimits";
 import { MAX_SPRAYS } from "../src/lib/constants";
 import { buildPatch } from "./patch";
@@ -23,10 +23,17 @@ export const listBottleStats = query({
       return {};
     }
 
-    const logs = await ctx.db
-      .query("wearLogs")
-      .withIndex("by_user", (q) => q.eq("userId", userId))
-      .collect();
+    const [logs, deletingBottles] = await Promise.all([
+      ctx.db
+        .query("wearLogs")
+        .withIndex("by_user", (q) => q.eq("userId", userId))
+        .collect(),
+      ctx.db
+        .query("bottles")
+        .withIndex("by_user_and_deleting_at", (q) => q.eq("userId", userId).gt("deletingAt", 0))
+        .collect(),
+    ]);
+    const deletingBottleIds = new Set(deletingBottles.map((bottle) => bottle._id));
     // Aggregate wear count, spray totals, and average rating per bottle
     // server-side so the collection view never needs to download the full
     // wear-log history.
@@ -35,6 +42,7 @@ export const listBottleStats = query({
       { wears: number; sprays: number; ratingSum: number; ratingCount: number }
     >();
     for (const log of logs) {
+      if (deletingBottleIds.has(log.bottleId)) continue;
       const existing = stats.get(log.bottleId) ?? {
         wears: 0,
         sprays: 0,
@@ -71,12 +79,19 @@ export const listWearLogs = query({
       return [];
     }
 
-    // Uses the by_user_time index so results arrive sorted by wornAt.
-    return await ctx.db
-      .query("wearLogs")
-      .withIndex("by_user_time", (q) => q.eq("userId", userId))
-      .order("desc")
-      .collect();
+    const [logs, deletingBottles] = await Promise.all([
+      ctx.db
+        .query("wearLogs")
+        .withIndex("by_user_time", (q) => q.eq("userId", userId))
+        .order("desc")
+        .collect(),
+      ctx.db
+        .query("bottles")
+        .withIndex("by_user_and_deleting_at", (q) => q.eq("userId", userId).gt("deletingAt", 0))
+        .collect(),
+    ]);
+    const deletingBottleIds = new Set(deletingBottles.map((bottle) => bottle._id));
+    return logs.filter((log) => !deletingBottleIds.has(log.bottleId));
   },
 });
 
@@ -86,6 +101,11 @@ export const listWearLogsByBottle = query({
   handler: async (ctx, args) => {
     const userId = await getOptionalUserId(ctx);
     if (userId === null) {
+      return [];
+    }
+
+    const bottle = await ctx.db.get(args.bottleId);
+    if (!bottle || bottle.userId !== userId || bottle.deletingAt !== undefined) {
       return [];
     }
 
@@ -111,6 +131,8 @@ export const getWearLog = query({
 
     const log = await ctx.db.get(args.wearLogId);
     if (!log || log.userId !== userId) return null;
+    const bottle = await ctx.db.get(log.bottleId);
+    if (!bottle || bottle.userId !== userId || bottle.deletingAt !== undefined) return null;
     return log;
   },
 });
@@ -179,8 +201,8 @@ export const addWearLog = mutation({
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "addWearLog", { key: userId, throws: true });
 
-    // Verify the bottle belongs to this user.
-    await getOwnedDoc(ctx, "bottles", args.bottleId, userId);
+    // Verify the bottle belongs to this user and is not being deleted.
+    await getActiveOwnedBottle(ctx, args.bottleId, userId);
 
     // Validate string lengths server-side (HTML max is client-only).
     assertValidWearLogStrings(args);
@@ -218,7 +240,12 @@ export const updateWearLog = mutation({
 
     const userId = await getUserId(ctx);
     await rateLimiter.limit(ctx, "updateWearLog", { key: userId, throws: true });
-    await getOwnedDoc(ctx, "wearLogs", args.wearLogId, userId);
+    const log = await getOwnedDoc(ctx, "wearLogs", args.wearLogId, userId);
+
+    // Updates to a child that is already scheduled for deletion are rejected:
+    // the change would never become durable user-visible state. Deletes remain
+    // allowed and safely reduce the cleanup worker's remaining batch.
+    await getActiveOwnedBottle(ctx, log.bottleId, userId);
 
     // Validate string lengths server-side.
     assertValidWearLogStrings(args);

--- a/my-app/convex/wearLogs.ts
+++ b/my-app/convex/wearLogs.ts
@@ -113,6 +113,9 @@ export const getWearLog = query({
 // ── Validation helpers ────────────────────────────────────────────────────────
 
 function assertValidWornAt(wornAt: number): void {
+  if (!Number.isFinite(wornAt)) {
+    throw new Error("wornAt must be a finite number.");
+  }
   if (wornAt <= 0) {
     throw new Error("wornAt must be a positive Unix timestamp (ms).");
   }
@@ -131,6 +134,9 @@ function assertValidSprays(sprays: number): void {
 }
 
 function assertValidRating(rating: number): void {
+  if (!Number.isFinite(rating)) {
+    throw new Error("rating must be a finite number.");
+  }
   if (rating < 1 || rating > 10) {
     throw new Error("rating must be between 1 and 10 inclusive.");
   }

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -17,8 +17,8 @@
     "test:run": "vitest run"
   },
   "dependencies": {
-    "@auth/core": "0.37.0",
-    "@convex-dev/auth": "^0.0.91",
+    "@auth/core": "0.41.3",
+    "@convex-dev/auth": "^0.0.95",
     "@convex-dev/rate-limiter": "^0.3.2",
     "@radix-ui/react-dialog": "^1.1.17",
     "@radix-ui/react-dropdown-menu": "^2.1.18",
@@ -33,7 +33,7 @@
     "clsx": "^2.1.1",
     "convex": "^1.42.0",
     "lucide-react": "^0.577.0",
-    "next": "16.2.6",
+    "next": "16.3.0",
     "next-themes": "^0.4.6",
     "postcss": "^8.5.16",
     "react": "19.2.3",
@@ -54,7 +54,7 @@
     "@types/react-dom": "^19.2.3",
     "convex-test": "^0.0.47",
     "eslint": "^9.39.4",
-    "eslint-config-next": "16.2.6",
+    "eslint-config-next": "16.3.0",
     "jsdom": "^29.1.1",
     "prettier": "^3.9.1",
     "typescript": "^5.9.3",
@@ -73,10 +73,10 @@
     "picomatch": ">=4.0.4",
     "flatted": ">=3.4.2",
     "ws": "8.21.0",
-    "brace-expansion": "^1.1.13",
-    "postcss": "8.5.16",
+    "brace-expansion": "^1.1.18",
+    "postcss": "8.5.26",
     "vite": "8.1.0",
-    "undici": "7.28.0",
-    "js-yaml": "5.2.0"
+    "undici": "7.29.0",
+    "js-yaml": "5.2.3"
   }
 }


### PR DESCRIPTION
## Outcome

Integrates four independently reviewed backend/security gains from the repository audit:

- #82 — reject blank names and non-finite numeric inputs at Convex mutation boundaries
- #83 — update vulnerable runtime/transitive dependencies; `bun audit` is clean
- #84 — add explicit Convex response validators and minimize `currentUser` data
- #85 — replace the unbounded destructive cascade with recoverable 50-row deletion batches

## Security and correctness gains

- prevents `NaN` timestamps/ratings/sizes from persisting or poisoning aggregates
- prevents direct clients from creating blank-name bottles
- constrains every custom public Convex function with an explicit response contract
- exposes only `name` and `email` from the current-user query
- immediately hides deleting bottles and related wear-log/stat data
- keeps deletion bounded, parent-last, owner/nonce guarded, retry-idempotent, and self-repairing
- clears the dependency advisories reported against the prior tree

## Combined validation

- `bun install --frozen-lockfile` (no lockfile drift)
- `bun run test:run` — 18 files, 174 tests
- focused deletion coverage — 205 children, five batches, exact 50/51 boundary, owner isolation, retry idempotency, canceled-job repair, no failed scheduled jobs
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun audit --json` — `{}`
- `NEXT_PUBLIC_CONVEX_URL=https://placeholder.convex.cloud bun run build`
- Convex dry-run codegen/typecheck against the configured development deployment
- `git diff origin/main...HEAD --check`
- independent reviews completed for each child change

## Deferred architectural findings

Several account-scoped queries still use unbounded `collect()`. Correctly fixing them requires pagination plus transactionally maintained aggregates/server-side sort/search so existing global totals and ordering are not silently changed. That larger migration is intentionally not bundled into this integration PR.

## Notes

- No production deployment or database migration was executed.
- The local production build used a placeholder public Convex URL; the Convex codegen/typecheck used the existing configured development deployment without modifying deployed functions.
